### PR TITLE
fix: send Slack resolved notification when ConsecutiveErrorTracker recovers

### DIFF
--- a/src/apps/crc-backers/main.ts
+++ b/src/apps/crc-backers/main.ts
@@ -192,6 +192,11 @@ async function loop(leaderElection: LeaderElection | null) {
       await stateStore?.save("crc-backers", nextFromBlock);
       recordRunSuccess("crc-backers", Date.now() - runStartedAt);
       errorTracker.recordSuccess();
+      if (errorTracker.wasAlertingAndRecovered()) {
+        slackService.notifySlackResolved("CRC Backers").catch((err) => {
+          rootLogger.warn("Failed to send Slack resolved notification:", err);
+        });
+      }
       currentDelay = pollIntervalMs; // reset on success
     } catch (caught: unknown) {
       const isError = caught instanceof Error;

--- a/src/apps/dublin-tms/main.ts
+++ b/src/apps/dublin-tms/main.ts
@@ -179,6 +179,11 @@ async function mainLoop(): Promise<void> {
 
       await notifySlackRunSummary(outcome);
       errorTracker.recordSuccess();
+      if (errorTracker.wasAlertingAndRecovered()) {
+        slackService.notifySlackResolved("Dublin TMS").catch((err) => {
+          rootLogger.warn("Failed to send Slack resolved notification:", err);
+        });
+      }
       currentDelay = pollIntervalMs;
     } catch (cause) {
       const error = cause instanceof Error ? cause : new Error(String(cause));

--- a/src/apps/gnosis-group/main.ts
+++ b/src/apps/gnosis-group/main.ts
@@ -199,6 +199,11 @@ async function mainLoop(): Promise<void> {
       await stateStore?.save("gnosis-group", 0, { lastSuccessfulRunAt: new Date().toISOString() });
       recordRunSuccess("gnosis-group", Date.now() - runStartedAt);
       errorTracker.recordSuccess();
+      if (errorTracker.wasAlertingAndRecovered()) {
+        slackService.notifySlackResolved("Gnosis Group").catch((err) => {
+          rootLogger.warn("Failed to send Slack resolved notification:", err);
+        });
+      }
       currentDelay = runIntervalMs;
       rootLogger.info(
         `Run completed. Addresses with relative score > ${outcome.threshold}: ${outcome.aboveThresholdCount}`

--- a/src/apps/gp-crc/main.ts
+++ b/src/apps/gp-crc/main.ts
@@ -183,6 +183,11 @@ async function mainLoop(): Promise<void> {
       await stateStore?.save("gp-crc", 0, { lastSuccessfulRunAt: new Date().toISOString() });
       recordRunSuccess("gp-crc", Date.now() - runStartedAt);
       errorTracker.recordSuccess();
+      if (errorTracker.wasAlertingAndRecovered()) {
+        slackService.notifySlackResolved("GP-CRC TMS").catch((err) => {
+          rootLogger.warn("Failed to send Slack resolved notification:", err);
+        });
+      }
       currentDelay = pollIntervalMs;
     } catch (cause) {
       const error = cause instanceof Error ? cause : new Error(String(cause));

--- a/src/apps/oic/main.ts
+++ b/src/apps/oic/main.ts
@@ -220,6 +220,11 @@ async function loop() {
       await stateStore?.save("oic", state.lastSafeHeadScanned);
       recordRunSuccess("oic", Date.now() - runStartedAt);
       errorTracker.recordSuccess();
+      if (errorTracker.wasAlertingAndRecovered()) {
+        slackService.notifySlackResolved("OIC").catch((err) => {
+          rootLogger.warn("Failed to send Slack resolved notification:", err);
+        });
+      }
       currentDelay = pollIntervalMs;
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));

--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -166,6 +166,11 @@ async function mainLoop(): Promise<void> {
       await stateStore?.save("router-tms", 0, { lastSuccessfulRunAt: new Date().toISOString() });
       recordRunSuccess("router-tms", Date.now() - runStartedAt);
       errorTracker.recordSuccess();
+      if (errorTracker.wasAlertingAndRecovered()) {
+        slackService.notifySlackResolved("Router TMS").catch((err) => {
+          rootLogger.warn("Failed to send Slack resolved notification:", err);
+        });
+      }
       currentDelay = pollIntervalMs;
       runLogger.info(
         "router-tms run completed: " +

--- a/src/interfaces/ISlackService.ts
+++ b/src/interfaces/ISlackService.ts
@@ -11,4 +11,6 @@ export interface ISlackService {
     notifyBackingNotCompleted(backingInitiatedEvent: BackingInitiatedEvent, reason: string): Promise<void>;
 
     notifySlackStartOrCrash(message: string, severity?: SlackSeverity): Promise<void>;
+
+    notifySlackResolved(appName: string): Promise<void>;
 }

--- a/src/services/consecutiveErrorTracker.ts
+++ b/src/services/consecutiveErrorTracker.ts
@@ -6,6 +6,7 @@
  */
 export class ConsecutiveErrorTracker {
   private count = 0;
+  private wasAlerting: boolean = false;
 
   constructor(private readonly threshold: number = 3) {}
 
@@ -18,7 +19,25 @@ export class ConsecutiveErrorTracker {
   }
 
   shouldAlert(): boolean {
-    return this.count >= this.threshold;
+    const alert = this.count >= this.threshold;
+    if (alert) {
+      this.wasAlerting = true;
+    }
+    return alert;
+  }
+
+  /**
+   * Returns true exactly once after the tracker transitions from
+   * an alerting state back to zero errors (i.e. recovery).
+   * Resets the flag so subsequent calls return false until the
+   * next alert→recovery cycle.
+   */
+  wasAlertingAndRecovered(): boolean {
+    if (this.wasAlerting && this.count === 0) {
+      this.wasAlerting = false;
+      return true;
+    }
+    return false;
   }
 
   getCount(): number {

--- a/src/services/slackService.ts
+++ b/src/services/slackService.ts
@@ -47,6 +47,30 @@ export class SlackService implements ISlackService {
     }
   }
 
+  async notifySlackResolved(appName: string): Promise<void> {
+    const message = `${this.tag} ✅ *${appName} recovered* — consecutive error streak resolved.`;
+    const webhookUrl = this.selectWebhook(SlackSeverity.INFO);
+    if (!webhookUrl) {
+      const ts = new Date().toISOString();
+      console.warn(`[${ts}]`, `Slack resolved notification (no webhook configured): ${message}`);
+      return;
+    }
+
+    const payload: Record<string, string> = { text: message };
+    if (this.infoChannel) {
+      payload.channel = this.infoChannel;
+    }
+
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) {
+      throw new Error(`Slack resolved notify failed: ${res.status} ${await res.text()}`);
+    }
+  }
+
   async notifySlackStartOrCrash(message: string, severity: SlackSeverity = SlackSeverity.CRITICAL): Promise<void> {
     const tagged = `${this.tag} ${message}`;
     const webhookUrl = this.selectWebhook(severity);


### PR DESCRIPTION
## Summary
- ConsecutiveErrorTracker now tracks alerting state (`wasAlerting` flag)
- New `wasAlertingAndRecovered()` method returns true exactly once on recovery
- SlackService gets `notifySlackResolved()` — posts INFO-severity recovery message
- All 6 apps (dublin-tms, gnosis-group, router-tms, crc-backers, gp-crc, oic) call resolved notification after `recordSuccess()`

## Problem
Direct Slack webhooks fire on errors but never send "resolved" messages. Stale alert noise accumulates in Slack — no way to tell if an issue is ongoing or already recovered.

## Test plan
- [ ] Deploy to staging, trigger consecutive errors (e.g. stop RPC), verify Slack alert fires
- [ ] Restart RPC, verify "resolved" message appears in Slack after next successful run
- [ ] Verify normal operation (no errors) doesn't send resolved messages