### PR TITLE
fix: review fixes — declaration ordering, alert cooldown, tests

### DIFF
--- a/src/apps/crc-backers/main.ts
+++ b/src/apps/crc-backers/main.ts
@@ -49,13 +49,13 @@ if (!dryRun) {
 }
 
 // Concrete services
+const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
 const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   console.warn(`[CirclesRpc] ${msg}`);
-  void slackService.notifySlackStartOrCrash(`⚠️ *crc-backers* pagination cap: ${msg}`, SlackSeverity.WARNING).catch(() => {});
+  void slackService.notifySlackStartOrCrash(`⚠️ *crc-backers* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
 });
 const chainRpc = new ChainRpcService(rpcUrl);
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl);
-const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
 const groupService = (!dryRun || canSimulateTransactions)
   ? new SafeGroupService(rpcUrl, safeSignerPrivateKey, safeAddress, txRpcUrl)
   : undefined;

--- a/src/apps/dublin-tms/main.ts
+++ b/src/apps/dublin-tms/main.ts
@@ -72,11 +72,11 @@ if (!dryRun && servicePrivateKey.trim().length === 0) {
   throw new Error("DUBLIN_TMS_SERVICE_PRIVATE_KEY is required when not running in dry-run mode");
 }
 
+const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
 const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   console.warn(`[CirclesRpc] ${msg}`);
-  void slackService.notifySlackStartOrCrash(`⚠️ *dublin-tms* pagination cap: ${msg}`, SlackSeverity.WARNING).catch(() => {});
+  void slackService.notifySlackStartOrCrash(`⚠️ *dublin-tms* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
 });
-const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
 const slackConfigured = slackWebhookUrl.trim().length > 0;
 
 let groupService: IGroupService | undefined;

--- a/src/apps/gnosis-group/main.ts
+++ b/src/apps/gnosis-group/main.ts
@@ -55,11 +55,11 @@ const groupBatchSize = parseEnvInt("GNOSIS_GROUP_BATCH_SIZE", DEFAULT_GROUP_BATC
 const scoreCacheTtlMs = parseEnvInt("GNOSIS_GROUP_SCORE_CACHE_TTL_MINUTES", DEFAULT_SCORE_CACHE_TTL_MS / 60_000) * 60_000;
 
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl);
+const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
 const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   console.warn(`[CirclesRpc] ${msg}`);
-  void slackService.notifySlackStartOrCrash(`⚠️ *gnosis-group* pagination cap: ${msg}`, SlackSeverity.WARNING).catch(() => {});
+  void slackService.notifySlackStartOrCrash(`⚠️ *gnosis-group* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
 });
-const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
 const slackConfigured = slackWebhookUrl.trim().length > 0;
 const scoreCache = new ScoreCache();
 const errorsBeforeCrash = 3;

--- a/src/apps/gp-crc/main.ts
+++ b/src/apps/gp-crc/main.ts
@@ -44,12 +44,12 @@ const errorsBeforeCrash = 3;
 const errorTracker = new ConsecutiveErrorTracker(errorsBeforeCrash);
 let leaderElection: LeaderElection | null = null;
 
+const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
 const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   console.warn(`[CirclesRpc] ${msg}`);
-  void slackService.notifySlackStartOrCrash(`⚠️ *gp-crc* pagination cap: ${msg}`, SlackSeverity.WARNING).catch(() => {});
+  void slackService.notifySlackStartOrCrash(`⚠️ *gp-crc* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
 });
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl);
-const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
 const slackConfigured = slackWebhookUrl.trim().length > 0;
 let groupService: IGroupService | undefined;
 let avatarSafeService: MetriSafeService;

--- a/src/apps/oic/main.ts
+++ b/src/apps/oic/main.ts
@@ -32,18 +32,17 @@ const verboseLogging = !!process.env.VERBOSE_LOGGING;
 const outputBatchSize = 20;
 
 const rootLogger = new LoggerService(verboseLogging);
-const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
-  console.warn(`[CirclesRpc] ${msg}`);
-  void slackService.notifySlackStartOrCrash(`⚠️ *oic* pagination cap: ${msg}`, SlackSeverity.WARNING).catch(() => {});
-});
-const chainRpc = new ChainRpcService(rpcUrl);
-let groupService: IGroupService;
-const affiliateRegistry = new AffiliateGroupEventsService(rpcUrl, rootLogger.child("oic:affiliate-registry"));
-
 const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL || "";
 const slackWebhookUrlInfo = process.env.SLACK_WEBHOOK_URL_INFO || "";
 const slackInfoChannel = process.env.SLACK_INFO_CHANNEL || "";
 const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
+const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
+  console.warn(`[CirclesRpc] ${msg}`);
+  void slackService.notifySlackStartOrCrash(`⚠️ *oic* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
+});
+const chainRpc = new ChainRpcService(rpcUrl);
+let groupService: IGroupService;
+const affiliateRegistry = new AffiliateGroupEventsService(rpcUrl, rootLogger.child("oic:affiliate-registry"));
 const slackConfigured = !!slackWebhookUrl;
 const errorsBeforeCrash = 3;
 const errorTracker = new ConsecutiveErrorTracker(errorsBeforeCrash);

--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -42,7 +42,7 @@ const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slac
 const slackConfigured = slackWebhookUrl.trim().length > 0;
 const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   console.warn(`[CirclesRpc] ${msg}`);
-  void slackService.notifySlackStartOrCrash(`⚠️ *router-tms* pagination cap: ${msg}`, SlackSeverity.WARNING).catch(() => {});
+  void slackService.notifySlackStartOrCrash(`⚠️ *router-tms* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
 });
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl);
 const enablementStore = new InMemoryRouterEnablementStore();

--- a/src/services/circlesRpcService.ts
+++ b/src/services/circlesRpcService.ts
@@ -10,6 +10,7 @@ const PAGE_TIMEOUT_MS = 30_000;
 const CIRCLES_EVENTS_RESULT_LIMIT = 100;
 const DEFAULT_TRUST_QUERY_PAGE_SIZE = 1000;
 const MAX_EVENT_RECURSION_DEPTH = 10;
+const WARNING_COOLDOWN_MS = 30 * 60 * 1000; // 30 minutes
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -40,7 +41,16 @@ export class CirclesRpcService implements ICirclesRpc {
 
   constructor(rpcUrl: string, onWarning?: (msg: string) => void) {
     this.rpc = new CirclesRpc(primaryRpcUrl(rpcUrl));
-    this.onWarning = onWarning ?? ((msg) => console.warn(`[CirclesRpc] ${msg}`));
+    const rawWarning = onWarning ?? ((msg) => console.warn(`[CirclesRpc] ${msg}`));
+    const lastWarningAt = new Map<string, number>();
+    this.onWarning = (msg) => {
+      const key = msg.split(":")[0]; // dedupe by method name prefix
+      const now = Date.now();
+      const last = lastWarningAt.get(key) ?? 0;
+      if (now - last < WARNING_COOLDOWN_MS) return;
+      lastWarningAt.set(key, now);
+      rawWarning(msg);
+    };
   }
 
   async isHuman(address: string): Promise<boolean> {

--- a/tests/services/circlesRpcService.spec.ts
+++ b/tests/services/circlesRpcService.spec.ts
@@ -50,8 +50,8 @@ jest.mock("@aboutcircles/sdk-rpc", () => ({
 const FACTORY = "0xFACT0RY000000000000000000000000DeAdBeEf";
 const RPC_URL = "https://rpc.example.com";
 
-function buildService(): CirclesRpcService {
-  return new CirclesRpcService(RPC_URL);
+function buildService(onWarning?: (msg: string) => void): CirclesRpcService {
+  return new CirclesRpcService(RPC_URL, onWarning);
 }
 
 function makeRawBackingCompletedEvent(blockNumber: number, suffix: string) {
@@ -561,6 +561,45 @@ describe("CirclesRpcService", () => {
       expect(svc.getLastBulkTrusteesForTrustersStats().pagesFetched).toBe(500);
 
       jest.useRealTimers();
+    });
+
+    it("calls onWarning callback when MAX_PAGES cap is hit", async () => {
+      jest.useFakeTimers();
+
+      const onWarning = jest.fn();
+      const truster = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      let callCount = 0;
+      const infiniteQuery = {
+        queryNextPage: jest.fn(async () => { callCount++; return true; }),
+        get currentPage() {
+          return { results: [{ truster, trustee: `0x${callCount.toString().padStart(40, "0")}` }] };
+        },
+      };
+      mockGetTrustRelations.mockReturnValueOnce(infiniteQuery);
+
+      const svc = buildService(onWarning);
+      const promise = svc.fetchAllTrustees(truster);
+      await jest.runAllTimersAsync();
+      await promise;
+
+      expect(onWarning).toHaveBeenCalledTimes(1);
+      expect(onWarning).toHaveBeenCalledWith(expect.stringContaining("hit 500-page cap"));
+
+      jest.useRealTimers();
+    });
+
+    it("does not call onWarning when pagination completes normally", async () => {
+      const onWarning = jest.fn();
+      mockGetTrustRelations.mockReturnValueOnce(
+        makeMockPagedQuery([
+          [{ truster: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", trustee: "0xbbb" }],
+        ]),
+      );
+
+      const svc = buildService(onWarning);
+      await svc.fetchAllTrustees("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+
+      expect(onWarning).not.toHaveBeenCalled();
     });
 
     it("fetchAllBaseGroups normalizes group addresses to lowercase", async () => {


### PR DESCRIPTION
## Summary
- Fix TDZ risk: move `slackService` before `circlesRpc` in all 6 apps
- Add 30min cooldown to pagination cap Slack alerts (prevents storms)
- Log Slack delivery failures instead of silent `.catch(() => {})`
- Add 2 tests for `onWarning` callback (fires on cap hit, silent on normal)

## Context
Code review of the Slack alerting commit found 4 issues. All fixed here.

## Test plan
- [x] 335 tests pass
- [x] Type check clean