### PR TITLE
fix: revert score batch to 20, configurable blacklist timeout 60s

### DIFF
--- a/src/apps/crc-backers/main.ts
+++ b/src/apps/crc-backers/main.ts
@@ -55,7 +55,13 @@ const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   void slackService.notifySlackStartOrCrash(`⚠️ *crc-backers* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
 });
 const chainRpc = new ChainRpcService(rpcUrl);
-const blacklistTimeoutMs = Math.max(1000, Number(process.env.BLACKLIST_TIMEOUT_MS) || 60_000);
+const blacklistTimeoutMs = (() => {
+  const raw = process.env.BLACKLIST_TIMEOUT_MS;
+  if (!raw) return 60_000;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) { console.warn(`[config] Invalid BLACKLIST_TIMEOUT_MS="${raw}", using default 60000`); return 60_000; }
+  return parsed;
+})();
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl, blacklistTimeoutMs);
 const groupService = (!dryRun || canSimulateTransactions)
   ? new SafeGroupService(rpcUrl, safeSignerPrivateKey, safeAddress, txRpcUrl)

--- a/src/apps/crc-backers/main.ts
+++ b/src/apps/crc-backers/main.ts
@@ -55,7 +55,8 @@ const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   void slackService.notifySlackStartOrCrash(`⚠️ *crc-backers* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
 });
 const chainRpc = new ChainRpcService(rpcUrl);
-const blacklistingService = new BlacklistingService(blacklistingServiceUrl);
+const blacklistTimeoutMs = Math.max(1000, Number(process.env.BLACKLIST_TIMEOUT_MS) || 60_000);
+const blacklistingService = new BlacklistingService(blacklistingServiceUrl, blacklistTimeoutMs);
 const groupService = (!dryRun || canSimulateTransactions)
   ? new SafeGroupService(rpcUrl, safeSignerPrivateKey, safeAddress, txRpcUrl)
   : undefined;

--- a/src/apps/gnosis-group/logic.ts
+++ b/src/apps/gnosis-group/logic.ts
@@ -88,7 +88,7 @@ export class ScoreCache {
 }
 
 export const DEFAULT_FETCH_PAGE_SIZE = 1_000;
-export const DEFAULT_SCORE_BATCH_SIZE = 200;
+export const DEFAULT_SCORE_BATCH_SIZE = 20;
 export const DEFAULT_SCORE_THRESHOLD = 100;
 export const DEFAULT_GROUP_BATCH_SIZE = 10;
 export const DEFAULT_BACKERS_GROUP_ADDRESS = "0x1aca75e38263c79d9d4f10df0635cc6fcfe6f026";

--- a/src/apps/gnosis-group/main.ts
+++ b/src/apps/gnosis-group/main.ts
@@ -56,7 +56,13 @@ const scoreThreshold = parseEnvNumber("GNOSIS_GROUP_SCORE_THRESHOLD", DEFAULT_SC
 const groupBatchSize = parseEnvInt("GNOSIS_GROUP_BATCH_SIZE", DEFAULT_GROUP_BATCH_SIZE);
 const scoreCacheTtlMs = parseEnvInt("GNOSIS_GROUP_SCORE_CACHE_TTL_MINUTES", DEFAULT_SCORE_CACHE_TTL_MS / 60_000) * 60_000;
 
-const blacklistTimeoutMs = Math.max(1000, Number(process.env.BLACKLIST_TIMEOUT_MS) || 60_000);
+const blacklistTimeoutMs = (() => {
+  const raw = process.env.BLACKLIST_TIMEOUT_MS;
+  if (!raw) return 60_000;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) { console.warn(`[config] Invalid BLACKLIST_TIMEOUT_MS="${raw}", using default 60000`); return 60_000; }
+  return parsed;
+})();
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl, blacklistTimeoutMs);
 const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
 const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {

--- a/src/apps/gnosis-group/main.ts
+++ b/src/apps/gnosis-group/main.ts
@@ -56,7 +56,8 @@ const scoreThreshold = parseEnvNumber("GNOSIS_GROUP_SCORE_THRESHOLD", DEFAULT_SC
 const groupBatchSize = parseEnvInt("GNOSIS_GROUP_BATCH_SIZE", DEFAULT_GROUP_BATCH_SIZE);
 const scoreCacheTtlMs = parseEnvInt("GNOSIS_GROUP_SCORE_CACHE_TTL_MINUTES", DEFAULT_SCORE_CACHE_TTL_MS / 60_000) * 60_000;
 
-const blacklistingService = new BlacklistingService(blacklistingServiceUrl);
+const blacklistTimeoutMs = Math.max(1000, Number(process.env.BLACKLIST_TIMEOUT_MS) || 60_000);
+const blacklistingService = new BlacklistingService(blacklistingServiceUrl, blacklistTimeoutMs);
 const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
 const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   console.warn(`[CirclesRpc] ${msg}`);

--- a/src/apps/gp-crc/main.ts
+++ b/src/apps/gp-crc/main.ts
@@ -49,7 +49,13 @@ const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   console.warn(`[CirclesRpc] ${msg}`);
   void slackService.notifySlackStartOrCrash(`⚠️ *gp-crc* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
 });
-const blacklistTimeoutMs = Math.max(1000, Number(process.env.BLACKLIST_TIMEOUT_MS) || 60_000);
+const blacklistTimeoutMs = (() => {
+  const raw = process.env.BLACKLIST_TIMEOUT_MS;
+  if (!raw) return 60_000;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) { console.warn(`[config] Invalid BLACKLIST_TIMEOUT_MS="${raw}", using default 60000`); return 60_000; }
+  return parsed;
+})();
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl, blacklistTimeoutMs);
 const slackConfigured = slackWebhookUrl.trim().length > 0;
 let groupService: IGroupService | undefined;

--- a/src/apps/gp-crc/main.ts
+++ b/src/apps/gp-crc/main.ts
@@ -49,7 +49,8 @@ const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   console.warn(`[CirclesRpc] ${msg}`);
   void slackService.notifySlackStartOrCrash(`⚠️ *gp-crc* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
 });
-const blacklistingService = new BlacklistingService(blacklistingServiceUrl);
+const blacklistTimeoutMs = Math.max(1000, Number(process.env.BLACKLIST_TIMEOUT_MS) || 60_000);
+const blacklistingService = new BlacklistingService(blacklistingServiceUrl, blacklistTimeoutMs);
 const slackConfigured = slackWebhookUrl.trim().length > 0;
 let groupService: IGroupService | undefined;
 let avatarSafeService: MetriSafeService;

--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -44,7 +44,8 @@ const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   console.warn(`[CirclesRpc] ${msg}`);
   void slackService.notifySlackStartOrCrash(`⚠️ *router-tms* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
 });
-const blacklistingService = new BlacklistingService(blacklistingServiceUrl);
+const blacklistTimeoutMs = Math.max(1000, Number(process.env.BLACKLIST_TIMEOUT_MS) || 60_000);
+const blacklistingService = new BlacklistingService(blacklistingServiceUrl, blacklistTimeoutMs);
 const enablementStore = new InMemoryRouterEnablementStore();
 const errorsBeforeCrash = 3;
 const errorTracker = new ConsecutiveErrorTracker(errorsBeforeCrash);

--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -44,7 +44,13 @@ const circlesRpc = new CirclesRpcService(rpcUrl, (msg) => {
   console.warn(`[CirclesRpc] ${msg}`);
   void slackService.notifySlackStartOrCrash(`⚠️ *router-tms* pagination cap: ${msg}`, SlackSeverity.WARNING).catch((e) => console.warn("[SlackAlert] failed:", (e as Error).message));
 });
-const blacklistTimeoutMs = Math.max(1000, Number(process.env.BLACKLIST_TIMEOUT_MS) || 60_000);
+const blacklistTimeoutMs = (() => {
+  const raw = process.env.BLACKLIST_TIMEOUT_MS;
+  if (!raw) return 60_000;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) { console.warn(`[config] Invalid BLACKLIST_TIMEOUT_MS="${raw}", using default 60000`); return 60_000; }
+  return parsed;
+})();
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl, blacklistTimeoutMs);
 const enablementStore = new InMemoryRouterEnablementStore();
 const errorsBeforeCrash = 3;

--- a/src/services/blacklistingService.ts
+++ b/src/services/blacklistingService.ts
@@ -1,6 +1,6 @@
 import {IBlacklistingService, IBlacklistServiceVerdict} from "../interfaces/IBlacklistingService";
 
-const DEFAULT_PAGE_TIMEOUT_MS = 30_000;
+export const DEFAULT_BLACKLIST_PAGE_TIMEOUT_MS = 60_000;
 const DEFAULT_PAGE_SIZE = 1000;
 const MAX_PAGES = 100; // 100k addresses max — well beyond expected blacklist size
 
@@ -18,7 +18,7 @@ export class BlacklistingService implements IBlacklistingService {
 
     constructor(
         private serviceUrl: string,
-        private readonly pageTimeoutMs: number = DEFAULT_PAGE_TIMEOUT_MS,
+        private readonly pageTimeoutMs: number = DEFAULT_BLACKLIST_PAGE_TIMEOUT_MS,
         private readonly pageSize: number = DEFAULT_PAGE_SIZE
     ) {}
 


### PR DESCRIPTION
## Summary
- Revert `DEFAULT_SCORE_BATCH_SIZE` from 200 back to 20 (conservative default)
- `BLACKLIST_TIMEOUT_MS` env var, default 60s (was hardcoded 30s). Parsed with validation in all 4 apps.

## Test plan
- [x] 342 tests pass
- [x] Type check clean