### PR TITLE
fix: raise gnosis-group score batch size 20→200

### DIFF
--- a/src/apps/gnosis-group/logic.ts
+++ b/src/apps/gnosis-group/logic.ts
@@ -87,7 +87,7 @@ export class ScoreCache {
 }
 
 export const DEFAULT_FETCH_PAGE_SIZE = 1_000;
-export const DEFAULT_SCORE_BATCH_SIZE = 20;
+export const DEFAULT_SCORE_BATCH_SIZE = 200;
 export const DEFAULT_SCORE_THRESHOLD = 100;
 export const DEFAULT_GROUP_BATCH_SIZE = 10;
 export const DEFAULT_BACKERS_GROUP_ADDRESS = "0x1aca75e38263c79d9d4f10df0635cc6fcfe6f026";


### PR DESCRIPTION
## Summary
- Raise `DEFAULT_SCORE_BATCH_SIZE` from 20 to 200
- Cuts scoring requests from ~607 to ~61 per run (10x reduction)
- Fixes `GroupTmsStaleAlert` caused by intermittent 504s from scoring service stretching runs past 1 hour

## Context
The scoring API is batch-native. Each request sends the full `target_sets` (~650 addresses) regardless of avatar batch size. Increasing batch size adds minimal payload but dramatically reduces HTTP round-trips.

## Test plan
- [x] 45 gnosis-group tests pass (all explicitly set `scoreBatchSize` — don't use the default)
- [x] Type check clean
- [ ] Deploy, verify logs show ~61 batches and run completes within 30min