### PR TITLE
feat: blockchain resilience P2 — retry, fallback RPC, state persistence, backoff

### DIFF
--- a/src/apps/crc-backers/main.ts
+++ b/src/apps/crc-backers/main.ts
@@ -12,6 +12,7 @@ import {startMetricsServer, recordRunSuccess, recordRunError, setLeaderStatus} f
 import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {LeaderElection, getEffectiveDryRun} from "../../services/leaderElection";
+import {StateStore} from "../../services/stateStore";
 
 const rpcUrl = process.env.RPC_URL || "https://rpc.aboutcircles.com/";
 const blacklistingServiceUrl = process.env.BLACKLISTING_SERVICE_URL || "https://squid-app-3gxnl.ondigitalocean.app/aboutcircles-advanced-analytics2/bot-analytics/blacklist";
@@ -121,6 +122,20 @@ function delay(ms: number): Promise<void> {
 }
 
 async function loop(leaderElection: LeaderElection | null) {
+  const pollIntervalMs = 60 * 1000;
+  const maxDelay = pollIntervalMs * 4;
+  let currentDelay = pollIntervalMs;
+
+  // Attempt to restore scan cursor from PG
+  const stateStore = process.env.LEADER_DB_URL ? new StateStore(process.env.LEADER_DB_URL) : null;
+  if (stateStore) {
+    const persisted = await stateStore.load("crc-backers");
+    if (persisted) {
+      nextFromBlock = persisted.lastScannedBlock;
+      rootLogger.info(`[state-store] Restored scan cursor: nextFromBlock=${nextFromBlock}`);
+    }
+  }
+
   while (true) {
     const runStartedAt = Date.now();
     const effectiveDryRun = getEffectiveDryRun(leaderElection, dryRun);
@@ -130,7 +145,7 @@ async function loop(leaderElection: LeaderElection | null) {
         rpcUrl,
         logger: rootLogger
       });
-      if (!isHealthy) { await delay(60 * 1000); continue; }
+      if (!isHealthy) { await delay(currentDelay); continue; }
 
       rootLogger.info("Checking for new backers...");
       await refreshBlacklist();
@@ -156,8 +171,10 @@ async function loop(leaderElection: LeaderElection | null) {
         }
       );
       nextFromBlock = outcome.nextFromBlock;
+      await stateStore?.save("crc-backers", nextFromBlock);
       recordRunSuccess("crc-backers", Date.now() - runStartedAt);
       errorTracker.recordSuccess();
+      currentDelay = pollIntervalMs; // reset on success
     } catch (caught: unknown) {
       const isError = caught instanceof Error;
       const baseError = isError ? caught : new Error(String(caught));
@@ -178,10 +195,10 @@ async function loop(leaderElection: LeaderElection | null) {
         setTimeout(() => process.exit(1), 3000).unref();
         return;
       }
+      currentDelay = Math.min(currentDelay * 2, maxDelay); // backoff on error
     }
 
-    // Wait one minute
-    await delay(60 * 1000);
+    await delay(currentDelay);
   }
 }
 

--- a/src/apps/gnosis-group/main.ts
+++ b/src/apps/gnosis-group/main.ts
@@ -23,6 +23,7 @@ import {startMetricsServer, recordRunSuccess, recordRunError, setLeaderStatus} f
 import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {LeaderElection, getEffectiveDryRun} from "../../services/leaderElection";
+import {StateStore} from "../../services/stateStore";
 
 const verboseLogging = !!process.env.VERBOSE_LOGGING;
 const rootLogger = new LoggerService(verboseLogging, "gnosis-group");
@@ -140,6 +141,10 @@ async function mainLoop(): Promise<void> {
     slackService,
     (isLeader) => setLeaderStatus("gnosis-group", isLeader)
   );
+  const maxDelay = runIntervalMs * 4;
+  let currentDelay = runIntervalMs;
+  const stateStore = process.env.LEADER_DB_URL ? new StateStore(process.env.LEADER_DB_URL) : null;
+
   while (true) {
     const runStartedAt = Date.now();
     const effectiveDryRun = getEffectiveDryRun(leaderElection, dryRun);
@@ -149,7 +154,7 @@ async function mainLoop(): Promise<void> {
         rpcUrl,
         logger: rootLogger
       });
-      if (!isHealthy) { await delay(runIntervalMs); continue; }
+      if (!isHealthy) { await delay(currentDelay); continue; }
       await refreshBlacklist();
       const outcome = await runOnce(
         {
@@ -162,8 +167,10 @@ async function mainLoop(): Promise<void> {
         { ...config, dryRun: effectiveDryRun }
       );
 
+      await stateStore?.save("gnosis-group", 0, { lastSuccessfulRunAt: new Date().toISOString() });
       recordRunSuccess("gnosis-group", Date.now() - runStartedAt);
       errorTracker.recordSuccess();
+      currentDelay = runIntervalMs;
       rootLogger.info(
         `Run completed. Addresses with relative score > ${outcome.threshold}: ${outcome.aboveThresholdCount}`
       );
@@ -180,10 +187,11 @@ async function mainLoop(): Promise<void> {
         setTimeout(() => process.exit(1), 3000).unref();
         return;
       }
+      currentDelay = Math.min(currentDelay * 2, maxDelay);
     }
 
     const elapsedMs = Date.now() - runStartedAt;
-    const waitMs = Math.max(0, runIntervalMs - elapsedMs);
+    const waitMs = Math.max(0, currentDelay - elapsedMs);
     if (waitMs > 0) {
       rootLogger.info(`Waiting ${(waitMs / 60_000).toFixed(1)} minute(s) before the next run.`);
       await delay(waitMs);

--- a/src/apps/gp-crc/main.ts
+++ b/src/apps/gp-crc/main.ts
@@ -18,6 +18,7 @@ import {startMetricsServer, recordRunSuccess, recordRunError, setLeaderStatus} f
 import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {LeaderElection, getEffectiveDryRun} from "../../services/leaderElection";
+import {StateStore} from "../../services/stateStore";
 
 const verboseLogging = !!process.env.VERBOSE_LOGGING;
 const rootLogger = new LoggerService(verboseLogging, "gp-crc");
@@ -136,6 +137,10 @@ async function mainLoop(): Promise<void> {
     slackService,
     (isLeader) => setLeaderStatus("gp-crc", isLeader)
   );
+  const maxDelay = pollIntervalMs * 4;
+  let currentDelay = pollIntervalMs;
+  const stateStore = process.env.LEADER_DB_URL ? new StateStore(process.env.LEADER_DB_URL) : null;
+
   while (true) {
     const runStartedAt = Date.now();
     const effectiveDryRun = getEffectiveDryRun(leaderElection, dryRun);
@@ -145,7 +150,7 @@ async function mainLoop(): Promise<void> {
         rpcUrl,
         logger: rootLogger
       });
-      if (!isHealthy) { await delay(pollIntervalMs); continue; }
+      if (!isHealthy) { await delay(currentDelay); continue; }
       await refreshBlacklist();
       const outcome = await runOnce(
         {
@@ -158,8 +163,10 @@ async function mainLoop(): Promise<void> {
         },
         { ...config, dryRun: effectiveDryRun }
       );
+      await stateStore?.save("gp-crc", 0, { lastSuccessfulRunAt: new Date().toISOString() });
       recordRunSuccess("gp-crc", Date.now() - runStartedAt);
       errorTracker.recordSuccess();
+      currentDelay = pollIntervalMs;
     } catch (cause) {
       const error = cause instanceof Error ? cause : new Error(String(cause));
       const consecutiveErrors = errorTracker.recordError();
@@ -172,9 +179,10 @@ async function mainLoop(): Promise<void> {
         setTimeout(() => process.exit(1), 3000).unref();
         return;
       }
+      currentDelay = Math.min(currentDelay * 2, maxDelay);
     }
 
-    await delay(pollIntervalMs);
+    await delay(currentDelay);
   }
 }
 

--- a/src/apps/oic/main.ts
+++ b/src/apps/oic/main.ts
@@ -12,6 +12,7 @@ import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
 import {formatErrorWithCauses} from "../../formatError";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {LeaderElection, getEffectiveDryRun} from "../../services/leaderElection";
+import {StateStore} from "../../services/stateStore";
 import {Wallet} from "ethers";
 
 const rpcUrl = process.env.RPC_URL || "https://rpc.aboutcircles.com/";
@@ -147,8 +148,23 @@ async function loop() {
     slackService,
     (isLeader) => setLeaderStatus("oic", isLeader)
   );
+  const pollIntervalMs = refreshIntervalSec * 1000;
+  const maxDelay = pollIntervalMs * 4;
+  let currentDelay = pollIntervalMs;
+
   const state: IncrementalState = createInitialIncrementalState();
   state.lastSafeHeadScanned = Math.max(0, deployedAtBlock - 1);
+
+  // Attempt to restore scan cursor from PG
+  const stateStore = process.env.LEADER_DB_URL ? new StateStore(process.env.LEADER_DB_URL) : null;
+  if (stateStore) {
+    const persisted = await stateStore.load("oic");
+    if (persisted) {
+      state.lastSafeHeadScanned = persisted.lastScannedBlock;
+      rootLogger.info(`[state-store] Restored scan cursor: lastSafeHeadScanned=${persisted.lastScannedBlock}`);
+    }
+  }
+
   // Only print startup/info logs once per process lifetime
   let printedStartupLogs = false;
   while (true) {
@@ -161,11 +177,10 @@ async function loop() {
         rpcUrl,
         logger: rootLogger
       });
-      if (!isHealthy) { await delay(refreshIntervalSec * 1000); continue; }
+      if (!isHealthy) { await delay(currentDelay); continue; }
 
       if (!printedStartupLogs) {
         LOG.info("OIC app starting (monitor + reconcile trust)...");
-        // Reduce noise: print config details only in verbose mode
         LOG.debug(`RPC: ${rpcUrl}`);
         LOG.debug(`Group: ${oicGroupAddress}`);
         LOG.debug(`MetaOrg: ${metaOrgAddress}`);
@@ -188,8 +203,10 @@ async function loop() {
         },
         state,
       );
+      await stateStore?.save("oic", state.lastSafeHeadScanned);
       recordRunSuccess("oic", Date.now() - runStartedAt);
       errorTracker.recordSuccess();
+      currentDelay = pollIntervalMs;
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       const consecutiveErrors = errorTracker.recordError();
@@ -202,9 +219,10 @@ async function loop() {
         setTimeout(() => process.exit(1), 3000).unref();
         return;
       }
+      currentDelay = Math.min(currentDelay * 2, maxDelay);
     }
 
-    await delay(refreshIntervalSec * 1000);
+    await delay(currentDelay);
   }
 }
 

--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -17,6 +17,7 @@ import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
 import {InMemoryRouterEnablementStore} from "./enablementStore";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {LeaderElection, getEffectiveDryRun} from "../../services/leaderElection";
+import {StateStore} from "../../services/stateStore";
 
 const rpcUrl = process.env.RPC_URL || "https://rpc.aboutcircles.com/";
 const routerAddress = process.env.ROUTER_ADDRESS || "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
@@ -122,6 +123,10 @@ async function mainLoop(): Promise<void> {
     slackService,
     (isLeader) => setLeaderStatus("router-tms", isLeader)
   );
+  const maxDelay = pollIntervalMs * 4;
+  let currentDelay = pollIntervalMs;
+  const stateStore = process.env.LEADER_DB_URL ? new StateStore(process.env.LEADER_DB_URL) : null;
+
   while (true) {
     const runStartedAt = Date.now();
     const effectiveDryRun = getEffectiveDryRun(leaderElection, dryRun);
@@ -131,7 +136,7 @@ async function mainLoop(): Promise<void> {
         rpcUrl,
         logger: rootLogger
       });
-      if (!isHealthy) { await delay(pollIntervalMs); continue; }
+      if (!isHealthy) { await delay(currentDelay); continue; }
       await refreshBlacklist();
       const outcome = await runOnce(
         {
@@ -143,8 +148,10 @@ async function mainLoop(): Promise<void> {
         },
         { ...config, dryRun: effectiveDryRun }
       );
+      await stateStore?.save("router-tms", 0, { lastSuccessfulRunAt: new Date().toISOString() });
       recordRunSuccess("router-tms", Date.now() - runStartedAt);
       errorTracker.recordSuccess();
+      currentDelay = pollIntervalMs;
       runLogger.info(
         "router-tms run completed: " +
           `uniqueHumans=${outcome.uniqueHumanCount} ` +
@@ -168,9 +175,10 @@ async function mainLoop(): Promise<void> {
         setTimeout(() => process.exit(1), 3000).unref();
         return;
       }
+      currentDelay = Math.min(currentDelay * 2, maxDelay);
     }
 
-    await delay(pollIntervalMs);
+    await delay(currentDelay);
   }
 }
 

--- a/src/services/affiliateGroupEventsService.ts
+++ b/src/services/affiliateGroupEventsService.ts
@@ -4,6 +4,8 @@ import {
   IAffiliateGroupEventsService,
 } from "../interfaces/IAffiliateGroupEventsService";
 import {ILoggerService} from "../interfaces/ILoggerService";
+import {retryWithBackoff} from "./retryWithBackoff";
+import {createProvider} from "./rpcProvider";
 
 const ABI = [
   "event AffiliateGroupChanged(address indexed human, address oldGroup, address newGroup)",
@@ -16,11 +18,9 @@ export class AffiliateGroupEventsService implements IAffiliateGroupEventsService
   private readonly logger?: ILoggerService;
 
   private readonly chunkSize: number = 100000;
-  private readonly maxRetries: number = 3;
-  private readonly retryDelayMs: number = 1000;
 
   constructor(rpcUrl: string, logger?: ILoggerService) {
-    this.provider = new JsonRpcProvider(rpcUrl);
+    this.provider = createProvider(rpcUrl) as JsonRpcProvider;
     this.logger = logger;
   }
 
@@ -46,45 +46,21 @@ export class AffiliateGroupEventsService implements IAffiliateGroupEventsService
     while (start <= latest) {
       const end = Math.min(latest, start + this.chunkSize - 1);
       chunkIndex++;
-      let attempt = 0;
-      // retry loop for transient RPC timeouts
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        try {
-          const chunkStartedAt = Date.now();
-          const chunkLogs = await this.provider.getLogs({
-            address: registryAddress,
-            fromBlock: start,
-            toBlock: end,
-            topics: [this.topic],
-          });
-          allLogs.push(...chunkLogs);
-          const elapsedMs = Date.now() - startedAt;
-          const chunkMs = Date.now() - chunkStartedAt;
-          this.logger?.info(
-            `[affiliate-fetch] chunk ${chunkIndex}/${totalChunks} range=${start}-${end} logs=${chunkLogs.length} totalLogs=${allLogs.length} chunkMs=${chunkMs} elapsedMs=${elapsedMs}`
-          );
-          break;
-        } catch (err: any) {
-          const msg = String(err?.message || err);
-          const code = (err && (err.code ?? err.error?.code)) as any;
-          const isTimeout =
-            code === -32016 ||
-            msg.includes("timeout") ||
-            msg.includes("canceled") ||
-            msg.includes("cancelled");
-          this.logger?.warn(
-            `[affiliate-fetch] chunk ${chunkIndex}/${totalChunks} range=${start}-${end} failed attempt=${attempt + 1}/${this.maxRetries + 1} code=${String(code ?? "unknown")} error=${msg}`
-          );
-          if (!isTimeout || attempt >= this.maxRetries) {
-            throw err;
-          }
-          attempt++;
-          if (this.retryDelayMs > 0) {
-            await new Promise((res) => setTimeout(res, this.retryDelayMs));
-          }
-        }
-      }
+      const chunkStartedAt = Date.now();
+      const chunkLogs = await retryWithBackoff(() =>
+        this.provider.getLogs({
+          address: registryAddress,
+          fromBlock: start,
+          toBlock: end,
+          topics: [this.topic],
+        })
+      );
+      allLogs.push(...chunkLogs);
+      const elapsedMs = Date.now() - startedAt;
+      const chunkMs = Date.now() - chunkStartedAt;
+      this.logger?.info(
+        `[affiliate-fetch] chunk ${chunkIndex}/${totalChunks} range=${start}-${end} logs=${chunkLogs.length} totalLogs=${allLogs.length} chunkMs=${chunkMs} elapsedMs=${elapsedMs}`
+      );
       start = end + 1;
     }
 

--- a/src/services/chainRpcService.ts
+++ b/src/services/chainRpcService.ts
@@ -1,11 +1,12 @@
 import {IChainRpc} from "../interfaces/IChainRpc";
 import {JsonRpcProvider, TransactionReceipt} from "ethers";
+import {createProvider} from "./rpcProvider";
 
 export class ChainRpcService implements IChainRpc {
   private provider: JsonRpcProvider;
 
   constructor(rpcUrl: string) {
-    this.provider = new JsonRpcProvider(rpcUrl);
+    this.provider = createProvider(rpcUrl) as JsonRpcProvider;
   }
 
   async getHeadBlock(): Promise<{ blockNumber: number; timestamp: number }> {

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -1,6 +1,8 @@
 import {GroupOwnerAndServiceAddress, IGroupService} from "../interfaces/IGroupService";
 import {Contract, getAddress, JsonRpcProvider, Wallet} from "ethers";
 import {TransactionConfirmationTimeoutError} from "./safeTransactionExecutor";
+import {retryWithBackoff} from "./retryWithBackoff";
+import {createProvider} from "./rpcProvider";
 
 const TX_CONFIRMATION_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -27,7 +29,7 @@ export class GroupService implements IGroupService {
   private readonly wallet: Wallet;
 
   constructor(private readonly rpcUrl: string, private readonly servicePrivateKey: string) {
-    this.provider = new JsonRpcProvider(rpcUrl);
+    this.provider = createProvider(rpcUrl) as JsonRpcProvider;
     this.wallet = new Wallet(servicePrivateKey, this.provider);
   }
 
@@ -36,7 +38,7 @@ export class GroupService implements IGroupService {
 
     const expiry: bigint = (1n << 96n) - 1n;
 
-    const tx = await group.trustBatchWithConditions(trusteeAddresses, expiry);
+    const tx = await retryWithBackoff(() => group.trustBatchWithConditions(trusteeAddresses, expiry));
     const receipt = await waitWithTimeout(tx, TX_CONFIRMATION_TIMEOUT_MS);
 
     if (!receipt || receipt.status !== 1) {
@@ -50,7 +52,7 @@ export class GroupService implements IGroupService {
 
     const group = this.getWritableGroupContract(groupAddress);
 
-    const tx = await group.trustBatchWithConditions(trusteeAddresses, 0n);
+    const tx = await retryWithBackoff(() => group.trustBatchWithConditions(trusteeAddresses, 0n));
     const receipt = await waitWithTimeout(tx, TX_CONFIRMATION_TIMEOUT_MS);
 
     if (!receipt || receipt.status !== 1) {

--- a/src/services/retryWithBackoff.ts
+++ b/src/services/retryWithBackoff.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared retry utility for transient RPC errors with exponential backoff.
+ */
+
+/** Known transient RPC error patterns that are safe to retry. */
+const TRANSIENT_MESSAGES = [
+  "timeout",
+  "canceled",
+  "cancelled",
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "socket hang up",
+];
+
+const TRANSIENT_CODES = new Set<number>([-32016]);
+
+export function isTransientRpcError(err: unknown): boolean {
+  if (err == null) return false;
+  const msg = String((err as any)?.message ?? err);
+  const code = ((err as any)?.code ?? (err as any)?.error?.code) as number | undefined;
+
+  if (code !== undefined && TRANSIENT_CODES.has(code)) return true;
+  return TRANSIENT_MESSAGES.some((t) => msg.includes(t));
+}
+
+export interface RetryOptions {
+  maxRetries?: number;
+  baseDelayMs?: number;
+}
+
+/**
+ * Execute `fn` with exponential backoff on transient RPC errors.
+ * Non-transient errors are thrown immediately.
+ */
+export async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  opts?: RetryOptions,
+): Promise<T> {
+  const maxRetries = opts?.maxRetries ?? 3;
+  const baseDelayMs = opts?.baseDelayMs ?? 1_000;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (!isTransientRpcError(err) || attempt >= maxRetries) {
+        throw err;
+      }
+      const delayMs = baseDelayMs * Math.pow(2, attempt);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  // Unreachable, but satisfies TypeScript
+  throw lastError;
+}

--- a/src/services/rpcHealthService.ts
+++ b/src/services/rpcHealthService.ts
@@ -1,5 +1,6 @@
 import {ILoggerService} from "../interfaces/ILoggerService";
 import {setRpcHealthy} from "./metricsService";
+import {parseRpcUrls} from "./rpcProvider";
 
 type RpcHealthResponse = {
   result?: unknown;
@@ -76,15 +77,23 @@ export async function ensureRpcHealthyOrNotify(params: {
   logger: ILoggerService;
   timeoutMs?: number;
 }): Promise<boolean> {
-  const health = await checkRpcHealth(params.rpcUrl, params.timeoutMs);
-  setRpcHealthy(params.appName, health.healthy);
+  const urls = parseRpcUrls(params.rpcUrl);
 
-  if (!health.healthy) {
-    const detail = health.error ?? "unknown error";
+  // Try each URL — first healthy one wins
+  for (const url of urls) {
+    const health = await checkRpcHealth(url, params.timeoutMs);
+    if (health.healthy) {
+      setRpcHealthy(params.appName, true);
+      return true;
+    }
     params.logger.warn(
-      `[rpc-health] ${params.appName}: unhealthy RPC endpoint '${params.rpcUrl}' (${detail}). Skipping run.`
+      `[rpc-health] ${params.appName}: unhealthy RPC endpoint '${url}' (${health.error ?? "unknown error"})`
     );
   }
 
-  return health.healthy;
+  setRpcHealthy(params.appName, false);
+  params.logger.warn(
+    `[rpc-health] ${params.appName}: all RPC endpoints unhealthy. Skipping run.`
+  );
+  return false;
 }

--- a/src/services/rpcProvider.ts
+++ b/src/services/rpcProvider.ts
@@ -13,6 +13,14 @@ export function parseRpcUrls(rpcUrl: string): string[] {
     .filter((u) => u.length > 0);
 }
 
+/** Return the first URL from a (possibly comma-separated) RPC_URL string.
+ *  Use this when passing a URL to third-party SDKs that only accept a single endpoint. */
+export function primaryRpcUrl(rpcUrl: string): string {
+  const urls = parseRpcUrls(rpcUrl);
+  if (urls.length === 0) throw new Error("RPC_URL must contain at least one URL");
+  return urls[0];
+}
+
 export function createProvider(rpcUrl: string): JsonRpcProvider | FallbackProvider {
   const urls = parseRpcUrls(rpcUrl);
   if (urls.length === 0) {

--- a/src/services/rpcProvider.ts
+++ b/src/services/rpcProvider.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared helper to create an ethers provider from a (possibly comma-separated) RPC_URL.
+ *
+ * Single URL  → JsonRpcProvider
+ * Multiple    → FallbackProvider with quorum=1 (first healthy wins)
+ */
+import { JsonRpcProvider, FallbackProvider } from "ethers";
+
+export function parseRpcUrls(rpcUrl: string): string[] {
+  return rpcUrl
+    .split(",")
+    .map((u) => u.trim())
+    .filter((u) => u.length > 0);
+}
+
+export function createProvider(rpcUrl: string): JsonRpcProvider | FallbackProvider {
+  const urls = parseRpcUrls(rpcUrl);
+  if (urls.length === 0) {
+    throw new Error("RPC_URL must contain at least one URL");
+  }
+  if (urls.length === 1) {
+    return new JsonRpcProvider(urls[0]);
+  }
+  return new FallbackProvider(
+    urls.map((u) => new JsonRpcProvider(u)),
+    1, // quorum — accept first successful response
+  );
+}

--- a/src/services/safeGroupService.ts
+++ b/src/services/safeGroupService.ts
@@ -2,6 +2,7 @@ import {Contract, Interface, JsonRpcProvider, getAddress} from "ethers";
 import {GroupOwnerAndServiceAddress, IGroupService} from "../interfaces/IGroupService";
 import {GROUP_MINI_ABI} from "./groupService";
 import {SafeTransactionExecutor} from "./safeTransactionExecutor";
+import {createProvider} from "./rpcProvider";
 
 const GROUP_INTERFACE = new Interface(GROUP_MINI_ABI);
 const MAX_UINT96 = (1n << 96n) - 1n;
@@ -11,7 +12,7 @@ export class SafeGroupService implements IGroupService {
   private readonly executor: SafeTransactionExecutor;
 
   constructor(rpcUrl: string, signerPrivateKey: string, safeAddress: string) {
-    this.provider = new JsonRpcProvider(rpcUrl);
+    this.provider = createProvider(rpcUrl) as JsonRpcProvider;
     this.executor = new SafeTransactionExecutor(rpcUrl, signerPrivateKey, safeAddress);
   }
 

--- a/src/services/safeTransactionExecutor.ts
+++ b/src/services/safeTransactionExecutor.ts
@@ -1,7 +1,7 @@
 import Safe from "@safe-global/protocol-kit";
 import {getAddress, JsonRpcProvider} from "ethers";
 import {retryWithBackoff} from "./retryWithBackoff";
-import {createProvider} from "./rpcProvider";
+import {createProvider, primaryRpcUrl} from "./rpcProvider";
 
 /** Default timeout for waiting on tx confirmation (5 minutes). */
 const DEFAULT_TX_CONFIRMATION_TIMEOUT_MS = 5 * 60 * 1000;
@@ -40,7 +40,7 @@ export class SafeTransactionExecutor {
     this.provider = createProvider(rpcUrl) as JsonRpcProvider;
     this.safeAddress = getAddress(safeAddress);
     this.safePromise = Safe.init({
-      provider: rpcUrl,
+      provider: primaryRpcUrl(rpcUrl),
       signer: signerPrivateKey,
       safeAddress: this.safeAddress
     });

--- a/src/services/safeTransactionExecutor.ts
+++ b/src/services/safeTransactionExecutor.ts
@@ -1,5 +1,7 @@
 import Safe from "@safe-global/protocol-kit";
 import {getAddress, JsonRpcProvider} from "ethers";
+import {retryWithBackoff} from "./retryWithBackoff";
+import {createProvider} from "./rpcProvider";
 
 /** Default timeout for waiting on tx confirmation (5 minutes). */
 const DEFAULT_TX_CONFIRMATION_TIMEOUT_MS = 5 * 60 * 1000;
@@ -35,7 +37,7 @@ export class SafeTransactionExecutor {
       throw new Error("Safe address is required");
     }
 
-    this.provider = new JsonRpcProvider(rpcUrl);
+    this.provider = createProvider(rpcUrl) as JsonRpcProvider;
     this.safeAddress = getAddress(safeAddress);
     this.safePromise = Safe.init({
       provider: rpcUrl,
@@ -65,7 +67,7 @@ export class SafeTransactionExecutor {
       ]
     });
 
-    const execution = await safe.executeTransaction(safeTx);
+    const execution = await retryWithBackoff(() => safe.executeTransaction(safeTx));
 
     const txHash =
       (execution as any).hash ?? (execution as any).transactionResponse?.hash;

--- a/src/services/stateStore.ts
+++ b/src/services/stateStore.ts
@@ -1,0 +1,83 @@
+/**
+ * Persist block scan cursors to PostgreSQL so event-driven apps
+ * resume from last successful scan instead of re-scanning from genesis.
+ *
+ * Graceful fallback: if PG is unavailable, logs a warning and returns null / is a no-op.
+ * Uses the same LEADER_DB_URL connection already available on both hosts.
+ */
+import pg from "pg";
+
+const DDL = `
+CREATE TABLE IF NOT EXISTS group_tms_state (
+  app_name         TEXT PRIMARY KEY,
+  last_scanned_block BIGINT NOT NULL,
+  state_data       JSONB,
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+`;
+
+export interface PersistedState {
+  lastScannedBlock: number;
+  data?: Record<string, unknown>;
+}
+
+export class StateStore {
+  private pool: pg.Pool;
+  private ready: Promise<void>;
+
+  constructor(dbUrl: string) {
+    this.pool = new pg.Pool({ connectionString: dbUrl, max: 2 });
+    this.ready = this.ensureTable();
+  }
+
+  private async ensureTable(): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query(DDL);
+    } finally {
+      client.release();
+    }
+  }
+
+  async load(appName: string): Promise<PersistedState | null> {
+    try {
+      await this.ready;
+      const result = await this.pool.query(
+        `SELECT last_scanned_block, state_data FROM group_tms_state WHERE app_name = $1`,
+        [appName],
+      );
+      if (result.rows.length === 0) return null;
+      const row = result.rows[0];
+      return {
+        lastScannedBlock: Number(row.last_scanned_block),
+        data: row.state_data ?? undefined,
+      };
+    } catch (err) {
+      // Graceful fallback — don't crash, just return null
+      console.warn(`[state-store] Failed to load state for ${appName}:`, (err as Error).message);
+      return null;
+    }
+  }
+
+  async save(appName: string, lastScannedBlock: number, data?: Record<string, unknown>): Promise<void> {
+    try {
+      await this.ready;
+      await this.pool.query(
+        `INSERT INTO group_tms_state (app_name, last_scanned_block, state_data, updated_at)
+         VALUES ($1, $2, $3, now())
+         ON CONFLICT (app_name) DO UPDATE
+           SET last_scanned_block = EXCLUDED.last_scanned_block,
+               state_data = EXCLUDED.state_data,
+               updated_at = now()`,
+        [appName, lastScannedBlock, data ? JSON.stringify(data) : null],
+      );
+    } catch (err) {
+      // Graceful fallback — log and continue
+      console.warn(`[state-store] Failed to save state for ${appName}:`, (err as Error).message);
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+}

--- a/tests/services/retryWithBackoff.spec.ts
+++ b/tests/services/retryWithBackoff.spec.ts
@@ -1,0 +1,97 @@
+import { retryWithBackoff, isTransientRpcError } from "../../src/services/retryWithBackoff";
+
+describe("isTransientRpcError", () => {
+  it("returns true for code -32016", () => {
+    expect(isTransientRpcError({ code: -32016, message: "some error" })).toBe(true);
+  });
+
+  it("returns true for nested error code -32016", () => {
+    expect(isTransientRpcError({ error: { code: -32016 }, message: "x" })).toBe(true);
+  });
+
+  it.each(["timeout", "canceled", "cancelled", "ECONNRESET", "ECONNREFUSED", "socket hang up"])(
+    "returns true for message containing '%s'",
+    (keyword) => {
+      expect(isTransientRpcError(new Error(`Request ${keyword} by server`))).toBe(true);
+    }
+  );
+
+  it("returns false for revert error", () => {
+    expect(isTransientRpcError(new Error("execution reverted"))).toBe(false);
+  });
+
+  it("returns false for nonce error", () => {
+    expect(isTransientRpcError(new Error("nonce too low"))).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isTransientRpcError(null)).toBe(false);
+    expect(isTransientRpcError(undefined)).toBe(false);
+  });
+});
+
+describe("retryWithBackoff", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns immediately on success", async () => {
+    const fn = jest.fn().mockResolvedValue("ok");
+    const result = await retryWithBackoff(fn);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on transient error then succeeds", async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new Error("ECONNRESET"))
+      .mockResolvedValueOnce("recovered");
+
+    const promise = retryWithBackoff(fn, { baseDelayMs: 100 });
+    // Advance past first backoff delay (100ms)
+    await jest.advanceTimersByTimeAsync(100);
+    const result = await promise;
+
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws immediately on non-transient error", async () => {
+    const fn = jest.fn().mockRejectedValue(new Error("execution reverted"));
+    await expect(retryWithBackoff(fn)).rejects.toThrow("execution reverted");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws after exhausting retries on transient errors", async () => {
+    jest.useRealTimers(); // real timers simpler for this case
+    const fn = jest.fn().mockRejectedValue(new Error("socket hang up"));
+
+    await expect(
+      retryWithBackoff(fn, { maxRetries: 2, baseDelayMs: 10 })
+    ).rejects.toThrow("socket hang up");
+    expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it("uses exponential backoff timing", async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce("ok");
+
+    const promise = retryWithBackoff(fn, { maxRetries: 3, baseDelayMs: 1000 });
+
+    // First backoff: 1000ms
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    // Second backoff: 2000ms
+    await jest.advanceTimersByTimeAsync(2000);
+    const result = await promise;
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/services/rpcProvider.spec.ts
+++ b/tests/services/rpcProvider.spec.ts
@@ -1,0 +1,42 @@
+import { parseRpcUrls, createProvider } from "../../src/services/rpcProvider";
+import { JsonRpcProvider, FallbackProvider } from "ethers";
+
+describe("parseRpcUrls", () => {
+  it("parses a single URL", () => {
+    expect(parseRpcUrls("http://localhost:8545")).toEqual(["http://localhost:8545"]);
+  });
+
+  it("parses comma-separated URLs", () => {
+    expect(parseRpcUrls("http://a:8545,http://b:8545")).toEqual([
+      "http://a:8545",
+      "http://b:8545",
+    ]);
+  });
+
+  it("trims whitespace", () => {
+    expect(parseRpcUrls("  http://a:8545 , http://b:8545  ")).toEqual([
+      "http://a:8545",
+      "http://b:8545",
+    ]);
+  });
+
+  it("filters empty segments", () => {
+    expect(parseRpcUrls("http://a:8545,,")).toEqual(["http://a:8545"]);
+  });
+});
+
+describe("createProvider", () => {
+  it("returns JsonRpcProvider for single URL", () => {
+    const provider = createProvider("http://localhost:8545");
+    expect(provider).toBeInstanceOf(JsonRpcProvider);
+  });
+
+  it("returns FallbackProvider for multiple URLs", () => {
+    const provider = createProvider("http://a:8545,http://b:8545");
+    expect(provider).toBeInstanceOf(FallbackProvider);
+  });
+
+  it("throws on empty string", () => {
+    expect(() => createProvider("")).toThrow("at least one URL");
+  });
+});

--- a/tests/services/stateStore.spec.ts
+++ b/tests/services/stateStore.spec.ts
@@ -1,0 +1,93 @@
+import { StateStore } from "../../src/services/stateStore";
+
+// Mock the pg module
+jest.mock("pg", () => {
+  const mockClient = {
+    query: jest.fn(),
+    release: jest.fn(),
+  };
+  const mockPool = {
+    connect: jest.fn().mockResolvedValue(mockClient),
+    query: jest.fn(),
+    end: jest.fn(),
+  };
+  return { Pool: jest.fn(() => mockPool) };
+});
+
+import pg from "pg";
+
+function getMockPool(): any {
+  return (pg.Pool as any).mock.results[0]?.value;
+}
+
+describe("StateStore", () => {
+  let store: StateStore;
+  let mockPool: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = new StateStore("postgres://localhost/test");
+    mockPool = getMockPool();
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  describe("load", () => {
+    it("returns null when no row exists", async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+      const result = await store.load("crc-backers");
+      expect(result).toBeNull();
+    });
+
+    it("returns persisted state when row exists", async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ last_scanned_block: "12345", state_data: { foo: "bar" } }],
+      });
+      const result = await store.load("crc-backers");
+      expect(result).toEqual({ lastScannedBlock: 12345, data: { foo: "bar" } });
+    });
+
+    it("returns null and logs warning on PG error (graceful fallback)", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      mockPool.query.mockRejectedValueOnce(new Error("connection refused"));
+      const result = await store.load("crc-backers");
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[state-store]"),
+        expect.stringContaining("connection refused")
+      );
+    });
+  });
+
+  describe("save", () => {
+    it("calls UPSERT with correct parameters", async () => {
+      mockPool.query.mockResolvedValueOnce({});
+      await store.save("oic", 99999);
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO group_tms_state"),
+        ["oic", 99999, null]
+      );
+    });
+
+    it("passes state_data as JSON when provided", async () => {
+      mockPool.query.mockResolvedValueOnce({});
+      await store.save("oic", 100, { extra: "data" });
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining("INSERT INTO group_tms_state"),
+        ["oic", 100, '{"extra":"data"}']
+      );
+    });
+
+    it("logs warning on PG error (graceful fallback)", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      mockPool.query.mockRejectedValueOnce(new Error("disk full"));
+      await store.save("oic", 100); // should not throw
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[state-store]"),
+        expect.stringContaining("disk full")
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Completes the P2/P3 blockchain resilience items (follows #48 which shipped P0/P1).

- **Transaction retry with exponential backoff** — shared `retryWithBackoff()` utility detects transient RPC errors (timeout, ECONNRESET, `-32016`) and retries with 1s→2s→4s backoff. Non-transient errors (reverts, nonce) throw immediately. Wired into `SafeTransactionExecutor`, `GroupService`, and `AffiliateGroupEventsService` (replaces inline retry).

- **Fallback RPC provider** — `RPC_URL` now supports comma-separated URLs (e.g. `http://rpc:8080,https://rpc.aboutcircles.com/`). Creates a `FallbackProvider` with quorum=1 (first healthy response wins). Applied to all 6 services that create `JsonRpcProvider`. Health check tries each URL sequentially, first healthy wins.

- **State persistence** — `StateStore` saves block scan cursors to PostgreSQL (`group_tms_state` table via `LEADER_DB_URL`). `crc-backers` and `oic` restore cursors on startup (no more full rescan from genesis after restart). `gp-crc`, `gnosis-group`, and `router-tms` persist last-successful-run timestamps for observability. Graceful fallback: if PG unavailable, logs warning and continues with in-memory state.

- **Exponential backoff in poll loops** — all 5 apps double their delay after errors (capped at 4×), reset to normal on success. Prevents hammering a recovering RPC node.

## Files changed
- **New**: `src/services/retryWithBackoff.ts`, `rpcProvider.ts`, `stateStore.ts`
- **Modified services**: `safeTransactionExecutor.ts`, `groupService.ts`, `affiliateGroupEventsService.ts`, `chainRpcService.ts`, `safeGroupService.ts`, `rpcHealthService.ts`
- **Modified main loops**: all 5 apps (`crc-backers`, `gp-crc`, `gnosis-group`, `router-tms`, `oic`)
- **New tests**: 29 tests across 3 spec files

## Test plan
- [x] `tsc --noEmit` — clean compilation
- [x] `jest` — 129/129 tests pass (16 new for retry, 7 for rpc provider, 6 for state store)
- [ ] Deploy to staging, verify health endpoints
- [ ] Check logs for retry/fallback/state-store messages
- [ ] Test with comma-separated `RPC_URL` on staging
- [ ] Verify crc-backers/oic resume from persisted block cursor after restart