### PR TITLE
feat(alerts): add ConsecutiveErrorTracker to suppress transient Slack…

### DIFF
--- a/src/services/consecutiveErrorTracker.ts
+++ b/src/services/consecutiveErrorTracker.ts
@@ -1,0 +1,27 @@
+/**
+ * Tracks consecutive errors across poll-loop iterations.
+ * Resets to 0 on any successful run. Only signals an alert
+ * after {@link threshold} consecutive failures, preventing
+ * transient network blips from flooding Slack / Prometheus.
+ */
+export class ConsecutiveErrorTracker {
+  private count = 0;
+
+  constructor(private readonly threshold: number = 3) {}
+
+  recordSuccess(): void {
+    this.count = 0;
+  }
+
+  recordError(): number {
+    return ++this.count;
+  }
+
+  shouldAlert(): boolean {
+    return this.count >= this.threshold;
+  }
+
+  getCount(): number {
+    return this.count;
+  }
+}

--- a/tests/services/consecutiveErrorTracker.spec.ts
+++ b/tests/services/consecutiveErrorTracker.spec.ts
@@ -1,0 +1,74 @@
+import {ConsecutiveErrorTracker} from "../../src/services/consecutiveErrorTracker";
+
+describe("ConsecutiveErrorTracker", () => {
+  it("starts with count 0 and should not alert", () => {
+    const tracker = new ConsecutiveErrorTracker(3);
+    expect(tracker.getCount()).toBe(0);
+    expect(tracker.shouldAlert()).toBe(false);
+  });
+
+  it("increments on recordError and returns new count", () => {
+    const tracker = new ConsecutiveErrorTracker(3);
+    expect(tracker.recordError()).toBe(1);
+    expect(tracker.recordError()).toBe(2);
+    expect(tracker.getCount()).toBe(2);
+  });
+
+  it("alerts once threshold is reached", () => {
+    const tracker = new ConsecutiveErrorTracker(3);
+    tracker.recordError();
+    tracker.recordError();
+    expect(tracker.shouldAlert()).toBe(false);
+    tracker.recordError();
+    expect(tracker.shouldAlert()).toBe(true);
+  });
+
+  it("continues to alert above threshold", () => {
+    const tracker = new ConsecutiveErrorTracker(2);
+    tracker.recordError();
+    tracker.recordError();
+    expect(tracker.shouldAlert()).toBe(true);
+    tracker.recordError(); // 3 > 2
+    expect(tracker.shouldAlert()).toBe(true);
+  });
+
+  it("resets count to 0 on recordSuccess", () => {
+    const tracker = new ConsecutiveErrorTracker(3);
+    tracker.recordError();
+    tracker.recordError();
+    expect(tracker.getCount()).toBe(2);
+    tracker.recordSuccess();
+    expect(tracker.getCount()).toBe(0);
+    expect(tracker.shouldAlert()).toBe(false);
+  });
+
+  it("requires full threshold again after a success resets the count", () => {
+    const tracker = new ConsecutiveErrorTracker(3);
+    // Get to 2 errors, then succeed
+    tracker.recordError();
+    tracker.recordError();
+    tracker.recordSuccess();
+    // Need 3 fresh consecutive errors to alert
+    tracker.recordError();
+    tracker.recordError();
+    expect(tracker.shouldAlert()).toBe(false);
+    tracker.recordError();
+    expect(tracker.shouldAlert()).toBe(true);
+  });
+
+  it("uses default threshold of 3 when none provided", () => {
+    const tracker = new ConsecutiveErrorTracker();
+    tracker.recordError();
+    tracker.recordError();
+    expect(tracker.shouldAlert()).toBe(false);
+    tracker.recordError();
+    expect(tracker.shouldAlert()).toBe(true);
+  });
+
+  it("works with threshold of 1 (alert on first error)", () => {
+    const tracker = new ConsecutiveErrorTracker(1);
+    expect(tracker.shouldAlert()).toBe(false);
+    tracker.recordError();
+    expect(tracker.shouldAlert()).toBe(true);
+  });
+});


### PR DESCRIPTION
… noise

All 5 poll-loop workers now gate Slack error notifications behind a consecutive-failure threshold (default 3). A single transient RPC/network blip no longer triggers an alert — only sustained failures do.

- New utility: ConsecutiveErrorTracker (recordSuccess/recordError/shouldAlert)
- Integrated into crc-backers, gnosis-group, gp-crc, oic, router-tms
- Unit tests covering threshold, reset-on-success, edge cases