### PR TITLE
fix: retry gas estimation on transient RPC failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,16 @@ npm run start:all
 
 ## Configuration (.env)
 
+`RPC_URL` remains the default read RPC for all apps. Set `TX_RPC_URL` when you want transaction submission and confirmation to use a different RPC; if unset, writes keep using `RPC_URL`.
+
+When `DRY_RUN=1`, the apps now attempt gas estimation plus transaction simulation for write batches if the relevant signer/Safe credentials are configured. If those credentials are omitted in dry-run mode, the app still logs planned actions and explicitly skips the simulation step.
+
 ### CRC Backers App Configuration
 
 ```dotenv
 # RPC & addresses
 RPC_URL=https://rpc.aboutcircles.com/
+TX_RPC_URL=https://your-write-rpc.example/   # optional; overrides only transaction execution
 BACKING_FACTORY_ADDRESS=0xeced91232c609a42f6016860e8223b8aecaa7bd0
 BACKERS_GROUP_ADDRESS=0x1ACA75e38263c79d9D4F10dF0635cc6FCfe6F026
 
@@ -100,6 +105,7 @@ DRY_RUN=0             # Set to "1" to skip Safe transactions and only log action
 ```dotenv
 # RPC & addresses
 RPC_URL=https://rpc.aboutcircles.com/
+TX_RPC_URL=https://your-write-rpc.example/   # optional; overrides only transaction execution
 GP_CRC_GROUP_ADDRESS=0xb629a1e86f3efada0f87c83494da8cc34c3f84ef
 
 # Safe execution (required unless dry run)
@@ -131,6 +137,7 @@ VERBOSE_LOGGING=1
 ```dotenv
 # RPC & addresses
 RPC_URL=https://rpc.aboutcircles.com/
+TX_RPC_URL=https://your-write-rpc.example/   # optional; overrides only transaction execution
 OIC_GROUP_ADDRESS=0x4E2564e5df6C1Fb10C1A018538de36E4D5844DE5
 OIC_META_ORG_ADDRESS=                    # REQUIRED - Meta organization address
 AFFILIATE_REGISTRY_ADDRESS=0xca8222e780d046707083f51377b5fd85e2866014
@@ -160,6 +167,7 @@ VERBOSE_LOGGING=1     # any truthy value enables debug/table
 ```dotenv
 # RPC
 RPC_URL=https://rpc.aboutcircles.com/
+TX_RPC_URL=https://your-write-rpc.example/   # optional; overrides only transaction execution
 
 # RegisterHuman source + target group
 DUBLIN_TMS_ADDRESS=0xAeCda439CC8Ac2a2da32bE871E0C2D7155350f80
@@ -193,6 +201,7 @@ VERBOSE_LOGGING=1
 ```dotenv
 # RPC & addresses
 RPC_URL=https://rpc.aboutcircles.com/
+TX_RPC_URL=https://your-write-rpc.example/   # optional; overrides only transaction execution
 ROUTER_ADDRESS=0xdc287474114cc0551a81ddc2eb51783fbf34802f
 ROUTER_BASE_GROUP_ADDRESS=0x1ACA75e38263c79d9D4F10dF0635cc6FCfe6F026
 
@@ -221,6 +230,7 @@ VERBOSE_LOGGING=1
 ```dotenv
 # RPC & addresses
 RPC_URL=https://rpc.aboutcircles.com/
+TX_RPC_URL=https://your-write-rpc.example/   # optional; overrides only transaction execution
 GNOSIS_GROUP_ADDRESS=0xC19BC204eb1c1D5B3FE500E5E5dfaBaB625F286c
 
 # Safe execution

--- a/fakes/fakes.ts
+++ b/fakes/fakes.ts
@@ -84,6 +84,15 @@ export class FakeCirclesRpc implements ICirclesRpc {
     return this.trusteesByTruster[truster.toLowerCase()] ?? [];
   }
 
+  async fetchAllTrusteesForTrusters(trusters: string[]): Promise<Map<string, string[]>> {
+    const result = new Map<string, string[]>();
+    for (const truster of trusters) {
+      const normalized = truster.toLowerCase();
+      result.set(normalized, [...(this.trusteesByTruster[normalized] ?? [])]);
+    }
+    return result;
+  }
+
   async fetchActiveGroupMembersAtBlock(groupAddress: string, blockNumber: number): Promise<string[]> {
     return this.activeGroupMembersAtBlock[this.makeGroupBlockKey(groupAddress, blockNumber)] ?? [];
   }

--- a/fakes/fakes.ts
+++ b/fakes/fakes.ts
@@ -65,6 +65,7 @@ export class FakeCirclesRpc implements ICirclesRpc {
   initiated: BackingInitiatedEvent[] = [];
   completed: BackingCompletedEvent[] = [];
   trusteesByTruster: Record<string, string[]> = {};
+  activeGroupMembersAtBlock: Record<string, string[]> = {};
   baseGroups: string[] = [];
   humanityOverrides = new Map<string, boolean>();
   humanAvatars: string[] = [];
@@ -81,6 +82,10 @@ export class FakeCirclesRpc implements ICirclesRpc {
 
   async fetchAllTrustees(truster: string): Promise<string[]> {
     return this.trusteesByTruster[truster.toLowerCase()] ?? [];
+  }
+
+  async fetchActiveGroupMembersAtBlock(groupAddress: string, blockNumber: number): Promise<string[]> {
+    return this.activeGroupMembersAtBlock[this.makeGroupBlockKey(groupAddress, blockNumber)] ?? [];
   }
 
   async fetchAllBaseGroups(_pageSize?: number): Promise<string[]> {
@@ -111,6 +116,10 @@ export class FakeCirclesRpc implements ICirclesRpc {
 
   async fetchAllHumanAvatars(_pageSize?: number): Promise<string[]> {
     return [...this.humanAvatars];
+  }
+
+  private makeGroupBlockKey(groupAddress: string, blockNumber: number): string {
+    return `${groupAddress.toLowerCase()}@${blockNumber}`;
   }
 }
 

--- a/fakes/fakes.ts
+++ b/fakes/fakes.ts
@@ -20,6 +20,7 @@ import {
 import {IRouterService} from "../src/interfaces/IRouterService";
 import {IRouterEnablementStore} from "../src/interfaces/IRouterEnablementStore";
 import {IAvatarSafeMappingStore, SafeTrustState} from "../src/interfaces/IAvatarSafeMappingStore";
+import {TransactionSimulationResult} from "../src/interfaces/ITransactionSimulation";
 
 export class FakeLogger implements ILoggerService {
   logs: { level: "info" | "warn" | "error" | "debug" | "table"; args: unknown[] }[] = [];
@@ -175,8 +176,11 @@ export class FakeBlacklist implements IBlacklistingService {
 
 export class FakeGroupService implements IGroupService {
   calls: { type: "trust" | "untrust"; groupAddress: string; trusteeAddresses: string[] }[] = [];
+  simulations: { type: "trust" | "untrust"; groupAddress: string; trusteeAddresses: string[] }[] = [];
   trustCalls = 0;
   untrustCalls = 0;
+  trustSimulations = 0;
+  untrustSimulations = 0;
 
   async trustBatchWithConditions(groupAddress: string, trusteeAddresses: string[]): Promise<string> {
     this.trustCalls += 1;
@@ -192,6 +196,18 @@ export class FakeGroupService implements IGroupService {
 
   async fetchGroupOwnerAndService(): Promise<any> {
     throw new Error("Not under test");
+  }
+
+  async simulateTrustBatchWithConditions(groupAddress: string, trusteeAddresses: string[]): Promise<TransactionSimulationResult> {
+    this.trustSimulations += 1;
+    this.simulations.push({type: "trust", groupAddress, trusteeAddresses: [...trusteeAddresses]});
+    return {gasEstimate: BigInt(100_000 + this.trustSimulations)};
+  }
+
+  async simulateUntrustBatch(groupAddress: string, trusteeAddresses: string[]): Promise<TransactionSimulationResult> {
+    this.untrustSimulations += 1;
+    this.simulations.push({type: "untrust", groupAddress, trusteeAddresses: [...trusteeAddresses]});
+    return {gasEstimate: BigInt(100_000 + this.untrustSimulations)};
   }
 }
 
@@ -271,6 +287,8 @@ export class FakeAvatarSafeService implements IAvatarSafeService {
 export class FakeBackingInstanceService implements IBackingInstanceService {
   simulateReset: Record<string, ResetCowSwapOrderResult> = {};
   simulateCreate: Record<string, CreateLBPResult> = {};
+  simulateResetTxCalls: string[] = [];
+  simulateCreateTxCalls: string[] = [];
   resetCalls: string[] = [];
   createCalls: string[] = [];
 
@@ -290,6 +308,16 @@ export class FakeBackingInstanceService implements IBackingInstanceService {
   async createLbp(addr: string): Promise<string> {
     this.createCalls.push(addr.toLowerCase());
     return `0xcreate_${addr.toLowerCase()}`;
+  }
+
+  async simulateResetCowSwapOrderTx(addr: string): Promise<TransactionSimulationResult> {
+    this.simulateResetTxCalls.push(addr.toLowerCase());
+    return {gasEstimate: 210_000n};
+  }
+
+  async simulateCreateLbpTx(addr: string): Promise<TransactionSimulationResult> {
+    this.simulateCreateTxCalls.push(addr.toLowerCase());
+    return {gasEstimate: 310_000n};
   }
 }
 
@@ -326,7 +354,9 @@ export class FakeAffiliateGroupEvents implements IAffiliateGroupEventsService {
 
 export class FakeRouterService implements IRouterService {
   calls: { baseGroup: string; crcAddresses: string[] }[] = [];
+  simulations: { baseGroup: string; crcAddresses: string[] }[] = [];
   txHashes: string[] = [];
+  simulationCalls = 0;
   private readonly responseQueue: string[];
   failWith?: Error;
 
@@ -345,6 +375,16 @@ export class FakeRouterService implements IRouterService {
       : `0xtx_${this.calls.length}`;
     this.txHashes.push(txHash);
     return txHash;
+  }
+
+  async simulateEnableCRCForRouting(baseGroup: string, crcAddresses: string[]): Promise<TransactionSimulationResult> {
+    this.simulationCalls += 1;
+    this.simulations.push({baseGroup, crcAddresses: [...crcAddresses]});
+    if (this.failWith) {
+      throw this.failWith;
+    }
+
+    return {gasEstimate: BigInt(150_000 + this.simulationCalls)};
   }
 }
 

--- a/fakes/fakes.ts
+++ b/fakes/fakes.ts
@@ -267,7 +267,7 @@ export class FakeAvatarSafeService implements IAvatarSafeService {
     const selectedOwnersBySafe = new Map<string, SafeOwnerSelection>();
     for (const candidate of candidates) {
       const existing = selectedOwnersBySafe.get(candidate.safe);
-      if (!existing || compareTimestamp(candidate.timestamp, existing.timestamp) > 0) {
+      if (!existing || shouldReplaceSelection(existing, candidate.avatar, candidate.timestamp)) {
         selectedOwnersBySafe.set(candidate.safe, {
           avatar: candidate.avatar,
           timestamp: candidate.timestamp
@@ -475,6 +475,22 @@ function compareTimestamp(left: string, right: string): number {
   if (leftBigInt > rightBigInt) return 1;
   if (leftBigInt < rightBigInt) return -1;
   return 0;
+}
+
+function shouldReplaceSelection(
+  existing: SafeOwnerSelection,
+  candidateAvatar: string,
+  candidateTimestamp: string
+): boolean {
+  const timestampComparison = compareTimestamp(candidateTimestamp, existing.timestamp);
+  if (timestampComparison > 0) {
+    return true;
+  }
+  if (timestampComparison < 0) {
+    return false;
+  }
+
+  return candidateAvatar.toLowerCase().localeCompare(existing.avatar.toLowerCase()) < 0;
 }
 
 function toComparableBigInt(raw: string): bigint | null {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,7 +15,6 @@ module.exports = {
     "<rootDir>/src/apps/oic/logic.ts",
     "<rootDir>/src/apps/gp-crc/logic.ts",
     "<rootDir>/src/apps/router-tms/logic.ts",
-    "<rootDir>/fakes/fakes.ts",
     "!<rootDir>/src/main.ts",
     "!**/*.d.ts",
     "!**/__tests__/**",

--- a/src/apps/crc-backers/logic.ts
+++ b/src/apps/crc-backers/logic.ts
@@ -193,16 +193,28 @@ export async function trustAllNewBackers(
   if (dryRun || !groupService) {
     if (willUntrustAny) {
       LOG.info(`  - Dry-run enabled; would untrust ${toUntrust.length} backers in ${untrustBatches.length} batch(es).`);
-      untrustBatches.forEach((batch, index) => {
+      for (const [index, batch] of untrustBatches.entries()) {
         LOG.info(`    DRY RUN untrust batch ${index + 1}/${untrustBatches.length}: ${batch.length} backers -> ${batch.join(", ")}`);
-      });
+        if (groupService?.simulateUntrustBatch) {
+          const simulation = await groupService.simulateUntrustBatch(groupAddress, batch);
+          LOG.info(`    DRY RUN untrust simulation ${index + 1}/${untrustBatches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`);
+        } else {
+          LOG.info(`    DRY RUN untrust simulation ${index + 1}/${untrustBatches.length}: skipped (no signer-backed simulator configured).`);
+        }
+      }
     }
     if (willAddAny) {
       LOG.info(`  - Dry-run enabled; would trust ${notAlreadyTrusted.length} backers in ${trustBatches.length} batch(es).`);
-      trustBatches.forEach((batch, index) => {
+      for (const [index, batch] of trustBatches.entries()) {
         const backersToTrust = batch.map((e) => e.backer);
         LOG.info(`    DRY RUN trust batch ${index + 1}/${trustBatches.length}: ${batch.length} backers -> ${backersToTrust.join(", ")}`);
-      });
+        if (groupService?.simulateTrustBatchWithConditions) {
+          const simulation = await groupService.simulateTrustBatchWithConditions(groupAddress, backersToTrust);
+          LOG.info(`    DRY RUN trust simulation ${index + 1}/${trustBatches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`);
+        } else {
+          LOG.info(`    DRY RUN trust simulation ${index + 1}/${trustBatches.length}: skipped (no signer-backed simulator configured).`);
+        }
+      }
     }
   } else {
     if (willUntrustAny) {
@@ -455,6 +467,12 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunResult> {
         case "Success": {
           if (dryRun) {
             LOG.info(`[DRY RUN] Would create LBP for ${event.backer} at ${event.circlesBackingInstance}.`);
+            if (cowSwapService.simulateCreateLbpTx) {
+              const simulation = await cowSwapService.simulateCreateLbpTx(event.circlesBackingInstance);
+              LOG.info(`[DRY RUN] createLBP simulation ok for ${event.circlesBackingInstance}; gasEstimate=${simulation.gasEstimate.toString()}.`);
+            } else {
+              LOG.info(`[DRY RUN] createLBP simulation skipped for ${event.circlesBackingInstance} (no signer-backed simulator configured).`);
+            }
           } else {
             LOG.info(`Creating LBP for ${event.backer} at ${event.circlesBackingInstance}...`);
             const txHash = await cowSwapService.createLbp(event.circlesBackingInstance);
@@ -488,6 +506,12 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunResult> {
       case "OrderValid": {
         if (dryRun) {
           LOG.info(`[DRY RUN] Would reset order for ${event.backer} at ${event.circlesBackingInstance}.`);
+          if (cowSwapService.simulateResetCowSwapOrderTx) {
+            const simulation = await cowSwapService.simulateResetCowSwapOrderTx(event.circlesBackingInstance);
+            LOG.info(`[DRY RUN] resetCowswapOrder simulation ok for ${event.circlesBackingInstance}; gasEstimate=${simulation.gasEstimate.toString()}.`);
+          } else {
+            LOG.info(`[DRY RUN] resetCowswapOrder simulation skipped for ${event.circlesBackingInstance} (no signer-backed simulator configured).`);
+          }
         } else {
           LOG.info(`Resetting order for ${event.backer} at ${event.circlesBackingInstance}...`);
           const txHash = await cowSwapService.resetCowSwapOrder(event.circlesBackingInstance);
@@ -500,6 +524,12 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunResult> {
         if (lbpState === "Success") {
           if (dryRun) {
             LOG.info(`[DRY RUN] Would create LBP for ${event.circlesBackingInstance} after settled order.`);
+            if (cowSwapService.simulateCreateLbpTx) {
+              const simulation = await cowSwapService.simulateCreateLbpTx(event.circlesBackingInstance);
+              LOG.info(`[DRY RUN] createLBP simulation ok for ${event.circlesBackingInstance}; gasEstimate=${simulation.gasEstimate.toString()}.`);
+            } else {
+              LOG.info(`[DRY RUN] createLBP simulation skipped for ${event.circlesBackingInstance} (no signer-backed simulator configured).`);
+            }
           } else {
             LOG.info(`LBP posthook likely missed; creating LBP for ${event.circlesBackingInstance}...`);
             const txHash = await cowSwapService.createLbp(event.circlesBackingInstance);

--- a/src/apps/crc-backers/main.ts
+++ b/src/apps/crc-backers/main.ts
@@ -220,6 +220,7 @@ async function main() {
   leaderElection = await LeaderElection.create(
     process.env.LEADER_DB_URL,
     process.env.INSTANCE_ID,
+    rootLogger.child("leader-election"),
     slackService,
     (isLeader) => setLeaderStatus("crc-backers", isLeader)
   );

--- a/src/apps/crc-backers/main.ts
+++ b/src/apps/crc-backers/main.ts
@@ -13,8 +13,10 @@ import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {LeaderElection, getEffectiveDryRun} from "../../services/leaderElection";
 import {StateStore} from "../../services/stateStore";
+import {resolveTransactionRpcUrl} from "../../services/transactionRpc";
 
 const rpcUrl = process.env.RPC_URL || "https://rpc.aboutcircles.com/";
+const txRpcUrl = resolveTransactionRpcUrl(rpcUrl);
 const blacklistingServiceUrl = process.env.BLACKLISTING_SERVICE_URL || "https://squid-app-3gxnl.ondigitalocean.app/aboutcircles-advanced-analytics2/bot-analytics/blacklist";
 const backersGroupAddress = process.env.BACKERS_GROUP_ADDRESS || "0x1ACA75e38263c79d9D4F10dF0635cc6FCfe6F026";
 const backingFactoryAddress = process.env.BACKING_FACTORY_ADDRESS || "0xeced91232c609a42f6016860e8223b8aecaa7bd0";
@@ -28,6 +30,7 @@ const confirmationBlocks = Number.parseInt(process.env.CONFIRMATION_BLOCKS || "2
 const safeAddress = process.env.CRC_BACKERS_SAFE_ADDRESS || "";
 const safeSignerPrivateKey = process.env.CRC_BACKERS_SAFE_SIGNER_PRIVATE_KEY || "";
 const dryRun = process.env.DRY_RUN === "1";
+const canSimulateTransactions = safeSignerPrivateKey.trim().length > 0 && safeAddress.trim().length > 0;
 const errorsBeforeCrash = 3;
 
 const rootLogger = new LoggerService(verboseLogging);
@@ -50,14 +53,17 @@ const circlesRpc = new CirclesRpcService(rpcUrl);
 const chainRpc = new ChainRpcService(rpcUrl);
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl);
 const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
-const groupService = dryRun ? undefined : new SafeGroupService(rpcUrl, safeSignerPrivateKey, safeAddress);
+const groupService = (!dryRun || canSimulateTransactions)
+  ? new SafeGroupService(rpcUrl, safeSignerPrivateKey, safeAddress, txRpcUrl)
+  : undefined;
 // In dry-run mode, skip passing signer keys so BackingInstanceService doesn't
 // eagerly initialise Safe Protocol Kit (which calls eth_chainId via viem).
 // simulate* methods only use the ethers provider; execute methods throw if needed.
 const cowSwapService = new BackingInstanceService(
   rpcUrl,
-  dryRun ? undefined : safeSignerPrivateKey,
-  dryRun ? undefined : safeAddress
+  !dryRun || canSimulateTransactions ? safeSignerPrivateKey : undefined,
+  !dryRun || canSimulateTransactions ? safeAddress : undefined,
+  txRpcUrl
 );
 // Track the next block to scan purely in memory between loop iterations.
 let nextFromBlock = deployedAtBlock;
@@ -100,6 +106,7 @@ async function sendStartupNotification(): Promise<void> {
   const startupMessage = `✅ *Backers Group TMS Service Started*\n\n` +
     `Service is now running and monitoring for new backers.\n` +
     `- RPC: ${rpcUrl}\n` +
+    `- TX RPC: ${txRpcUrl}\n` +
     `- Group: ${backersGroupAddress}\n` +
     `- Factory: ${backingFactoryAddress}\n` +
     `- Safe: ${safeAddress || "(not set)"}\n` +

--- a/src/apps/dublin-tms/logic.ts
+++ b/src/apps/dublin-tms/logic.ts
@@ -182,11 +182,19 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
       `Dry-run mode enabled; would trust ${humansQueuedForTrust.length} human avatar(s) in ` +
       `${batches.length} batch(es) for group ${targetGroupAddress}.`
     );
-    batches.forEach((batch, index) => {
+    for (const [index, batch] of batches.entries()) {
       logger.info(
         `DRY RUN trust batch ${index + 1}/${batches.length}: ${batch.length} avatar(s) -> ${batch.join(", ")}`
       );
-    });
+      if (groupService?.simulateTrustBatchWithConditions) {
+        const simulation = await groupService.simulateTrustBatchWithConditions(targetGroupAddress, batch);
+        logger.info(
+          `DRY RUN trust simulation ${index + 1}/${batches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`
+        );
+      } else {
+        logger.info(`DRY RUN trust simulation ${index + 1}/${batches.length}: skipped (no signer-backed simulator configured).`);
+      }
+    }
   } else {
     const batches = chunkArray(humansQueuedForTrust, groupBatchSize);
     logger.info(

--- a/src/apps/dublin-tms/main.ts
+++ b/src/apps/dublin-tms/main.ts
@@ -16,6 +16,7 @@ import {formatErrorWithCauses} from "../../formatError";
 import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
 import {getAddress, Wallet} from "ethers";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
+import {resolveTransactionRpcUrl} from "../../services/transactionRpc";
 
 const DEFAULT_RPC_URL = "https://rpc.aboutcircles.com/";
 const DEFAULT_INVITATION_MODULE = "0x00738aca013B7B2e6cfE1690F0021C3182Fa40B5";
@@ -36,6 +37,7 @@ const verboseLogging = !!process.env.VERBOSE_LOGGING;
 const rootLogger = new LoggerService(verboseLogging, "dublin-tms");
 
 const rpcUrl = process.env.RPC_URL || DEFAULT_RPC_URL;
+const txRpcUrl = resolveTransactionRpcUrl(rpcUrl);
 const invitationModuleAddress = DEFAULT_INVITATION_MODULE;
 const targetGroupAddress = normalizeAddressOrThrow(
   process.env.DUBLIN_TMS_ADDRESS || DEFAULT_TARGET_GROUP,
@@ -55,6 +57,7 @@ const configuredServiceEoa = normalizeAddressOrThrow(
 
 const dryRun = process.env.DRY_RUN === "1";
 const servicePrivateKey = process.env.DUBLIN_TMS_SERVICE_PRIVATE_KEY || "";
+const canSimulateTransactions = servicePrivateKey.trim().length > 0;
 const slackWebhookUrl = process.env.DUBLIN_TMS_SLACK_WEBHOOK_URL || process.env.SLACK_WEBHOOK_URL || "";
 const slackWebhookUrlInfo = process.env.DUBLIN_TMS_SLACK_WEBHOOK_URL_INFO || process.env.SLACK_WEBHOOK_URL_INFO || "";
 const slackInfoChannel = process.env.SLACK_INFO_CHANNEL || "";
@@ -74,14 +77,14 @@ const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slac
 const slackConfigured = slackWebhookUrl.trim().length > 0;
 
 let groupService: IGroupService | undefined;
-if (!dryRun) {
+if (!dryRun || canSimulateTransactions) {
   const signerAddress = normalizeAddressOrThrow(new Wallet(servicePrivateKey).address, "DUBLIN_TMS_SERVICE_PRIVATE_KEY");
   if (signerAddress.toLowerCase() !== configuredServiceEoa.toLowerCase()) {
     throw new Error(
       `Configured DUBLIN_TMS_SERVICE_EOA (${configuredServiceEoa}) does not match signer address (${signerAddress}).`
     );
   }
-  groupService = new GroupService(rpcUrl, servicePrivateKey);
+  groupService = new GroupService(rpcUrl, servicePrivateKey, txRpcUrl);
 }
 
 const runLogger = rootLogger.child("run");
@@ -100,6 +103,7 @@ let nextFromBlock = configuredStartBlock;
 
 rootLogger.info("Starting dublin-tms watcher with config:");
 rootLogger.info(`  - rpcUrl=${rpcUrl}`);
+rootLogger.info(`  - txRpcUrl=${txRpcUrl}`);
 rootLogger.info(`  - invitationModuleAddress=${invitationModuleAddress}`);
 rootLogger.info(`  - targetGroupAddress=${targetGroupAddress}`);
 rootLogger.info(`  - configuredStartBlock=${configuredStartBlock}`);
@@ -112,6 +116,7 @@ rootLogger.info(`  - originInviters=${originInviters.join(",")}`);
 rootLogger.info(`  - dryRun=${dryRun}`);
 rootLogger.info(`  - serviceEoa=${configuredServiceEoa}`);
 rootLogger.info(`  - servicePrivateKeyConfigured=${servicePrivateKey.trim().length > 0}`);
+rootLogger.info(`  - dryRunSimulationConfigured=${canSimulateTransactions}`);
 rootLogger.info(`  - slackConfigured=${slackConfigured}`);
 
 const errorsBeforeCrash = 3;
@@ -214,6 +219,8 @@ async function notifySlackStartup(): Promise<void> {
   const message =
     `${header}\n\n` +
     `Watching RegisterHuman and trusting matching avatars.\n` +
+    `- RPC: ${rpcUrl}\n` +
+    `- TX RPC: ${txRpcUrl}\n` +
     `- Target Group: ${targetGroupAddress}\n` +
     `- Service EOA: ${configuredServiceEoa}\n` +
     `- Origin Inviters: ${originInviters.join(", ")}\n` +

--- a/src/apps/gnosis-group/logic.ts
+++ b/src/apps/gnosis-group/logic.ts
@@ -21,6 +21,7 @@ export type RunConfig = {
   rpcUrl: string;
   scoringServiceUrl: string;
   targetGroupAddress: string;
+  historicAutoTrustSnapshotMembers?: string[];
   fetchPageSize?: number;
   scoreBatchSize?: number;
   scoreThreshold?: number;
@@ -91,6 +92,8 @@ export const DEFAULT_SCORE_THRESHOLD = 100;
 export const DEFAULT_GROUP_BATCH_SIZE = 10;
 export const DEFAULT_BACKERS_GROUP_ADDRESS = "0x1aca75e38263c79d9d4f10df0635cc6fcfe6f026";
 export const DEFAULT_GP_CRC_GROUP_ADDRESS = "0xb629a1e86F3eFada0F87C83494Da8Cc34C3F84ef";
+export const HISTORIC_AUTO_TRUST_GROUP_ADDRESS = "0x86533d1ada8ffbe7b6f7244f9a1b707f7f3e239b";
+export const HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER = 42_945_178;
 export const FIXED_AUTO_TRUST_GROUP_ADDRESSES = [
   DEFAULT_BACKERS_GROUP_ADDRESS,
   DEFAULT_GP_CRC_GROUP_ADDRESS
@@ -148,6 +151,13 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
     autoTrustGroupTrustees.set(groupAddress, trustees);
   }
 
+  const historicAutoTrustMembers = uniqueNormalizedAddresses(
+    cfg.historicAutoTrustSnapshotMembers ?? await circlesRpc.fetchActiveGroupMembersAtBlock(
+      HISTORIC_AUTO_TRUST_GROUP_ADDRESS,
+      HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER
+    )
+  );
+
   const targetGroupTrusteesRaw = await circlesRpc.fetchAllTrustees(targetGroupAddress);
   const targetGroupTrustees = uniqueNormalizedAddresses(targetGroupTrusteesRaw);
 
@@ -162,6 +172,9 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
     for (const address of trustees) {
       blacklistCandidates.add(address);
     }
+  }
+  for (const member of historicAutoTrustMembers) {
+    blacklistCandidates.add(member);
   }
   const addressesForBlacklistEvaluation = Array.from(blacklistCandidates);
 
@@ -218,6 +231,33 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
     autoTrustGroupTrustees.set(groupAddress, allowedTrustees);
   }
 
+  const allowedHistoricAutoTrustMembers = historicAutoTrustMembers.filter((address) =>
+    !blacklistedLowercase.has(address.toLowerCase())
+  );
+  const blacklistedHistoricAutoTrustMembers = historicAutoTrustMembers.filter((address) =>
+    blacklistedLowercase.has(address.toLowerCase())
+  );
+
+  if (blacklistedHistoricAutoTrustMembers.length > 0) {
+    loggerBlacklist.warn(
+      `Blacklist service flagged ${blacklistedHistoricAutoTrustMembers.length} address(es) from historical auto-trust snapshot ${HISTORIC_AUTO_TRUST_GROUP_ADDRESS}@${HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER}; they will be ignored.`
+    );
+    loggerBlacklist.debug(
+      `Blacklisted historical auto-trust addresses: ${blacklistedHistoricAutoTrustMembers.join(", ")}`
+    );
+  }
+
+  for (const member of allowedHistoricAutoTrustMembers) {
+    const lower = member.toLowerCase();
+    if (!autoTrustedNormalized.has(lower)) {
+      autoTrustedNormalized.set(lower, member);
+    }
+  }
+
+  loggerTrust.info(
+    `Historical auto-trust snapshot ${HISTORIC_AUTO_TRUST_GROUP_ADDRESS}@${HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER}: ${allowedHistoricAutoTrustMembers.length} eligible member(s) after blacklist (fetched ${historicAutoTrustMembers.length}).`
+  );
+
   const trustedTargets = autoTrustGroupTrustees.get(backersGroupAddress) ?? [];
 
   if (trustedTargets.length === 0) {
@@ -268,6 +308,7 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
 
     const scoreBatches = chunkArray(uncachedAvatars, scoreBatchSize);
     if (dryRun) {
+      /* istanbul ignore next: impossible once allowedAvatars > 0; kept for defensive logging */
       if (scoreBatches.length === 0 && uncachedAvatars.length === 0 && cachedAvatars.length === 0) {
         loggerScores.info("Dry-run mode enabled; no avatars to score.");
       } else {
@@ -380,6 +421,7 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
         loggerTrust.debug(`Dry-run untrust batch ${index + 1}/${trustPlan.untrustBatches.length}: ${batch.join(", ")}`);
       });
     } else {
+      /* istanbul ignore next: guarded at the top of runOnce */
       if (!groupService) {
         throw new Error("Group service dependency missing; cannot execute untrust batches.");
       }
@@ -424,12 +466,14 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
         loggerTrust.debug(`Dry-run trust batch ${index + 1}/${trustPlan.trustBatches.length}: ${batch.join(", ")}`);
       });
     } else {
+      /* istanbul ignore next: guarded at the top of runOnce */
       if (!groupService) {
         throw new Error("Group service dependency missing; cannot execute trust batches.");
       }
       for (const [batchIndex, batch] of trustPlan.trustBatches.entries()) {
         const filteredBatch = batch.filter((address) => {
           const lower = address.toLowerCase();
+          /* istanbul ignore next: the trust plan already de-duplicates existing trustees */
           if (targetGroupTrusteesLowercase.has(lower)) {
             loggerTrust.debug(
               `Skipping ${address} in batch ${batchIndex + 1}/${trustPlan.trustBatches.length}: already trusted.`
@@ -439,6 +483,7 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
           return true;
         });
 
+        /* istanbul ignore next: the trust plan does not emit empty or fully trusted batches */
         if (filteredBatch.length === 0) {
           loggerTrust.info(
             `Skipping trust batch ${batchIndex + 1}/${trustPlan.trustBatches.length}; all address(es) already trusted.`
@@ -608,6 +653,7 @@ export function computeTrustPlan(input: ComputeTrustPlanInput): TrustPlan {
       continue;
     }
     const normalized = guaranteedMap.get(guaranteedLower);
+    /* istanbul ignore next: guaranteedLowercase is derived from guaranteedMap.keys() */
     if (!normalized) {
       continue;
     }
@@ -739,6 +785,7 @@ async function fetchRelativeTrustScoresWithRetry(
     }
   }
 
+  /* istanbul ignore next */
   throw new Error("Failed to fetch relative trust scores after retries.");
 }
 
@@ -871,6 +918,7 @@ async function fetchBlacklistVerdictsWithRetry(
     }
   }
 
+  /* istanbul ignore next */
   throw new Error("Failed to fetch blacklist verdicts after retries.");
 }
 
@@ -975,6 +1023,13 @@ function formatErrorMessage(error: unknown): string {
 }
 
 export const __testables = {
+  fetchRelativeTrustScores,
+  formatErrorMessage,
+  getScoreForAddress,
+  isBlacklisted,
+  normalizeAddress,
+  resolveScoreThreshold,
+  uniqueNormalizedAddresses,
   timedFetch,
   isRetryableFetchError
 };

--- a/src/apps/gnosis-group/logic.ts
+++ b/src/apps/gnosis-group/logic.ts
@@ -417,9 +417,19 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
   if (trustPlan.untrustBatches.length > 0) {
     if (dryRun) {
       loggerTrust.info("Dry-run mode enabled; skipping untrust transactions for prepared batches.");
-      trustPlan.untrustBatches.forEach((batch, index) => {
+      for (const [index, batch] of trustPlan.untrustBatches.entries()) {
         loggerTrust.debug(`Dry-run untrust batch ${index + 1}/${trustPlan.untrustBatches.length}: ${batch.join(", ")}`);
-      });
+        if (groupService?.simulateUntrustBatch) {
+          const simulation = await groupService.simulateUntrustBatch(targetGroupAddress, batch);
+          loggerTrust.info(
+            `Dry-run untrust simulation ${index + 1}/${trustPlan.untrustBatches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`
+          );
+        } else {
+          loggerTrust.info(
+            `Dry-run untrust simulation ${index + 1}/${trustPlan.untrustBatches.length}: skipped (no signer-backed simulator configured).`
+          );
+        }
+      }
     } else {
       /* istanbul ignore next: guarded at the top of runOnce */
       if (!groupService) {
@@ -462,9 +472,19 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
   if (trustPlan.trustBatches.length > 0) {
     if (dryRun) {
       loggerTrust.info("Dry-run mode enabled; skipping trust transactions for prepared batches.");
-      trustPlan.trustBatches.forEach((batch, index) => {
+      for (const [index, batch] of trustPlan.trustBatches.entries()) {
         loggerTrust.debug(`Dry-run trust batch ${index + 1}/${trustPlan.trustBatches.length}: ${batch.join(", ")}`);
-      });
+        if (groupService?.simulateTrustBatchWithConditions) {
+          const simulation = await groupService.simulateTrustBatchWithConditions(targetGroupAddress, batch);
+          loggerTrust.info(
+            `Dry-run trust simulation ${index + 1}/${trustPlan.trustBatches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`
+          );
+        } else {
+          loggerTrust.info(
+            `Dry-run trust simulation ${index + 1}/${trustPlan.trustBatches.length}: skipped (no signer-backed simulator configured).`
+          );
+        }
+      }
     } else {
       /* istanbul ignore next: guarded at the top of runOnce */
       if (!groupService) {

--- a/src/apps/gnosis-group/main.ts
+++ b/src/apps/gnosis-group/main.ts
@@ -14,6 +14,8 @@ import {
   DEFAULT_SCORE_THRESHOLD,
   DEFAULT_GROUP_BATCH_SIZE,
   FIXED_AUTO_TRUST_GROUP_ADDRESSES,
+  HISTORIC_AUTO_TRUST_GROUP_ADDRESS,
+  HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER,
   DEFAULT_SCORE_CACHE_TTL_MS,
   RunOutcome
 } from "./logic";
@@ -95,6 +97,8 @@ rootLogger.info(`  - scoreBatchSize=${scoreBatchSize}`);
 rootLogger.info(`  - scoreThreshold=${scoreThreshold}`);
 rootLogger.info(`  - groupBatchSize=${groupBatchSize}`);
 rootLogger.info(`  - fixedAutoTrustGroupAddresses=${FIXED_AUTO_TRUST_GROUP_ADDRESSES.join(",")}`);
+rootLogger.info(`  - historicAutoTrustGroupAddress=${HISTORIC_AUTO_TRUST_GROUP_ADDRESS}`);
+rootLogger.info(`  - historicAutoTrustGroupBlockNumber=${HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER}`);
 rootLogger.info(`  - safeAddress=${safeAddress || "(not set)"}`);
 rootLogger.info(`  - safeSignerPrivateKeyConfigured=${safeSignerPrivateKey.trim().length > 0}`);
 rootLogger.info(`  - dryRun=${dryRun}`);
@@ -135,12 +139,14 @@ async function mainLoop(): Promise<void> {
   leaderElection = await LeaderElection.create(
     process.env.LEADER_DB_URL,
     process.env.INSTANCE_ID,
+    rootLogger.child("leader-election"),
     slackService,
     (isLeader) => setLeaderStatus("gnosis-group", isLeader)
   );
   const maxDelay = Math.min(runIntervalMs * 4, 15 * 60 * 1000); // cap at 15 min
   let currentDelay = runIntervalMs;
   const stateStore = process.env.LEADER_DB_URL ? new StateStore(process.env.LEADER_DB_URL) : null;
+  let historicAutoTrustSnapshotMembers: string[] | null = null;
 
   while (true) {
     const runStartedAt = Date.now();
@@ -152,6 +158,9 @@ async function mainLoop(): Promise<void> {
         logger: rootLogger
       });
       if (!isHealthy) { await delay(currentDelay); continue; }
+      if (historicAutoTrustSnapshotMembers === null) {
+        historicAutoTrustSnapshotMembers = await loadHistoricAutoTrustSnapshotMembers();
+      }
       await refreshBlacklist();
       const outcome = await runOnce(
         {
@@ -161,7 +170,11 @@ async function mainLoop(): Promise<void> {
           logger: runLogger,
           scoreCache
         },
-        { ...config, dryRun: effectiveDryRun }
+        {
+          ...config,
+          dryRun: effectiveDryRun,
+          historicAutoTrustSnapshotMembers
+        }
       );
 
       await stateStore?.save("gnosis-group", 0, { lastSuccessfulRunAt: new Date().toISOString() });
@@ -196,6 +209,20 @@ async function mainLoop(): Promise<void> {
       rootLogger.info("Run interval elapsed; starting next run immediately.");
     }
   }
+}
+
+async function loadHistoricAutoTrustSnapshotMembers(): Promise<string[]> {
+  runLogger.info(
+    `Loading historical auto-trust snapshot ${HISTORIC_AUTO_TRUST_GROUP_ADDRESS}@${HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER}.`
+  );
+  const members = await circlesRpc.fetchActiveGroupMembersAtBlock(
+    HISTORIC_AUTO_TRUST_GROUP_ADDRESS,
+    HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER
+  );
+  runLogger.info(
+    `Loaded ${members.length} historical auto-trust snapshot member(s) from ${HISTORIC_AUTO_TRUST_GROUP_ADDRESS}@${HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER}.`
+  );
+  return members;
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/apps/gnosis-group/main.ts
+++ b/src/apps/gnosis-group/main.ts
@@ -25,11 +25,13 @@ import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {LeaderElection, getEffectiveDryRun} from "../../services/leaderElection";
 import {StateStore} from "../../services/stateStore";
+import {resolveTransactionRpcUrl} from "../../services/transactionRpc";
 
 const verboseLogging = !!process.env.VERBOSE_LOGGING;
 const rootLogger = new LoggerService(verboseLogging, "gnosis-group");
 
 const rpcUrl = process.env.RPC_URL || "https://rpc.aboutcircles.com/";
+const txRpcUrl = resolveTransactionRpcUrl(rpcUrl);
 const blacklistingServiceUrl = process.env.BLACKLISTING_SERVICE_URL || "https://squid-app-3gxnl.ondigitalocean.app/aboutcircles-advanced-analytics2/bot-analytics/blacklist";
 const scoringServiceUrl = process.env.GNOSIS_GROUP_SCORING_URL || "https://squid-app-3gxnl.ondigitalocean.app/aboutcircles-advanced-analytics2/scoring/relative_trustscore/batch";
 const targetGroupAddress = process.env.GNOSIS_GROUP_ADDRESS || "0xC19BC204eb1c1D5B3FE500E5E5dfaBaB625F286c";
@@ -60,6 +62,7 @@ const scoreCache = new ScoreCache();
 const errorsBeforeCrash = 3;
 const errorTracker = new ConsecutiveErrorTracker(errorsBeforeCrash);
 let leaderElection: LeaderElection | null = null;
+const canSimulateTransactions = safeSignerPrivateKey.trim().length > 0 && safeAddress.trim().length > 0;
 
 const runLogger = rootLogger.child("run");
 let groupService: IGroupService | undefined;
@@ -72,8 +75,8 @@ if (!dryRun && safeAddress.trim().length === 0) {
   throw new Error("GNOSIS_GROUP_SAFE_ADDRESS is required when not running gnosis-group in dry-run mode");
 }
 
-if (!dryRun) {
-  groupService = new SafeGroupService(rpcUrl, safeSignerPrivateKey, safeAddress);
+if (!dryRun || canSimulateTransactions) {
+  groupService = new SafeGroupService(rpcUrl, safeSignerPrivateKey, safeAddress, txRpcUrl);
 }
 
 const config: RunConfig = {
@@ -90,6 +93,7 @@ const config: RunConfig = {
 
 rootLogger.info("Starting gnosis-group run with config:");
 rootLogger.info(`  - rpcUrl=${rpcUrl}`);
+rootLogger.info(`  - txRpcUrl=${txRpcUrl}`);
 rootLogger.info(`  - scoringServiceUrl=${scoringServiceUrl}`);
 rootLogger.info(`  - targetGroupAddress=${targetGroupAddress}`);
 rootLogger.info(`  - fetchPageSize=${fetchPageSize}`);
@@ -101,6 +105,7 @@ rootLogger.info(`  - historicAutoTrustGroupAddress=${HISTORIC_AUTO_TRUST_GROUP_A
 rootLogger.info(`  - historicAutoTrustGroupBlockNumber=${HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER}`);
 rootLogger.info(`  - safeAddress=${safeAddress || "(not set)"}`);
 rootLogger.info(`  - safeSignerPrivateKeyConfigured=${safeSignerPrivateKey.trim().length > 0}`);
+rootLogger.info(`  - dryRunSimulationConfigured=${canSimulateTransactions}`);
 rootLogger.info(`  - dryRun=${dryRun}`);
 rootLogger.info(`  - runIntervalMinutes=${runIntervalMinutes}`);
 rootLogger.info(`  - scoreCacheTtlMinutes=${scoreCacheTtlMs / 60_000}`);
@@ -292,6 +297,7 @@ async function notifySlackStartup(): Promise<void> {
   const message =
     `${header}\n\n` +
     `- RPC: ${rpcUrl}\n` +
+    `- TX RPC: ${txRpcUrl}\n` +
     `- Scoring Service: ${scoringServiceUrl}\n` +
     `- Gnosis Group: ${targetGroupAddress}\n` +
     `- Score Threshold: ${scoreThreshold}\n` +

--- a/src/apps/gp-crc/logic.ts
+++ b/src/apps/gp-crc/logic.ts
@@ -272,16 +272,6 @@ export async function runOnce(
     .map((lower) => currentTrusteesMap.get(lower))
     .filter((address): address is string => !!address);
 
-  const untrustLowerSet = new Set(avatarsToUntrust.map((a) => a.toLowerCase()));
-  for (const avatar of safeReassignmentUntrustedAvatars) {
-    const lower = avatar.toLowerCase();
-    if (currentTrustedLowerSet.has(lower) && !untrustLowerSet.has(lower)) {
-      const normalizedAddress = currentTrusteesMap.get(lower) || avatar;
-      avatarsToUntrust.push(normalizedAddress);
-      untrustLowerSet.add(lower);
-    }
-  }
-
   const alreadyTrustedFromEvents = allowedAvatars
     .filter((avatar) => eligibleLowerSet.has(avatar.toLowerCase()))
     .filter((avatar) => currentTrustedLowerSet.has(avatar.toLowerCase()));
@@ -482,6 +472,7 @@ async function trustBatchWithRetry(
     }
   }
 
+  /* istanbul ignore next */
   throw new Error("Failed to trust batch after retries");
 }
 
@@ -508,6 +499,7 @@ async function untrustBatchWithRetry(
     }
   }
 
+  /* istanbul ignore next */
   throw new Error("Failed to untrust batch after retries");
 }
 
@@ -530,6 +522,7 @@ async function fetchBlacklistVerdictsWithRetry(
     }
   }
 
+  /* istanbul ignore next */
   throw new Error("Failed to fetch blacklist verdicts after retries");
 }
 
@@ -637,3 +630,15 @@ function toComparableBigInt(value: string): bigint | null {
 
   return null;
 }
+
+export const __testables = {
+  compareTimestamp,
+  formatErrorMessage,
+  isBlacklisted,
+  isRetryableFetchError,
+  isRetryableTrustError,
+  normalizeAddress,
+  normalizeSwitchCount,
+  toComparableBigInt,
+  uniqueNormalizedAddresses
+};

--- a/src/apps/gp-crc/logic.ts
+++ b/src/apps/gp-crc/logic.ts
@@ -288,9 +288,17 @@ export async function runOnce(
       logger.info(
         `Dry-run mode enabled; would untrust ${avatarsToUntrust.length} avatar(s) in group ${groupAddress} across ${batches.length} batch(es).`
       );
-      batches.forEach((batch, index) => {
+      for (const [index, batch] of batches.entries()) {
         logger.info(`DRY RUN untrust batch ${index + 1}/${batches.length}: ${batch.length} avatar(s).`);
-      });
+        if (groupService?.simulateUntrustBatch) {
+          const simulation = await groupService.simulateUntrustBatch(groupAddress, batch);
+          logger.info(
+            `DRY RUN untrust simulation ${index + 1}/${batches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`
+          );
+        } else {
+          logger.info(`DRY RUN untrust simulation ${index + 1}/${batches.length}: skipped (no signer-backed simulator configured).`);
+        }
+      }
       untrustedAvatars.push(...avatarsToUntrust);
     } else {
       logger.info(`Untrusting ${avatarsToUntrust.length} avatar(s) in group ${groupAddress} across ${batches.length} batch(es).`);
@@ -320,9 +328,17 @@ export async function runOnce(
       logger.info(
         `Dry-run mode enabled; would trust ${avatarsToTrust.length} avatar(s) in group ${groupAddress} across ${batches.length} batch(es).`
       );
-      batches.forEach((batch, index) => {
+      for (const [index, batch] of batches.entries()) {
         logger.info(`DRY RUN trust batch ${index + 1}/${batches.length}: ${batch.length} avatar(s).`);
-      });
+        if (groupService?.simulateTrustBatchWithConditions) {
+          const simulation = await groupService.simulateTrustBatchWithConditions(groupAddress, batch);
+          logger.info(
+            `DRY RUN trust simulation ${index + 1}/${batches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`
+          );
+        } else {
+          logger.info(`DRY RUN trust simulation ${index + 1}/${batches.length}: skipped (no signer-backed simulator configured).`);
+        }
+      }
       trustedAvatars.push(...avatarsToTrust);
     } else {
       logger.info(`Trusting ${avatarsToTrust.length} avatar(s) in group ${groupAddress} across ${batches.length} batch(es).`);

--- a/src/apps/gp-crc/main.ts
+++ b/src/apps/gp-crc/main.ts
@@ -135,6 +135,7 @@ async function mainLoop(): Promise<void> {
   leaderElection = await LeaderElection.create(
     process.env.LEADER_DB_URL,
     process.env.INSTANCE_ID,
+    rootLogger.child("leader-election"),
     slackService,
     (isLeader) => setLeaderStatus("gp-crc", isLeader)
   );

--- a/src/apps/gp-crc/main.ts
+++ b/src/apps/gp-crc/main.ts
@@ -19,11 +19,13 @@ import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {LeaderElection, getEffectiveDryRun} from "../../services/leaderElection";
 import {StateStore} from "../../services/stateStore";
+import {resolveTransactionRpcUrl} from "../../services/transactionRpc";
 
 const verboseLogging = !!process.env.VERBOSE_LOGGING;
 const rootLogger = new LoggerService(verboseLogging, "gp-crc");
 
 const rpcUrl = process.env.RPC_URL || "https://rpc.aboutcircles.com/";
+const txRpcUrl = resolveTransactionRpcUrl(rpcUrl);
 const blacklistingServiceUrl = process.env.BLACKLISTING_SERVICE_URL || "https://squid-app-3gxnl.ondigitalocean.app/aboutcircles-advanced-analytics2/bot-analytics/blacklist";
 const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL || "";
 const slackWebhookUrlInfo = process.env.SLACK_WEBHOOK_URL_INFO || "";
@@ -48,6 +50,7 @@ const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slac
 const slackConfigured = slackWebhookUrl.trim().length > 0;
 let groupService: IGroupService | undefined;
 let avatarSafeService: MetriSafeService;
+const canSimulateTransactions = safeSignerPrivateKey.trim().length > 0 && safeAddress.trim().length > 0;
 
 if (!groupAddress) {
   throw new Error("GP_CRC_GROUP_ADDRESS is required");
@@ -69,8 +72,8 @@ if (!dryRun && safeAddress.trim().length === 0) {
   throw new Error("GP_CRC_SAFE_ADDRESS is required when not running gp-crc in dry-run mode");
 }
 
-if (!dryRun) {
-  groupService = new SafeGroupService(rpcUrl, safeSignerPrivateKey, safeAddress);
+if (!dryRun || canSimulateTransactions) {
+  groupService = new SafeGroupService(rpcUrl, safeSignerPrivateKey, safeAddress, txRpcUrl);
 }
 
 const runLogger = rootLogger.child("run");
@@ -85,6 +88,7 @@ const config: RunConfig = {
 
 rootLogger.info("Starting gp-crc watcher with config:");
 rootLogger.info(`  - rpcUrl=${rpcUrl}`);
+rootLogger.info(`  - txRpcUrl=${txRpcUrl}`);
 rootLogger.info(`  - fetchPageSize=${fetchPageSize}`);
 rootLogger.info(`  - pollIntervalMs=${pollIntervalMs}`);
 rootLogger.info(`  - groupAddress=${groupAddress}`);
@@ -92,6 +96,7 @@ rootLogger.info(`  - groupBatchSize=${groupBatchSize}`);
 rootLogger.info(`  - metriSafeGraphqlUrl=${metriSafeGraphqlUrl}`);
 rootLogger.info(`  - safeAddress=${safeAddress || "(not set)"}`);
 rootLogger.info(`  - safeSignerConfigured=${safeSignerPrivateKey.trim().length > 0}`);
+rootLogger.info(`  - dryRunSimulationConfigured=${canSimulateTransactions}`);
 rootLogger.info(`  - dryRun=${dryRun}`);
 
 void notifySlackStartup();
@@ -240,6 +245,7 @@ async function notifySlackStartup(): Promise<void> {
     const startupMessage = `✅ *GP-CRC TMS Service started*\n\n` +
     `Monitoring CRC avatars who also have a GP account in Metri.\n` +
     `- RPC: ${rpcUrl}\n` +
+    `- TX RPC: ${txRpcUrl}\n` +
     `- Blacklisting Service: ${blacklistingServiceUrl}\n` +
     `- Fetch Page Size: ${fetchPageSize}\n` +
     `- Metri Safe GraphQL: ${metriSafeGraphqlUrl}\n` +

--- a/src/apps/oic/logic.ts
+++ b/src/apps/oic/logic.ts
@@ -131,6 +131,46 @@ async function processTrustOperations(
   }
 }
 
+async function simulateTrustOperations(
+  groupService: IGroupService,
+  group: string,
+  shouldTrust: string[],
+  shouldUntrust: string[],
+  outputBatchSize: number,
+  logger: ILoggerService
+): Promise<void> {
+  const trustBatches = chunk(shouldTrust, outputBatchSize);
+  const untrustBatches = chunk(shouldUntrust, outputBatchSize);
+
+  for (let i = 0; i < untrustBatches.length; i++) {
+    const batch = untrustBatches[i];
+    if (groupService.simulateUntrustBatch) {
+      const simulation = await groupService.simulateUntrustBatch(group, batch);
+      logger.info(
+        `DRY RUN untrust simulation batch ${i + 1}/${untrustBatches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`
+      );
+    } else {
+      logger.info(
+        `DRY RUN untrust simulation batch ${i + 1}/${untrustBatches.length}: skipped (no signer-backed simulator configured).`
+      );
+    }
+  }
+
+  for (let i = 0; i < trustBatches.length; i++) {
+    const batch = trustBatches[i];
+    if (groupService.simulateTrustBatchWithConditions) {
+      const simulation = await groupService.simulateTrustBatchWithConditions(group, batch);
+      logger.info(
+        `DRY RUN trust simulation batch ${i + 1}/${trustBatches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`
+      );
+    } else {
+      logger.info(
+        `DRY RUN trust simulation batch ${i + 1}/${trustBatches.length}: skipped (no signer-backed simulator configured).`
+      );
+    }
+  }
+}
+
 // Core logic shared between runOnce and runIncremental
 async function executeCoreLogic(
   deps: Deps,
@@ -194,6 +234,14 @@ async function executeCoreLogic(
         LOG.info(`DRY RUN untrust: ${fmt(d)}`);
       }
     }
+    await simulateTrustOperations(
+      groupService,
+      group,
+      shouldTrust,
+      shouldUntrust,
+      cfg.outputBatchSize,
+      LOG
+    );
     return;
   }
 

--- a/src/apps/oic/main.ts
+++ b/src/apps/oic/main.ts
@@ -146,6 +146,7 @@ async function loop() {
   leaderElection = await LeaderElection.create(
     process.env.LEADER_DB_URL,
     process.env.INSTANCE_ID,
+    rootLogger.child("leader-election"),
     slackService,
     (isLeader) => setLeaderStatus("oic", isLeader)
   );

--- a/src/apps/oic/main.ts
+++ b/src/apps/oic/main.ts
@@ -13,13 +13,16 @@ import {formatErrorWithCauses} from "../../formatError";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {LeaderElection, getEffectiveDryRun} from "../../services/leaderElection";
 import {StateStore} from "../../services/stateStore";
+import {resolveTransactionRpcUrl} from "../../services/transactionRpc";
 import {Wallet} from "ethers";
 
 const rpcUrl = process.env.RPC_URL || "https://rpc.aboutcircles.com/";
+const txRpcUrl = resolveTransactionRpcUrl(rpcUrl);
 const oicGroupAddress = (process.env.OIC_GROUP_ADDRESS || "0x4E2564e5df6C1Fb10C1A018538de36E4D5844DE5").toLowerCase();
 const metaOrgAddress = (process.env.OIC_META_ORG_ADDRESS || "").toLowerCase();
 const affiliateRegistryAddress = (process.env.AFFILIATE_REGISTRY_ADDRESS || "0xca8222e780d046707083f51377b5fd85e2866014").toLowerCase();
 const servicePrivateKey = process.env.OIC_SERVICE_PRIVATE_KEY || process.env.OIC_SAFE_SIGNER_PRIVATE_KEY || "";
+const canSimulateTransactions = servicePrivateKey.trim().length > 0;
 const configuredServiceEoa = (process.env.OIC_SERVICE_EOA || "").toLowerCase();
 const deployedAtBlock = 41_734_312;
 const confirmationBlocks = Number.parseInt(process.env.CONFIRMATION_BLOCKS || "10");
@@ -46,9 +49,12 @@ let leaderElection: LeaderElection | null = null;
 validateConfig();
 
 if (dryRun) {
-  groupService = createDryRunGroupService();
+  const simulationService = canSimulateTransactions
+    ? new GroupService(rpcUrl, servicePrivateKey, txRpcUrl)
+    : undefined;
+  groupService = createDryRunGroupService(simulationService);
 } else {
-  groupService = new GroupService(rpcUrl, servicePrivateKey);
+  groupService = new GroupService(rpcUrl, servicePrivateKey, txRpcUrl);
 }
 
 function validateConfig() {
@@ -65,14 +71,16 @@ function validateConfig() {
   }
 }
 
-function createDryRunGroupService(): IGroupService {
+function createDryRunGroupService(simulationService?: IGroupService): IGroupService {
   const notAvailable = async () => {
     throw new Error("Group service is not available in dry-run mode");
   };
   return {
     trustBatchWithConditions: notAvailable,
     untrustBatch: notAvailable,
-    fetchGroupOwnerAndService: notAvailable
+    fetchGroupOwnerAndService: notAvailable,
+    simulateTrustBatchWithConditions: simulationService?.simulateTrustBatchWithConditions?.bind(simulationService),
+    simulateUntrustBatch: simulationService?.simulateUntrustBatch?.bind(simulationService)
   };
 }
 
@@ -116,6 +124,7 @@ process.on('unhandledRejection', async (reason: any) => {
     const startupMessage = `✅ *OIC Service Started*\n\n` +
       `Service is now running and monitoring + reconciling trust.\n` +
       `- RPC: ${rpcUrl}\n` +
+      `- TX RPC: ${txRpcUrl}\n` +
       `- Group: ${oicGroupAddress}\n` +
       `- MetaOrg: ${metaOrgAddress}\n` +
       `- AffiliateRegistry: ${affiliateRegistryAddress}\n` +
@@ -184,6 +193,7 @@ async function loop() {
       if (!printedStartupLogs) {
         LOG.info("OIC app starting (monitor + reconcile trust)...");
         LOG.debug(`RPC: ${rpcUrl}`);
+        LOG.debug(`TX RPC: ${txRpcUrl}`);
         LOG.debug(`Group: ${oicGroupAddress}`);
         LOG.debug(`MetaOrg: ${metaOrgAddress}`);
         LOG.debug(`AffiliateRegistry: ${affiliateRegistryAddress}`);

--- a/src/apps/router-tms/logic.ts
+++ b/src/apps/router-tms/logic.ts
@@ -457,3 +457,15 @@ function buildBaseGroupEnableTargets(
 
   return {targets, scheduledAvatars};
 }
+
+export const __testables = {
+  buildAvatarBaseGroupAssignments,
+  buildBaseGroupEnableTargets,
+  chunkArray,
+  createIsHumanChecker,
+  filterHumanAvatars,
+  isBlacklisted,
+  normalizeAddress,
+  normalizeAddressArray,
+  validateEnableTargets
+};

--- a/src/apps/router-tms/logic.ts
+++ b/src/apps/router-tms/logic.ts
@@ -35,10 +35,22 @@ export type RunOutcome = {
 };
 
 type EnableTarget = {baseGroup: string; addresses: string[]; source?: "base-group" | "fallback"};
+type HumanityChecker = {
+  isHuman: (address: string) => Promise<boolean>;
+  isHumanBatch: (addresses: string[]) => Promise<Map<string, boolean>>;
+};
+type BulkTrusteesStats = {
+  pagesFetched: number;
+  rowsScanned: number;
+};
+type BulkTrusteesStatsProvider = {
+  getLastBulkTrusteesForTrustersStats: () => BulkTrusteesStats;
+};
 
 export const DEFAULT_ENABLE_BATCH_SIZE = 10;
 export const DEFAULT_FETCH_PAGE_SIZE = 1_000;
 export const DEFAULT_BASE_GROUP_ADDRESS = "0x1ACA75e38263c79d9D4F10dF0635cc6FCfe6F026";
+const BASE_GROUP_TRUST_QUERY_BATCH_SIZE = 100;
 const HUMANITY_CHECK_BATCH_SIZE = 50;
 
 export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
@@ -61,7 +73,8 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
 
   const enableBatchSize = Math.max(1, cfg.enableBatchSize ?? DEFAULT_ENABLE_BATCH_SIZE);
   const fetchPageSize = Math.max(1, cfg.fetchPageSize ?? DEFAULT_FETCH_PAGE_SIZE);
-  const isHuman = createIsHumanChecker(circlesRpc);
+  const humanityChecker = createHumanityChecker(circlesRpc);
+  const {isHuman, isHumanBatch} = humanityChecker;
 
   await assertBaseGroupIsGroupAvatar(baseGroupAddress, isHuman, logger);
 
@@ -138,6 +151,7 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
   const {validTargets, nonHumanAvatars} = await validateEnableTargets(
     enableTargets,
     isHuman,
+    isHumanBatch,
     baseGroupAddress,
     logger
   );
@@ -299,9 +313,20 @@ function normalizeAddressArray(addresses: string[]): string[] {
   return Array.from(unique);
 }
 
-function createIsHumanChecker(circlesRpc: ICirclesRpc): (address: string) => Promise<boolean> {
+function getBulkTrusteesStats(circlesRpc: ICirclesRpc): BulkTrusteesStats | undefined {
+  if (
+    "getLastBulkTrusteesForTrustersStats" in circlesRpc &&
+    typeof circlesRpc.getLastBulkTrusteesForTrustersStats === "function"
+  ) {
+    return (circlesRpc as ICirclesRpc & BulkTrusteesStatsProvider).getLastBulkTrusteesForTrustersStats();
+  }
+  return undefined;
+}
+
+function createHumanityChecker(circlesRpc: ICirclesRpc): HumanityChecker {
   const cache = new Map<string, Promise<boolean>>();
-  return async (address: string): Promise<boolean> => {
+
+  const isHuman = async (address: string): Promise<boolean> => {
     const normalized = normalizeAddress(address);
     if (!normalized) {
       throw new Error(`Invalid address passed to isHuman check: '${address ?? ""}'`);
@@ -320,11 +345,52 @@ function createIsHumanChecker(circlesRpc: ICirclesRpc): (address: string) => Pro
     cache.set(normalized, lookup);
     return lookup;
   };
+
+  const isHumanBatch = async (addresses: string[]): Promise<Map<string, boolean>> => {
+    const normalizedAddresses = addresses.map((address) => {
+      const normalized = normalizeAddress(address);
+      if (!normalized) {
+        throw new Error(`Invalid address passed to isHuman check: '${address ?? ""}'`);
+      }
+      return normalized;
+    });
+
+    const missingAddresses = Array.from(
+      new Set(normalizedAddresses.filter((address) => !cache.has(address)))
+    );
+
+    if (missingAddresses.length > 0) {
+      const lookup = circlesRpc.isHumanBatch(missingAddresses);
+      for (const address of missingAddresses) {
+        const verdict = lookup.then((results) => results.get(address) === true).catch((error) => {
+          cache.delete(address);
+          throw error;
+        });
+        cache.set(address, verdict);
+      }
+    }
+
+    const result = new Map<string, boolean>();
+    for (const address of normalizedAddresses) {
+      result.set(address, await isHuman(address));
+    }
+    return result;
+  };
+
+  return {isHuman, isHumanBatch};
+}
+
+function createIsHumanChecker(circlesRpc: ICirclesRpc): (address: string) => Promise<boolean> {
+  return createHumanityChecker(circlesRpc).isHuman;
+}
+
+function createIsHumanBatchChecker(circlesRpc: ICirclesRpc): (addresses: string[]) => Promise<Map<string, boolean>> {
+  return createHumanityChecker(circlesRpc).isHumanBatch;
 }
 
 async function filterHumanAvatars(
   addresses: string[],
-  isHuman: (address: string) => Promise<boolean>,
+  isHumanBatch: (addresses: string[]) => Promise<Map<string, boolean>>,
   batchSize: number
 ): Promise<{humans: string[]; nonHumans: string[]}> {
   const humans: string[] = [];
@@ -332,11 +398,10 @@ async function filterHumanAvatars(
 
   for (let i = 0; i < addresses.length; i += batchSize) {
     const batch = addresses.slice(i, i + batchSize);
-    const verdicts = await Promise.all(batch.map((address) => isHuman(address)));
+    const verdicts = await isHumanBatch(batch);
 
-    for (let j = 0; j < batch.length; j += 1) {
-      const address = batch[j];
-      if (verdicts[j]) {
+    for (const address of batch) {
+      if (verdicts.get(address.toLowerCase()) === true) {
         humans.push(address);
       } else {
         nonHumans.push(address);
@@ -350,6 +415,7 @@ async function filterHumanAvatars(
 async function validateEnableTargets(
   enableTargets: EnableTarget[],
   isHuman: (address: string) => Promise<boolean>,
+  isHumanBatch: (addresses: string[]) => Promise<Map<string, boolean>>,
   defaultBaseGroup: string,
   logger: ILoggerService
 ): Promise<{validTargets: EnableTarget[]; nonHumanAvatars: Set<string>}> {
@@ -369,7 +435,7 @@ async function validateEnableTargets(
       continue;
     }
 
-    const {humans, nonHumans} = await filterHumanAvatars(target.addresses, isHuman, HUMANITY_CHECK_BATCH_SIZE);
+    const {humans, nonHumans} = await filterHumanAvatars(target.addresses, isHumanBatch, HUMANITY_CHECK_BATCH_SIZE);
     nonHumans.forEach((avatar) => nonHumanAvatars.add(avatar));
 
     if (nonHumans.length > 0) {
@@ -409,9 +475,39 @@ async function buildAvatarBaseGroupAssignments(
   const normalizedBaseGroups = normalizeAddressArray(baseGroups);
   logger.info(`Fetched ${normalizedBaseGroups.length} base group(s).`);
 
+  const baseGroupBatches = chunkArray(normalizedBaseGroups, BASE_GROUP_TRUST_QUERY_BATCH_SIZE);
+  logger.info(
+    `Fetching trustees for ${normalizedBaseGroups.length} base group(s) across ${baseGroupBatches.length} trust-query batch(es).`
+  );
+
+  const trusteesByBaseGroup = new Map<string, string[]>();
+  let totalPagesFetched = 0;
+  let totalRowsScanned = 0;
+
+  for (const batch of baseGroupBatches) {
+    const trusteesByTruster = await circlesRpc.fetchAllTrusteesForTrusters(batch);
+    const stats = getBulkTrusteesStats(circlesRpc);
+    totalPagesFetched += stats?.pagesFetched ?? 0;
+
+    if (stats) {
+      totalRowsScanned += stats.rowsScanned;
+    } else {
+      totalRowsScanned += Array.from(trusteesByTruster.values()).reduce((sum, trustees) => sum + trustees.length, 0);
+    }
+
+    for (const baseGroup of batch) {
+      trusteesByBaseGroup.set(baseGroup, trusteesByTruster.get(baseGroup) ?? []);
+    }
+  }
+
+  logger.info(
+    `Fetched trustee rows for base groups across ${baseGroupBatches.length} trust-query batch(es), ` +
+      `${totalPagesFetched} page(s), and ${totalRowsScanned} trustee row(s).`
+  );
+
   const assignment = new Map<string, string>();
   for (const baseGroup of normalizedBaseGroups) {
-    const trustees = await circlesRpc.fetchAllTrustees(baseGroup);
+    const trustees = trusteesByBaseGroup.get(baseGroup) ?? [];
     const normalizedTrustees = normalizeAddressArray(trustees);
     logger.info(`Base group ${baseGroup} has ${normalizedTrustees.length} trustee(s).`);
     for (const trustee of normalizedTrustees) {
@@ -462,7 +558,9 @@ export const __testables = {
   buildAvatarBaseGroupAssignments,
   buildBaseGroupEnableTargets,
   chunkArray,
+  createHumanityChecker,
   createIsHumanChecker,
+  createIsHumanBatchChecker,
   filterHumanAvatars,
   isBlacklisted,
   normalizeAddress,

--- a/src/apps/router-tms/logic.ts
+++ b/src/apps/router-tms/logic.ts
@@ -105,26 +105,6 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
   const allowedHumanSet = new Set(allowedHumanAvatars);
   const blacklistedSet = new Set(blacklistedHumanAvatars);
   const avatarBaseGroupAssignments = await buildAvatarBaseGroupAssignments(circlesRpc, logger);
-  const baseGroupAvatars = Array.from(avatarBaseGroupAssignments.keys());
-  const unknownBaseGroupAvatars = baseGroupAvatars.filter(
-    (avatar) => !allowedHumanSet.has(avatar) && !blacklistedSet.has(avatar)
-  );
-
-  const allowedBaseGroupAvatars = new Set<string>(allowedHumanSet);
-  const blacklistedBaseGroupAvatars = new Set<string>(blacklistedSet);
-
-  if (unknownBaseGroupAvatars.length > 0) {
-    logger.info(
-      `Evaluating blacklist for ${unknownBaseGroupAvatars.length} base group member(s) not present in RegisterHuman table...`
-    );
-    const {allowed, blacklisted} = await partitionBlacklistedAddresses(
-      blacklistingService,
-      unknownBaseGroupAvatars,
-      logger
-    );
-    allowed.forEach((address) => allowedBaseGroupAvatars.add(address));
-    blacklisted.forEach((address) => blacklistedBaseGroupAvatars.add(address));
-  }
 
   const eligibilityFilter = (avatar: string): boolean =>
     !routerTrustSet.has(avatar) && !previouslyEnabled.has(avatar);
@@ -134,8 +114,8 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
     scheduledAvatars: baseGroupScheduledAvatars
   } = buildBaseGroupEnableTargets(
     avatarBaseGroupAssignments,
-    allowedBaseGroupAvatars,
-    blacklistedBaseGroupAvatars,
+    allowedHumanSet,
+    blacklistedSet,
     eligibilityFilter
   );
 

--- a/src/apps/router-tms/logic.ts
+++ b/src/apps/router-tms/logic.ts
@@ -205,6 +205,16 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
           `[DRY-RUN] Would call enableCRCForRouting with ${batch.length} avatar(s) ` +
             `(batch ${batchIndex + 1}/${batches.length}) for base group ${target.baseGroup}.`
         );
+        if (routerService?.simulateEnableCRCForRouting) {
+          const simulation = await routerService.simulateEnableCRCForRouting(target.baseGroup, batch);
+          logger.info(
+            `[DRY-RUN] enableCRCForRouting simulation ${batchIndex + 1}/${batches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`
+          );
+        } else {
+          logger.info(
+            `[DRY-RUN] enableCRCForRouting simulation ${batchIndex + 1}/${batches.length}: skipped (no signer-backed simulator configured).`
+          );
+        }
         continue;
       }
 

--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -121,6 +121,7 @@ async function mainLoop(): Promise<void> {
   leaderElection = await LeaderElection.create(
     process.env.LEADER_DB_URL,
     process.env.INSTANCE_ID,
+    rootLogger.child("leader-election"),
     slackService,
     (isLeader) => setLeaderStatus("router-tms", isLeader)
   );

--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -206,7 +206,7 @@ start().catch((cause) => {
 async function notifySlackStartup(): Promise<void> {
   const pollIntervalMinutes = formatMinutes(pollIntervalMs);
   const message = `✅ *Router-TMS Service started*\n\n` +
-    `Enabling routing for every non-blacklisted human avatar.\n` +
+    `Enabling routing only for non-blacklisted v2 human avatars.\n` +
     `- RPC: ${rpcUrl}\n` +
     `- TX RPC: ${txRpcUrl}\n` +
     `- Router: ${routerAddress}\n` +

--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -18,8 +18,10 @@ import {InMemoryRouterEnablementStore} from "./enablementStore";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {LeaderElection, getEffectiveDryRun} from "../../services/leaderElection";
 import {StateStore} from "../../services/stateStore";
+import {resolveTransactionRpcUrl} from "../../services/transactionRpc";
 
 const rpcUrl = process.env.RPC_URL || "https://rpc.aboutcircles.com/";
+const txRpcUrl = resolveTransactionRpcUrl(rpcUrl);
 const routerAddress = process.env.ROUTER_ADDRESS || "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
 const baseGroupAddress = process.env.ROUTER_BASE_GROUP_ADDRESS || DEFAULT_BASE_GROUP_ADDRESS;
 const dryRun = process.env.DRY_RUN === "1";
@@ -32,6 +34,7 @@ const slackWebhookUrlInfo = process.env.SLACK_WEBHOOK_URL_INFO || "";
 const slackInfoChannel = process.env.SLACK_INFO_CHANNEL || "";
 const safeAddress = process.env.ROUTER_SAFE_ADDRESS || "";
 const safeSignerPrivateKey = process.env.ROUTER_SAFE_SIGNER_PRIVATE_KEY || "";
+const canSimulateTransactions = safeSignerPrivateKey.trim().length > 0 && safeAddress.trim().length > 0;
 const blacklistingServiceUrl = process.env.BLACKLISTING_SERVICE_URL || "https://squid-app-3gxnl.ondigitalocean.app/aboutcircles-advanced-analytics2/bot-analytics/blacklist";
 
 const rootLogger = new LoggerService(verboseLogging, "router-tms");
@@ -57,14 +60,14 @@ async function refreshBlacklist(): Promise<void> {
 }
 
 let routerService: RouterService | undefined;
-if (!dryRun) {
+if (!dryRun || canSimulateTransactions) {
   if (!safeSignerPrivateKey || safeSignerPrivateKey.trim().length === 0) {
     throw new Error("ROUTER_SAFE_SIGNER_PRIVATE_KEY is required when router-tms is not in dry-run mode.");
   }
   if (!safeAddress || safeAddress.trim().length === 0) {
     throw new Error("ROUTER_SAFE_ADDRESS is required when router-tms is not in dry-run mode.");
   }
-  routerService = new RouterService(rpcUrl, routerAddress, safeSignerPrivateKey, safeAddress);
+  routerService = new RouterService(rpcUrl, routerAddress, safeSignerPrivateKey, safeAddress, txRpcUrl);
 }
 
 const config: RunConfig = {
@@ -205,6 +208,7 @@ async function notifySlackStartup(): Promise<void> {
   const message = `✅ *Router-TMS Service started*\n\n` +
     `Enabling routing for every non-blacklisted human avatar.\n` +
     `- RPC: ${rpcUrl}\n` +
+    `- TX RPC: ${txRpcUrl}\n` +
     `- Router: ${routerAddress}\n` +
     `- Base Group: ${baseGroupAddress}\n` +
     `- Blacklisting Service: ${blacklistingServiceUrl}\n` +

--- a/src/interfaces/IBackingInstanceService.ts
+++ b/src/interfaces/IBackingInstanceService.ts
@@ -1,3 +1,5 @@
+import {TransactionSimulationResult} from "./ITransactionSimulation";
+
 export type ResetCowSwapOrderResult = "OrderAlreadySettled" | "OrderUidIsTheSame" | "OrderValid";
 export type CreateLBPResult = "LBPAlreadyCreated" | "OrderNotYetFilled" | "BackingAssetBalanceInsufficient" | "Success";
 
@@ -29,4 +31,14 @@ export interface IBackingInstanceService {
      * @param circlesBackingInstance The address of the CirclesBacking contract instance.
      */
     createLbp(circlesBackingInstance: string) : Promise<string>;
+
+    /**
+     * Simulates the actual Safe transaction that would call `resetCowSwapOrder` and estimates its gas.
+     */
+    simulateResetCowSwapOrderTx?(circlesBackingInstance: string): Promise<TransactionSimulationResult>;
+
+    /**
+     * Simulates the actual Safe transaction that would call `createLBP` and estimates its gas.
+     */
+    simulateCreateLbpTx?(circlesBackingInstance: string): Promise<TransactionSimulationResult>;
 }

--- a/src/interfaces/ICirclesRpc.ts
+++ b/src/interfaces/ICirclesRpc.ts
@@ -30,6 +30,7 @@ export interface ICirclesRpc {
   fetchBackingInitiatedEvents(backingFactoryAddress: string, fromBlock: number, toBlock?: number): Promise<BackingInitiatedEvent[]>;
   fetchBackingCompletedEvents(backingFactoryAddress: string, fromBlock: number, toBlock?: number): Promise<BackingCompletedEvent[]>;
   fetchAllTrustees(truster: string): Promise<string[]>;
+  fetchActiveGroupMembersAtBlock(groupAddress: string, blockNumber: number): Promise<string[]>;
   fetchAllBaseGroups(pageSize?: number): Promise<string[]>;
   isHuman(address: string): Promise<boolean>;
   isHumanBatch(addresses: string[]): Promise<Map<string, boolean>>;

--- a/src/interfaces/ICirclesRpc.ts
+++ b/src/interfaces/ICirclesRpc.ts
@@ -30,6 +30,7 @@ export interface ICirclesRpc {
   fetchBackingInitiatedEvents(backingFactoryAddress: string, fromBlock: number, toBlock?: number): Promise<BackingInitiatedEvent[]>;
   fetchBackingCompletedEvents(backingFactoryAddress: string, fromBlock: number, toBlock?: number): Promise<BackingCompletedEvent[]>;
   fetchAllTrustees(truster: string): Promise<string[]>;
+  fetchAllTrusteesForTrusters(trusters: string[], pageSize?: number): Promise<Map<string, string[]>>;
   fetchActiveGroupMembersAtBlock(groupAddress: string, blockNumber: number): Promise<string[]>;
   fetchAllBaseGroups(pageSize?: number): Promise<string[]>;
   isHuman(address: string): Promise<boolean>;

--- a/src/interfaces/IGroupService.ts
+++ b/src/interfaces/IGroupService.ts
@@ -1,3 +1,5 @@
+import {TransactionSimulationResult} from "./ITransactionSimulation";
+
 export type GroupOwnerAndServiceAddress = {
     owner: string,
     service: string
@@ -6,5 +8,7 @@ export type GroupOwnerAndServiceAddress = {
 export interface IGroupService {
     trustBatchWithConditions(groupAddress: string, trusteeAddresses: string[]): Promise<string>;
     untrustBatch(groupAddress: string, trusteeAddresses: string[]): Promise<string>;
-    fetchGroupOwnerAndService(groupAddress: string): Promise<GroupOwnerAndServiceAddress>
+    fetchGroupOwnerAndService(groupAddress: string): Promise<GroupOwnerAndServiceAddress>;
+    simulateTrustBatchWithConditions?(groupAddress: string, trusteeAddresses: string[]): Promise<TransactionSimulationResult>;
+    simulateUntrustBatch?(groupAddress: string, trusteeAddresses: string[]): Promise<TransactionSimulationResult>;
 }

--- a/src/interfaces/IRouterService.ts
+++ b/src/interfaces/IRouterService.ts
@@ -1,10 +1,12 @@
+import {TransactionSimulationResult} from "./ITransactionSimulation";
+
 export interface IRouterService {
   /**
    * Calls the router contract to enable CRC routing for the given base group.
    * @param baseGroup Base group that already trusts the provided CRCs.
    * @param crcAddresses Human CRC addresses that should also be trusted by the router.
    * @returns Transaction hash of the enableCRCForRouting call.
-   */
+  */
   enableCRCForRouting(baseGroup: string, crcAddresses: string[]): Promise<string>;
+  simulateEnableCRCForRouting?(baseGroup: string, crcAddresses: string[]): Promise<TransactionSimulationResult>;
 }
-

--- a/src/interfaces/ITransactionSimulation.ts
+++ b/src/interfaces/ITransactionSimulation.ts
@@ -1,0 +1,3 @@
+export type TransactionSimulationResult = {
+  gasEstimate: bigint;
+};

--- a/src/services/backingInstanceService.ts
+++ b/src/services/backingInstanceService.ts
@@ -1,5 +1,6 @@
 import {ResetCowSwapOrderResult, IBackingInstanceService, CreateLBPResult} from "../interfaces/IBackingInstanceService";
 import {Contract, Interface, JsonRpcProvider, FallbackProvider} from "ethers";
+import {TransactionSimulationResult} from "../interfaces/ITransactionSimulation";
 import CirclesBackingABI from "../abi/CirclesBackingABI.json";
 import {SafeTransactionExecutor} from "./safeTransactionExecutor";
 import {createProvider} from "./rpcProvider";
@@ -10,10 +11,10 @@ export class BackingInstanceService implements IBackingInstanceService {
   private readonly provider: JsonRpcProvider | FallbackProvider;
   private readonly executor?: SafeTransactionExecutor;
 
-  constructor(rpcUrl: string, signerPrivateKey?: string, safeAddress?: string) {
+  constructor(rpcUrl: string, signerPrivateKey?: string, safeAddress?: string, txRpcUrl: string = rpcUrl) {
     this.provider = createProvider(rpcUrl);
     if (signerPrivateKey && signerPrivateKey.trim().length > 0 && safeAddress && safeAddress.trim().length > 0) {
-      this.executor = new SafeTransactionExecutor(rpcUrl, signerPrivateKey, safeAddress);
+      this.executor = new SafeTransactionExecutor(txRpcUrl, signerPrivateKey, safeAddress);
     }
   }
 
@@ -35,6 +36,22 @@ export class BackingInstanceService implements IBackingInstanceService {
     }
     const data = BACKING_INTERFACE.encodeFunctionData("createLBP", []);
     return this.executor.execute(circlesBackingInstance, data);
+  }
+
+  async simulateResetCowSwapOrderTx(circlesBackingInstance: string): Promise<TransactionSimulationResult> {
+    if (!this.executor) {
+      throw new Error("simulateResetCowSwapOrderTx requires a configured Safe signer");
+    }
+    const data = BACKING_INTERFACE.encodeFunctionData("resetCowswapOrder", []);
+    return this.executor.simulate(circlesBackingInstance, data);
+  }
+
+  async simulateCreateLbpTx(circlesBackingInstance: string): Promise<TransactionSimulationResult> {
+    if (!this.executor) {
+      throw new Error("simulateCreateLbpTx requires a configured Safe signer");
+    }
+    const data = BACKING_INTERFACE.encodeFunctionData("createLBP", []);
+    return this.executor.simulate(circlesBackingInstance, data);
   }
 
   async simulateCreateLbp(circlesBackingInstance: string): Promise<CreateLBPResult> {

--- a/src/services/circlesRpcService.ts
+++ b/src/services/circlesRpcService.ts
@@ -5,9 +5,19 @@ import {ILoggerService} from "../interfaces/ILoggerService";
 import {primaryRpcUrl} from "./rpcProvider";
 
 const CIRCLES_EVENTS_RESULT_LIMIT = 100;
+const DEFAULT_TRUST_QUERY_PAGE_SIZE = 1000;
+
+export type BulkTrusteesForTrustersStats = {
+  pagesFetched: number;
+  rowsScanned: number;
+};
 
 export class CirclesRpcService implements ICirclesRpc {
   private readonly rpc: CirclesRpc;
+  private lastBulkTrusteesForTrustersStats: BulkTrusteesForTrustersStats = {
+    pagesFetched: 0,
+    rowsScanned: 0
+  };
 
   constructor(rpcUrl: string) {
     this.rpc = new CirclesRpc(primaryRpcUrl(rpcUrl));
@@ -34,7 +44,7 @@ export class CirclesRpcService implements ICirclesRpc {
 
   async fetchAllTrustees(truster: string): Promise<string[]> {
     const trusterLc = truster.toLowerCase();
-    const query = this.rpc.trust.getTrustRelations(trusterLc, 1000);
+    const query = this.rpc.trust.getTrustRelations(trusterLc, DEFAULT_TRUST_QUERY_PAGE_SIZE);
     const allTrustees: string[] = [];
 
     while (await query.queryNextPage()) {
@@ -47,6 +57,92 @@ export class CirclesRpcService implements ICirclesRpc {
     }
 
     return allTrustees;
+  }
+
+  async fetchAllTrusteesForTrusters(
+    trusters: string[],
+    pageSize: number = DEFAULT_TRUST_QUERY_PAGE_SIZE
+  ): Promise<Map<string, string[]>> {
+    const normalizedTrusters = Array.from(new Set(trusters.map((truster) => truster.toLowerCase())));
+    const trusteesByTruster = new Map<string, string[]>();
+    normalizedTrusters.forEach((truster) => trusteesByTruster.set(truster, []));
+
+    this.lastBulkTrusteesForTrustersStats = {
+      pagesFetched: 0,
+      rowsScanned: 0
+    };
+
+    if (normalizedTrusters.length === 0) {
+      return trusteesByTruster;
+    }
+
+    const query = new PagedQuery<{
+      truster: string;
+      trustee: string;
+    }>(this.rpc.client, {
+      namespace: "V_Crc",
+      table: "TrustRelations",
+      sortOrder: "DESC",
+      columns: [
+        "blockNumber",
+        "timestamp",
+        "transactionIndex",
+        "logIndex",
+        "transactionHash",
+        "version",
+        "trustee",
+        "truster",
+        "expiryTime"
+      ],
+      filter: [{
+        Type: "Conjunction",
+        ConjunctionType: "And",
+        Predicates: [
+          {
+            Type: "FilterPredicate",
+            FilterType: "Equals",
+            Column: "version",
+            Value: 2
+          },
+          {
+            Type: "Conjunction",
+            ConjunctionType: "Or",
+            Predicates: normalizedTrusters.map((truster) => ({
+              Type: "FilterPredicate" as const,
+              FilterType: "Equals" as const,
+              Column: "truster",
+              Value: truster
+            }))
+          }
+        ]
+      }],
+      limit: pageSize
+    });
+
+    while (await query.queryNextPage()) {
+      this.lastBulkTrusteesForTrustersStats.pagesFetched += 1;
+      const rows = query.currentPage?.results ?? [];
+      this.lastBulkTrusteesForTrustersStats.rowsScanned += rows.length;
+
+      for (const row of rows) {
+        if (typeof row.truster !== "string" || typeof row.trustee !== "string") {
+          continue;
+        }
+
+        const normalizedTruster = row.truster.toLowerCase();
+        if (!trusteesByTruster.has(normalizedTruster)) {
+          continue;
+        }
+
+        trusteesByTruster.get(normalizedTruster)?.push(row.trustee.toLowerCase());
+      }
+    }
+
+    return trusteesByTruster;
+  }
+
+  getLastBulkTrusteesForTrustersStats(): BulkTrusteesForTrustersStats {
+    return this.lastBulkTrusteesForTrustersStats;
   }
 
   async fetchActiveGroupMembersAtBlock(groupAddress: string, blockNumber: number): Promise<string[]> {

--- a/src/services/circlesRpcService.ts
+++ b/src/services/circlesRpcService.ts
@@ -4,6 +4,8 @@ import {ICirclesRpc, BackingCompletedEvent, BackingInitiatedEvent} from "../inte
 import {ILoggerService} from "../interfaces/ILoggerService";
 import {primaryRpcUrl} from "./rpcProvider";
 
+const CIRCLES_EVENTS_RESULT_LIMIT = 100;
+
 export class CirclesRpcService implements ICirclesRpc {
   private readonly rpc: CirclesRpc;
 
@@ -47,23 +49,98 @@ export class CirclesRpcService implements ICirclesRpc {
     return allTrustees;
   }
 
+  async fetchActiveGroupMembersAtBlock(groupAddress: string, blockNumber: number): Promise<string[]> {
+    const normalizedGroupAddress = getAddress(groupAddress).toLowerCase();
+    const blockTimestamp = await this.fetchBlockTimestamp(blockNumber);
+    const query = new PagedQuery<{
+      member: string;
+      expiryTime: string;
+    }>(this.rpc.client, {
+      namespace: "V_CrcV2",
+      table: "GroupMemberships",
+      sortOrder: "DESC",
+      columns: ["member", "expiryTime", "blockNumber", "transactionIndex", "logIndex"],
+      filter: [{
+        Type: "Conjunction",
+        ConjunctionType: "And",
+        Predicates: [
+          {Type: "FilterPredicate", FilterType: "Equals", Column: "group", Value: normalizedGroupAddress},
+          {
+            Type: "FilterPredicate",
+            FilterType: "LessThanOrEquals" as unknown as "LessOrEqualThan",
+            Column: "blockNumber",
+            Value: blockNumber
+          }
+        ]
+      }],
+      limit: 1000
+    });
+
+    const members: string[] = [];
+    const seen = new Set<string>();
+    const blockTimestampBigInt = BigInt(blockTimestamp);
+
+    while (await query.queryNextPage()) {
+      const rows = query.currentPage?.results ?? [];
+      for (const row of rows) {
+        if (typeof row.member !== "string" || typeof row.expiryTime !== "string") {
+          continue;
+        }
+
+        let normalizedMember: string;
+        try {
+          normalizedMember = getAddress(row.member).toLowerCase();
+        } catch {
+          continue;
+        }
+
+        let expiryTime: bigint;
+        try {
+          expiryTime = BigInt(row.expiryTime);
+        } catch {
+          continue;
+        }
+
+        if (expiryTime <= blockTimestampBigInt || seen.has(normalizedMember)) {
+          continue;
+        }
+
+        seen.add(normalizedMember);
+        members.push(normalizedMember);
+      }
+    }
+
+    return members;
+  }
+
   /**
    * Workaround: sdk-rpc v0.1.24 sends circles_events params in wrong order.
-   * Uses raw client.call with correct param order: [address, fromBlock, toBlock, eventTypes, filterPredicates].
-   * Backing events aren't emitted by the factory — they're emitted by individual
-   * backing instances, so we query all events and filter by emitter column.
+   * Uses raw client.call with correct param order:
+   * [address, fromBlock, toBlock, eventTypes, filterPredicates].
+   *
+   * The RPC currently returns a bare array for circles_events, but older mocks
+   * and wrappers may still expose an { events } object. Accept both shapes.
    */
-  private async fetchEvents<T>(
+  private async fetchEventsPage(
     emitterAddress: string,
     fromBlock: number,
-    toBlock: number | null,
+    toBlock: number,
     eventTypes: string[],
-  ): Promise<T[]> {
+  ): Promise<any[]> {
     const result = await this.rpc.client.call("circles_events", [
       undefined, fromBlock, toBlock, eventTypes,
       [{ Type: "FilterPredicate", FilterType: "Equals", Column: "emitter", Value: emitterAddress }],
     ]);
-    return (result as any)?.events?.map((e: any) => ({
+
+    return Array.isArray(result)
+      ? result
+      : Array.isArray((result as any)?.events)
+        ? (result as any).events
+        : [];
+  }
+
+  private mapEvents<T>(rawEvents: any[]): T[] {
+    return rawEvents.map((e: any) => ({
       $event: e.event,
       blockNumber: typeof e.values?.blockNumber === "string"
         ? parseInt(e.values.blockNumber, 16) : e.values?.blockNumber,
@@ -79,7 +156,86 @@ export class CirclesRpcService implements ICirclesRpc {
           ([k]) => !["blockNumber", "timestamp", "transactionIndex", "logIndex", "transactionHash"].includes(k)
         )
       ),
-    })) ?? [];
+    })) as T[];
+  }
+
+  private async fetchEventsRecursive<T>(
+    emitterAddress: string,
+    fromBlock: number,
+    toBlock: number,
+    eventTypes: string[],
+  ): Promise<T[]> {
+    const rawEvents = await this.fetchEventsPage(emitterAddress, fromBlock, toBlock, eventTypes);
+    if (rawEvents.length < CIRCLES_EVENTS_RESULT_LIMIT || fromBlock >= toBlock) {
+      return this.mapEvents<T>(rawEvents);
+    }
+
+    const midpoint = Math.floor((fromBlock + toBlock) / 2);
+    if (midpoint < fromBlock || midpoint >= toBlock) {
+      return this.mapEvents<T>(rawEvents);
+    }
+
+    const [left, right] = await Promise.all([
+      this.fetchEventsRecursive<T>(emitterAddress, fromBlock, midpoint, eventTypes),
+      this.fetchEventsRecursive<T>(emitterAddress, midpoint + 1, toBlock, eventTypes),
+    ]);
+
+    return [...left, ...right];
+  }
+
+  private sortEventsDescending<T extends {
+    blockNumber: number;
+    transactionIndex: number;
+    logIndex: number;
+  }>(events: T[]): T[] {
+    return events.sort((a, b) => (
+      b.blockNumber - a.blockNumber ||
+      b.transactionIndex - a.transactionIndex ||
+      b.logIndex - a.logIndex
+    ));
+  }
+
+  private async fetchHeadBlockNumber(): Promise<number> {
+    const head = await this.rpc.client.call("eth_blockNumber", []) as string | number | null;
+    if (typeof head === "number" && Number.isFinite(head)) {
+      return head;
+    }
+
+    if (typeof head === "string") {
+      const parsed = head.startsWith("0x")
+        ? Number.parseInt(head, 16)
+        : Number.parseInt(head, 10);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+
+    throw new Error("Unable to fetch current head block number.");
+  }
+
+  private async fetchEvents<T extends {
+    blockNumber: number;
+    transactionIndex: number;
+    logIndex: number;
+  }>(
+    emitterAddress: string,
+    fromBlock: number,
+    toBlock: number | null,
+    eventTypes: string[],
+  ): Promise<T[]> {
+    const resolvedToBlock = toBlock ?? await this.fetchHeadBlockNumber();
+    if (resolvedToBlock < fromBlock) {
+      return [];
+    }
+
+    const events = await this.fetchEventsRecursive<T>(
+      emitterAddress,
+      fromBlock,
+      resolvedToBlock,
+      eventTypes,
+    );
+
+    return this.sortEventsDescending(events);
   }
 
   async fetchBackingCompletedEvents(backingFactoryAddress: string, fromBlock: number, toBlock?: number): Promise<BackingCompletedEvent[]> {
@@ -140,5 +296,31 @@ export class CirclesRpcService implements ICirclesRpc {
 
     logger?.info(`Fetched ${avatars.length} avatars from RegisterHuman table across ${pages} page(s).`);
     return avatars;
+  }
+
+  private async fetchBlockTimestamp(blockNumber: number): Promise<number> {
+    const hexBlockNumber = `0x${blockNumber.toString(16)}`;
+    const block = await this.rpc.client.call("eth_getBlockByNumber", [hexBlockNumber, false]) as {
+      timestamp?: string | number;
+    } | null;
+
+    if (!block || block.timestamp === undefined) {
+      throw new Error(`Unable to fetch timestamp for block ${blockNumber}.`);
+    }
+
+    if (typeof block.timestamp === "number" && Number.isFinite(block.timestamp)) {
+      return block.timestamp;
+    }
+
+    if (typeof block.timestamp === "string") {
+      const parsed = block.timestamp.startsWith("0x")
+        ? Number.parseInt(block.timestamp, 16)
+        : Number.parseInt(block.timestamp, 10);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+
+    throw new Error(`Unable to parse timestamp for block ${blockNumber}.`);
   }
 }

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -1,5 +1,6 @@
 import {GroupOwnerAndServiceAddress, IGroupService} from "../interfaces/IGroupService";
-import {Contract, getAddress, JsonRpcProvider, Wallet} from "ethers";
+import {Contract, FallbackProvider, getAddress, JsonRpcProvider, Wallet} from "ethers";
+import {TransactionSimulationResult} from "../interfaces/ITransactionSimulation";
 import {TransactionConfirmationTimeoutError} from "./safeTransactionExecutor";
 import {retryWithBackoff} from "./retryWithBackoff";
 import {createProvider} from "./rpcProvider";
@@ -25,12 +26,17 @@ export const GROUP_MINI_ABI = [
 ];
 
 export class GroupService implements IGroupService {
-  private readonly provider: JsonRpcProvider;
+  private readonly provider: JsonRpcProvider | FallbackProvider;
   private readonly wallet: Wallet;
 
-  constructor(private readonly rpcUrl: string, private readonly servicePrivateKey: string) {
-    this.provider = createProvider(rpcUrl) as JsonRpcProvider;
-    this.wallet = new Wallet(servicePrivateKey, this.provider);
+  constructor(
+    private readonly rpcUrl: string,
+    private readonly servicePrivateKey: string,
+    txRpcUrl: string = rpcUrl
+  ) {
+    this.provider = createProvider(rpcUrl);
+    const txProvider = createProvider(txRpcUrl);
+    this.wallet = new Wallet(servicePrivateKey, txProvider);
   }
 
   async trustBatchWithConditions(groupAddress: string, trusteeAddresses: string[]): Promise<string> {
@@ -77,7 +83,30 @@ export class GroupService implements IGroupService {
     };
   }
 
+  async simulateTrustBatchWithConditions(groupAddress: string, trusteeAddresses: string[]): Promise<TransactionSimulationResult> {
+    return this.simulateGroupWrite(groupAddress, trusteeAddresses, (1n << 96n) - 1n);
+  }
+
+  async simulateUntrustBatch(groupAddress: string, trusteeAddresses: string[]): Promise<TransactionSimulationResult> {
+    return this.simulateGroupWrite(groupAddress, trusteeAddresses, 0n);
+  }
+
   private getWritableGroupContract(groupAddress: string): Contract {
     return new Contract(groupAddress, GROUP_MINI_ABI, this.wallet);
+  }
+
+  private async simulateGroupWrite(
+    groupAddress: string,
+    trusteeAddresses: string[],
+    expiry: bigint
+  ): Promise<TransactionSimulationResult> {
+    const group = this.getWritableGroupContract(groupAddress);
+
+    await retryWithBackoff(() => group.trustBatchWithConditions.staticCall(trusteeAddresses, expiry));
+    const gasEstimate = await retryWithBackoff(() =>
+      group.trustBatchWithConditions.estimateGas(trusteeAddresses, expiry)
+    );
+
+    return {gasEstimate};
   }
 }

--- a/src/services/leaderElection.ts
+++ b/src/services/leaderElection.ts
@@ -1,5 +1,6 @@
 import { Pool } from "pg";
 import { SlackSeverity } from "../interfaces/ISlackService";
+import { ILoggerService } from "../interfaces/ILoggerService";
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const STALENESS_THRESHOLD_SEC = 45;
@@ -11,6 +12,7 @@ interface LeaderElectionNotifier {
 export class LeaderElection {
   private pool: Pool;
   private instanceId: string;
+  private logger: ILoggerService;
   private notifier: LeaderElectionNotifier | undefined;
   private onStatusUpdate: ((isLeader: boolean) => void) | undefined;
   private _isLeader = false;
@@ -19,11 +21,13 @@ export class LeaderElection {
   constructor(
     dbUrl: string,
     instanceId: string,
+    logger: ILoggerService,
     notifier?: LeaderElectionNotifier,
     onStatusUpdate?: (isLeader: boolean) => void
   ) {
     this.pool = new Pool({ connectionString: dbUrl, max: 2 });
     this.instanceId = instanceId;
+    this.logger = logger;
     this.notifier = notifier;
     this.onStatusUpdate = onStatusUpdate;
   }
@@ -35,11 +39,12 @@ export class LeaderElection {
   static async create(
     dbUrl?: string,
     instanceId?: string,
+    logger?: ILoggerService,
     notifier?: LeaderElectionNotifier,
     onStatusUpdate?: (isLeader: boolean) => void
   ): Promise<LeaderElection | null> {
-    if (!dbUrl || !instanceId) return null;
-    const le = new LeaderElection(dbUrl, instanceId, notifier, onStatusUpdate);
+    if (!dbUrl || !instanceId || !logger) return null;
+    const le = new LeaderElection(dbUrl, instanceId, logger, notifier, onStatusUpdate);
     await le.start();
     return le;
   }
@@ -80,15 +85,15 @@ export class LeaderElection {
       this._isLeader = result.rowCount !== null && result.rowCount > 0;
     } catch (err) {
       // PG unreachable → safe: go dry-run
-      console.error(`[leader-election] PG error, falling back to standby:`, err instanceof Error ? err.message : err);
+      this.logger.error(`[leader-election] PG error, falling back to standby:`, err instanceof Error ? err.message : err);
       this._isLeader = false;
     }
 
     if (!wasLeader && this._isLeader) {
-      console.log(`[leader-election] Acquired leadership (instance=${this.instanceId})`);
+      this.logger.info(`[leader-election] Acquired leadership (instance=${this.instanceId})`);
       this.notifySlack(`🟢 Acquired leadership`);
     } else if (wasLeader && !this._isLeader) {
-      console.log(`[leader-election] Lost leadership (instance=${this.instanceId})`);
+      this.logger.info(`[leader-election] Lost leadership (instance=${this.instanceId})`);
       this.notifySlack(`🔴 Lost leadership — switching to dry-run`);
     }
 
@@ -98,7 +103,7 @@ export class LeaderElection {
   private notifySlack(message: string): void {
     if (!this.notifier) return;
     this.notifier.notifySlackStartOrCrash(message, SlackSeverity.INFO).catch((err) => {
-      console.warn(`[leader-election] Slack notification failed:`, err instanceof Error ? err.message : err);
+      this.logger.warn(`[leader-election] Slack notification failed:`, err instanceof Error ? err.message : err);
     });
   }
 
@@ -117,9 +122,9 @@ export class LeaderElection {
            WHERE instance_id = $2`,
           [STALENESS_THRESHOLD_SEC + 1, this.instanceId]
         );
-        console.log(`[leader-election] Released leadership on shutdown (instance=${this.instanceId})`);
+        this.logger.info(`[leader-election] Released leadership on shutdown (instance=${this.instanceId})`);
       } catch (err) {
-        console.warn(`[leader-election] Failed to release leadership on shutdown:`, err instanceof Error ? err.message : err);
+        this.logger.warn(`[leader-election] Failed to release leadership on shutdown:`, err instanceof Error ? err.message : err);
       }
     }
     this._isLeader = false;

--- a/src/services/metriSafeService.ts
+++ b/src/services/metriSafeService.ts
@@ -23,7 +23,7 @@ type GraphqlResponse = {
 };
 
 const DEFAULT_TIMEOUT_MS = 30_000;
-const DEFAULT_CHUNK_SIZE = 2500;
+const DEFAULT_CHUNK_SIZE = 500;
 
 const QUERY = `query($addresses:[String!]!){
   Metri_Pay_DelayModule(where:{owners:{ownerAddress:{_in:$addresses}}}){
@@ -147,7 +147,7 @@ export class MetriSafeService implements IAvatarSafeService {
         }
 
         const existing = accumulator.get(safe);
-        if (!existing || compareTimestamp(timestamp, existing.timestamp) > 0) {
+        if (!existing || shouldReplaceSelection(existing, avatar, timestamp)) {
           accumulator.set(safe, {avatar, timestamp});
         }
       }
@@ -217,6 +217,23 @@ function compareTimestamp(left: string, right: string): number {
   }
 
   return left.localeCompare(right);
+}
+
+function shouldReplaceSelection(
+  existing: SafeOwnerSelection,
+  candidateAvatar: string,
+  candidateTimestamp: string
+): boolean {
+  const timestampComparison = compareTimestamp(candidateTimestamp, existing.timestamp);
+  if (timestampComparison > 0) {
+    return true;
+  }
+  if (timestampComparison < 0) {
+    return false;
+  }
+
+  // Break ties deterministically so response ordering cannot flip the selected owner.
+  return candidateAvatar.toLowerCase().localeCompare(existing.avatar.toLowerCase()) < 0;
 }
 
 function toComparableBigInt(value: string): bigint | null {

--- a/src/services/retryWithBackoff.ts
+++ b/src/services/retryWithBackoff.ts
@@ -10,9 +10,14 @@ const TRANSIENT_MESSAGES = [
   "ECONNRESET",
   "ECONNREFUSED",
   "socket hang up",
+  "evm timeout",
+  "missing revert data",
 ];
 
-const TRANSIENT_CODES = new Set<number>([-32016]);
+const TRANSIENT_CODES = new Set<number>([
+  -32016,
+  -32009, // Gnosis RPC "evm timeout" during gas estimation
+]);
 
 export function isTransientRpcError(err: unknown): boolean {
   if (err == null) return false;
@@ -20,6 +25,11 @@ export function isTransientRpcError(err: unknown): boolean {
   const code = ((err as any)?.code ?? (err as any)?.error?.code) as number | undefined;
 
   if (code !== undefined && TRANSIENT_CODES.has(code)) return true;
+
+  // ethers CALL_EXCEPTION with no revert data = RPC failed to simulate, not a real revert
+  const ethersCode = (err as any)?.code as string | undefined;
+  if (ethersCode === "CALL_EXCEPTION" && !(err as any)?.data) return true;
+
   return TRANSIENT_MESSAGES.some((t) => msg.includes(t));
 }
 

--- a/src/services/routerService.ts
+++ b/src/services/routerService.ts
@@ -1,5 +1,6 @@
 import {getAddress, Interface} from "ethers";
 import {IRouterService} from "../interfaces/IRouterService";
+import {TransactionSimulationResult} from "../interfaces/ITransactionSimulation";
 import {SafeTransactionExecutor} from "./safeTransactionExecutor";
 
 const ROUTER_ABI = [
@@ -11,9 +12,15 @@ export class RouterService implements IRouterService {
   private readonly executor: SafeTransactionExecutor;
   private readonly routerAddress: string;
 
-  constructor(rpcUrl: string, routerAddress: string, signerPrivateKey: string, safeAddress: string) {
+  constructor(
+    rpcUrl: string,
+    routerAddress: string,
+    signerPrivateKey: string,
+    safeAddress: string,
+    txRpcUrl: string = rpcUrl
+  ) {
     this.routerAddress = getAddress(routerAddress);
-    this.executor = new SafeTransactionExecutor(rpcUrl, signerPrivateKey, safeAddress);
+    this.executor = new SafeTransactionExecutor(txRpcUrl, signerPrivateKey, safeAddress);
   }
 
   async enableCRCForRouting(baseGroup: string, crcAddresses: string[]): Promise<string> {
@@ -30,5 +37,21 @@ export class RouterService implements IRouterService {
     ]);
 
     return this.executor.execute(this.routerAddress, data);
+  }
+
+  async simulateEnableCRCForRouting(baseGroup: string, crcAddresses: string[]): Promise<TransactionSimulationResult> {
+    if (crcAddresses.length === 0) {
+      throw new Error("enableCRCForRouting requires at least one CRC address.");
+    }
+
+    const normalizedBaseGroup = getAddress(baseGroup);
+    const normalizedCrcs = crcAddresses.map((address) => getAddress(address));
+
+    const data = ROUTER_INTERFACE.encodeFunctionData("enableCRCForRouting", [
+      normalizedBaseGroup,
+      normalizedCrcs
+    ]);
+
+    return this.executor.simulate(this.routerAddress, data);
   }
 }

--- a/src/services/safeGroupService.ts
+++ b/src/services/safeGroupService.ts
@@ -1,5 +1,6 @@
-import {Contract, Interface, JsonRpcProvider, getAddress} from "ethers";
+import {Contract, FallbackProvider, Interface, JsonRpcProvider, getAddress} from "ethers";
 import {GroupOwnerAndServiceAddress, IGroupService} from "../interfaces/IGroupService";
+import {TransactionSimulationResult} from "../interfaces/ITransactionSimulation";
 import {GROUP_MINI_ABI} from "./groupService";
 import {SafeTransactionExecutor} from "./safeTransactionExecutor";
 import {createProvider} from "./rpcProvider";
@@ -8,12 +9,12 @@ const GROUP_INTERFACE = new Interface(GROUP_MINI_ABI);
 const MAX_UINT96 = (1n << 96n) - 1n;
 
 export class SafeGroupService implements IGroupService {
-  private readonly provider: JsonRpcProvider;
+  private readonly provider: JsonRpcProvider | FallbackProvider;
   private readonly executor: SafeTransactionExecutor;
 
-  constructor(rpcUrl: string, signerPrivateKey: string, safeAddress: string) {
-    this.provider = createProvider(rpcUrl) as JsonRpcProvider;
-    this.executor = new SafeTransactionExecutor(rpcUrl, signerPrivateKey, safeAddress);
+  constructor(rpcUrl: string, signerPrivateKey: string, safeAddress: string, txRpcUrl: string = rpcUrl) {
+    this.provider = createProvider(rpcUrl);
+    this.executor = new SafeTransactionExecutor(txRpcUrl, signerPrivateKey, safeAddress);
   }
 
   async trustBatchWithConditions(groupAddress: string, trusteeAddresses: string[]): Promise<string> {
@@ -44,5 +45,23 @@ export class SafeGroupService implements IGroupService {
       owner: getAddress(owner).toLowerCase(),
       service: getAddress(service).toLowerCase()
     };
+  }
+
+  async simulateTrustBatchWithConditions(groupAddress: string, trusteeAddresses: string[]): Promise<TransactionSimulationResult> {
+    const data = GROUP_INTERFACE.encodeFunctionData("trustBatchWithConditions", [
+      trusteeAddresses,
+      MAX_UINT96
+    ]);
+
+    return this.executor.simulate(groupAddress, data);
+  }
+
+  async simulateUntrustBatch(groupAddress: string, trusteeAddresses: string[]): Promise<TransactionSimulationResult> {
+    const data = GROUP_INTERFACE.encodeFunctionData("trustBatchWithConditions", [
+      trusteeAddresses,
+      0n
+    ]);
+
+    return this.executor.simulate(groupAddress, data);
   }
 }

--- a/src/services/safeTransactionExecutor.ts
+++ b/src/services/safeTransactionExecutor.ts
@@ -1,10 +1,12 @@
 import Safe from "@safe-global/protocol-kit";
-import {getAddress, JsonRpcProvider} from "ethers";
-import {retryWithBackoff} from "./retryWithBackoff";
-import {createProvider, primaryRpcUrl} from "./rpcProvider";
+import { getAddress, JsonRpcProvider, Wallet } from "ethers";
+import { retryWithBackoff } from "./retryWithBackoff";
+import { createProvider, primaryRpcUrl } from "./rpcProvider";
 
 /** Default timeout for waiting on tx confirmation (5 minutes). */
 const DEFAULT_TX_CONFIRMATION_TIMEOUT_MS = 5 * 60 * 1000;
+const GAS_LIMIT_BUFFER_NUMERATOR = 120n;
+const GAS_LIMIT_BUFFER_DENOMINATOR = 100n;
 
 export class TransactionConfirmationTimeoutError extends Error {
   constructor(public readonly txHash: string, public readonly timeoutMs: number) {
@@ -28,6 +30,7 @@ export class SafeTransactionExecutor {
   private readonly provider: JsonRpcProvider;
   private readonly safePromise: Promise<Safe>;
   private readonly safeAddress: string;
+  private readonly signerAddress: string;
 
   constructor(rpcUrl: string, signerPrivateKey: string, safeAddress: string) {
     if (!signerPrivateKey || signerPrivateKey.trim().length === 0) {
@@ -39,6 +42,7 @@ export class SafeTransactionExecutor {
 
     this.provider = createProvider(rpcUrl) as JsonRpcProvider;
     this.safeAddress = getAddress(safeAddress);
+    this.signerAddress = getAddress(SafeTransactionExecutor.privateKeyToAddress(signerPrivateKey));
     this.safePromise = Safe.init({
       provider: primaryRpcUrl(rpcUrl),
       signer: signerPrivateKey,
@@ -57,7 +61,7 @@ export class SafeTransactionExecutor {
     const normalizedTo = getAddress(to);
     const normalizedValue = typeof value === "bigint" ? value.toString() : value ?? "0";
 
-    const safeTx = await safe.createTransaction({
+    const unsignedSafeTx = await safe.createTransaction({
       transactions: [
         {
           to: normalizedTo,
@@ -66,8 +70,12 @@ export class SafeTransactionExecutor {
         }
       ]
     });
+    const signedSafeTx = await safe.signTransaction(unsignedSafeTx);
+    const gasLimit = await this.estimateExecutionGasLimit(safe, signedSafeTx);
 
-    const execution = await retryWithBackoff(() => safe.executeTransaction(safeTx));
+    const execution = await retryWithBackoff(() =>
+      safe.executeTransaction(signedSafeTx, { gasLimit: gasLimit.toString() })
+    );
 
     const txHash =
       (execution as any).hash ?? (execution as any).transactionResponse?.hash;
@@ -87,5 +95,23 @@ export class SafeTransactionExecutor {
     ensureSuccessfulReceipt(receipt, `Safe tx to ${normalizedTo}`);
 
     return txHash;
+  }
+
+  private async estimateExecutionGasLimit(safe: Safe, safeTx: Awaited<ReturnType<Safe["createTransaction"]>>): Promise<bigint> {
+    // Estimate the fully encoded execTransaction with ethers to avoid Protocol Kit's
+    // internal viem estimate path, which is flaky on the Circles RPC.
+    const encodedSafeTx = await safe.getEncodedTransaction(safeTx);
+    const gasEstimate = await this.provider.estimateGas({
+      from: this.signerAddress,
+      to: this.safeAddress,
+      data: encodedSafeTx
+    });
+
+    return ((gasEstimate * GAS_LIMIT_BUFFER_NUMERATOR) + (GAS_LIMIT_BUFFER_DENOMINATOR - 1n)) / GAS_LIMIT_BUFFER_DENOMINATOR;
+  }
+
+  private static privateKeyToAddress(privateKey: string): string {
+    const normalized = privateKey.startsWith("0x") ? privateKey : `0x${privateKey}`;
+    return new Wallet(normalized).address;
   }
 }

--- a/src/services/safeTransactionExecutor.ts
+++ b/src/services/safeTransactionExecutor.ts
@@ -1,5 +1,6 @@
 import Safe from "@safe-global/protocol-kit";
 import { getAddress, JsonRpcProvider, Wallet } from "ethers";
+import {TransactionSimulationResult} from "../interfaces/ITransactionSimulation";
 import { retryWithBackoff } from "./retryWithBackoff";
 import { createProvider, primaryRpcUrl } from "./rpcProvider";
 
@@ -95,6 +96,37 @@ export class SafeTransactionExecutor {
     ensureSuccessfulReceipt(receipt, `Safe tx to ${normalizedTo}`);
 
     return txHash;
+  }
+
+  async simulate(
+    to: string,
+    data: string,
+    value: string | bigint = 0n
+  ): Promise<TransactionSimulationResult> {
+    const safe = await this.safePromise;
+    const normalizedTo = getAddress(to);
+    const normalizedValue = typeof value === "bigint" ? value.toString() : value ?? "0";
+
+    const unsignedSafeTx = await safe.createTransaction({
+      transactions: [
+        {
+          to: normalizedTo,
+          value: normalizedValue,
+          data
+        }
+      ]
+    });
+    const signedSafeTx = await safe.signTransaction(unsignedSafeTx);
+    const gasEstimate = await this.estimateExecutionGasLimit(safe, signedSafeTx);
+    const encodedSafeTx = await safe.getEncodedTransaction(signedSafeTx);
+
+    await retryWithBackoff(() => this.provider.call({
+      from: this.signerAddress,
+      to: this.safeAddress,
+      data: encodedSafeTx
+    }));
+
+    return {gasEstimate};
   }
 
   private async estimateExecutionGasLimit(safe: Safe, safeTx: Awaited<ReturnType<Safe["createTransaction"]>>): Promise<bigint> {

--- a/src/services/safeTransactionExecutor.ts
+++ b/src/services/safeTransactionExecutor.ts
@@ -131,13 +131,14 @@ export class SafeTransactionExecutor {
 
   private async estimateExecutionGasLimit(safe: Safe, safeTx: Awaited<ReturnType<Safe["createTransaction"]>>): Promise<bigint> {
     // Estimate the fully encoded execTransaction with ethers to avoid Protocol Kit's
-    // internal viem estimate path, which is flaky on the Circles RPC.
+    // internal viem estimate path. Wrapped in retryWithBackoff because public RPCs
+    // intermittently return "evm timeout" or empty CALL_EXCEPTION on complex Safe calls.
     const encodedSafeTx = await safe.getEncodedTransaction(safeTx);
-    const gasEstimate = await this.provider.estimateGas({
+    const gasEstimate = await retryWithBackoff<bigint>(() => this.provider.estimateGas({
       from: this.signerAddress,
       to: this.safeAddress,
       data: encodedSafeTx
-    });
+    }));
 
     return ((gasEstimate * GAS_LIMIT_BUFFER_NUMERATOR) + (GAS_LIMIT_BUFFER_DENOMINATOR - 1n)) / GAS_LIMIT_BUFFER_DENOMINATOR;
   }

--- a/src/services/transactionRpc.ts
+++ b/src/services/transactionRpc.ts
@@ -1,0 +1,9 @@
+export const TX_RPC_URL_ENV_VAR = "TX_RPC_URL";
+
+export function resolveTransactionRpcUrl(
+  readRpcUrl: string,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const configured = env[TX_RPC_URL_ENV_VAR]?.trim();
+  return configured && configured.length > 0 ? configured : readRpcUrl;
+}

--- a/tests/apps/crc-backing/logic.spec.ts
+++ b/tests/apps/crc-backing/logic.spec.ts
@@ -317,6 +317,22 @@ describe("trustAllNewBackers", () => {
     )).toBe(true);
     expect(grp.calls).toHaveLength(0);
   });
+
+  it("requires a group service when trust reconciliation is not in dry-run mode", async () => {
+    await expect(
+      trustAllNewBackers(
+        new FakeCirclesRpc(),
+        new FakeBlacklist(),
+        undefined,
+        GROUP,
+        BACKING_FACTORY_ADDRESS,
+        DEPLOYED_AT,
+        SAFE_HEAD,
+        false,
+        new FakeLogger(true)
+      )
+    ).rejects.toThrow("Group service dependency is required when crc-backers is not running in dry-run mode");
+  });
 });
 
 describe("findPendingBackingProcesses", () => {
@@ -380,9 +396,35 @@ describe("computeOrderDeadlineSeconds", () => {
     const bad = mkInitiated({timestamp: undefined});
     expect(() => computeOrderDeadlineSeconds(bad)).toThrow(/has no timestamp/);
   });
+
+  it("adds one day to the initiation timestamp", () => {
+    const initiated = mkInitiated({timestamp: 100});
+    expect(computeOrderDeadlineSeconds(initiated)).toBe(100 + 24 * 60 * 60);
+  });
 });
 
 describe("runOnce – reconciliation flow", () => {
+  it("requires a group service outside dry-run mode", async () => {
+    const deps = makeDeps({groupService: undefined});
+
+    await expect(runOnce(deps, CFG)).rejects.toThrow(
+      "Group service dependency is required when crc-backers is not running in dry-run mode"
+    );
+  });
+
+  it("returns early when no safe blocks remain to scan", async () => {
+    const deps = makeDeps({chainRpc: new FakeChainRpc({blockNumber: DEPLOYED_AT, timestamp: HEAD.timestamp})});
+
+    await expect(
+      runOnce(deps, {...CFG, fromBlock: DEPLOYED_AT + 10})
+    ).resolves.toEqual({
+      fromBlock: DEPLOYED_AT + 10,
+      toBlock: DEPLOYED_AT - CFG.confirmationBlocks,
+      safeHeadBlock: DEPLOYED_AT - CFG.confirmationBlocks,
+      nextFromBlock: DEPLOYED_AT + 10
+    });
+  });
+
   it("before deadline (overdue wrt policy): OrderValid → resetCowSwapOrder", async () => {
     const deps = makeDeps();
     const rpc = deps.circlesRpc as FakeCirclesRpc;
@@ -463,6 +505,27 @@ describe("runOnce – reconciliation flow", () => {
 
     expect(svc.createCalls).toEqual([inst.toLowerCase()]);
     expect(svc.resetCalls).toEqual([]);
+  });
+
+  it("past on-chain deadline in dry-run mode logs a create without executing it", async () => {
+    const deps = makeDeps();
+    const rpc = deps.circlesRpc as FakeCirclesRpc;
+    const svc = deps.cowSwapService as FakeBackingInstanceService;
+
+    const inst = "0xinst201a".padEnd(42, "1");
+    rpc.initiated = [
+      mkInitiated({
+        backer: "0xok".padEnd(42, "0"),
+        circlesBackingInstance: inst,
+        timestamp: HEAD.timestamp - 100_000,
+        blockNumber: DEPLOYED_AT + 11
+      })
+    ];
+    svc.simulateCreate[inst.toLowerCase()] = "Success";
+
+    await runOnce(deps, {...CFG, dryRun: true});
+
+    expect(svc.createCalls).toEqual([]);
   });
 
   it("past on-chain deadline: simulateCreate LBPAlreadyCreated → no-op", async () => {
@@ -580,6 +643,25 @@ describe("runOnce – reconciliation flow", () => {
     expect(slack.notifications[0].reason).toMatch(/BackingAssetBalanceInsufficient/);
   });
 
+  it("throws on an unknown LBP state returned after the deadline", async () => {
+    const deps = makeDeps();
+    const rpc = deps.circlesRpc as FakeCirclesRpc;
+    const svc = deps.cowSwapService as FakeBackingInstanceService;
+
+    const inst = "0xinst203a".padEnd(42, "1");
+    rpc.initiated = [
+      mkInitiated({
+        backer: "0xok".padEnd(42, "0"),
+        circlesBackingInstance: inst,
+        timestamp: HEAD.timestamp - 100_000,
+        blockNumber: DEPLOYED_AT + 13
+      })
+    ];
+    svc.simulateCreate[inst.toLowerCase()] = "weird" as any;
+
+    await expect(runOnce(deps, CFG)).rejects.toThrow(/Unknown LBP state/);
+  });
+
   it("before deadline: OrderAlreadySettled then LBP Success → createLbp", async () => {
     const deps = makeDeps();
     const rpc = deps.circlesRpc as FakeCirclesRpc;
@@ -598,6 +680,26 @@ describe("runOnce – reconciliation flow", () => {
 
     await runOnce(deps, CFG);
     expect(svc.createCalls).toEqual([inst.toLowerCase()]);
+  });
+
+  it("before deadline in dry-run mode does not create an LBP after a settled order", async () => {
+    const deps = makeDeps();
+    const rpc = deps.circlesRpc as FakeCirclesRpc;
+    const svc = deps.cowSwapService as FakeBackingInstanceService;
+
+    const inst = "0xinst300a".padEnd(42, "1");
+    rpc.initiated = [
+      mkInitiated({
+        circlesBackingInstance: inst,
+        timestamp: HEAD.timestamp - 120,
+        blockNumber: DEPLOYED_AT + 14
+      })
+    ];
+    svc.simulateReset[inst.toLowerCase()] = "OrderAlreadySettled";
+    svc.simulateCreate[inst.toLowerCase()] = "Success";
+
+    await runOnce(deps, {...CFG, dryRun: true});
+    expect(svc.createCalls).toEqual([]);
   });
 
   it("before deadline: OrderAlreadySettled then LBPAlreadyCreated → no-op", async () => {
@@ -662,5 +764,68 @@ describe("runOnce – reconciliation flow", () => {
     await runOnce(deps, CFG);
     expect(slack.notifications.length).toBe(1);
     expect(slack.notifications[0].reason).toMatch(/OrderNotYetFilled inconsistency/);
+  });
+
+  it("throws on an unknown LBP state after a settled order", async () => {
+    const deps = makeDeps();
+    const rpc = deps.circlesRpc as FakeCirclesRpc;
+    const svc = deps.cowSwapService as FakeBackingInstanceService;
+
+    const inst = "0xinst303a".padEnd(42, "1");
+    rpc.initiated = [
+      mkInitiated({
+        circlesBackingInstance: inst,
+        timestamp: HEAD.timestamp - 120,
+        blockNumber: DEPLOYED_AT + 17
+      })
+    ];
+    svc.simulateReset[inst.toLowerCase()] = "OrderAlreadySettled";
+    svc.simulateCreate[inst.toLowerCase()] = "weird" as any;
+
+    await expect(runOnce(deps, CFG)).rejects.toThrow(/Unknown LBP state/);
+  });
+
+  it("throws on an unknown order state before the deadline", async () => {
+    const deps = makeDeps();
+    const rpc = deps.circlesRpc as FakeCirclesRpc;
+    const svc = deps.cowSwapService as FakeBackingInstanceService;
+
+    const inst = "0xinst304a".padEnd(42, "1");
+    rpc.initiated = [
+      mkInitiated({
+        circlesBackingInstance: inst,
+        timestamp: HEAD.timestamp - 120,
+        blockNumber: DEPLOYED_AT + 18
+      })
+    ];
+    svc.simulateReset[inst.toLowerCase()] = "unknown" as any;
+
+    await expect(runOnce(deps, CFG)).rejects.toThrow(/Unknown order state/);
+  });
+
+  it("warns when the Slack summary fails after trust and untrust changes", async () => {
+    const deps = makeDeps();
+    const rpc = deps.circlesRpc as FakeCirclesRpc;
+    const logger = deps.logger as FakeLogger;
+
+    const blacklistedTrusted = "0xBLOCKED".padEnd(42, "0");
+    const newBacker = mkCompleted({backer: "0xNEW".padEnd(42, "0"), blockNumber: DEPLOYED_AT + 1});
+    rpc.completed = [newBacker];
+    rpc.trusteesByTruster[GROUP.toLowerCase()] = [blacklistedTrusted];
+
+    deps.blacklistingService = new FakeBlacklist(new Set([blacklistedTrusted.toLowerCase()]));
+    deps.slackService = {
+      notifyBackingNotCompleted: async () => undefined,
+      notifySlackStartOrCrash: async () => {
+        throw new Error("slack down");
+      }
+    } as any;
+
+    await runOnce(deps, CFG);
+
+    const warningMessages = logger.logs
+      .filter((entry) => entry.level === "warn")
+      .flatMap((entry) => entry.args.map((arg) => String(arg)));
+    expect(warningMessages.some((message) => message.includes("Failed to send Slack trust/untrust summary"))).toBe(true);
   });
 });

--- a/tests/apps/crc-backing/logic.spec.ts
+++ b/tests/apps/crc-backing/logic.spec.ts
@@ -478,8 +478,10 @@ describe("runOnce – reconciliation flow", () => {
     await runOnce(deps, {...CFG, dryRun: true});
 
     expect(grp.calls).toHaveLength(0);
+    expect(grp.trustSimulations).toBe(1);
     expect(svc.resetCalls).toHaveLength(0);
     expect(svc.createCalls).toHaveLength(0);
+    expect(svc.simulateResetTxCalls).toEqual([inst.toLowerCase()]);
     expect(slack.notifications).toHaveLength(0);
   });
 

--- a/tests/apps/gnosis-group/computeTrustPlan.spec.ts
+++ b/tests/apps/gnosis-group/computeTrustPlan.spec.ts
@@ -113,4 +113,25 @@ describe("computeTrustPlan", () => {
     expect(plan.addressesAutoTrustedByGroups).toEqual([normalizedGuaranteed]);
     expect(plan.trustBatches).toEqual([[normalizedGuaranteed]]);
   });
+
+  it("ignores invalid and duplicate addresses across planner inputs", () => {
+    const allowed = makeAddress(10);
+    const normalizedAllowed = getAddress(allowed);
+    const existing = makeAddress(11);
+    const normalizedExisting = getAddress(existing);
+
+    const plan = computeTrustPlan({
+      allowedAvatars: [allowed, "bad-address", allowed.toLowerCase()],
+      scores: {[normalizedAllowed.toLowerCase()]: 70},
+      scoreThreshold: 50,
+      guaranteedAddresses: ["bad-address", normalizedAllowed, normalizedAllowed.toLowerCase()],
+      existingTargetGroupAddresses: [normalizedExisting, "bad-address", normalizedExisting.toLowerCase()],
+      batchSize: 0
+    });
+
+    expect(plan.addressesQueuedForTrust).toEqual([normalizedAllowed]);
+    expect(plan.trustBatches).toEqual([[normalizedAllowed]]);
+    expect(plan.addressesToUntrust).toEqual([normalizedExisting, normalizedExisting]);
+    expect(plan.untrustBatches).toEqual([[normalizedExisting], [normalizedExisting]]);
+  });
 });

--- a/tests/apps/gnosis-group/helpers.spec.ts
+++ b/tests/apps/gnosis-group/helpers.spec.ts
@@ -1,8 +1,22 @@
-import {__testables} from "../../../src/apps/gnosis-group/logic";
+import {__testables, ScoreCache} from "../../../src/apps/gnosis-group/logic";
 
-const {timedFetch, isRetryableFetchError} = __testables;
+const {
+  fetchRelativeTrustScores,
+  formatErrorMessage,
+  getScoreForAddress,
+  isBlacklisted,
+  isRetryableFetchError,
+  normalizeAddress,
+  resolveScoreThreshold,
+  timedFetch,
+  uniqueNormalizedAddresses
+} = __testables;
 
 describe("gnosis-group helpers", () => {
+  afterEach(() => {
+    delete process.env.GNOSIS_GROUP_SCORE_THRESHOLD;
+  });
+
   afterEach(() => {
     jest.useRealTimers();
   });
@@ -30,5 +44,119 @@ describe("gnosis-group helpers", () => {
     expect(isRetryableFetchError({name: "AbortError"})).toBe(true);
     expect(isRetryableFetchError({message: "network timeout"})).toBe(true);
     expect(isRetryableFetchError({name: "TypeError", code: "NONRETRY", message: "fatal"})).toBe(false);
+  });
+
+  it("classifies blacklist verdicts", () => {
+    expect(isBlacklisted({address: "0x1", is_bot: true} as any)).toBe(true);
+    expect(isBlacklisted({address: "0x1", is_bot: false, category: "flagged"} as any)).toBe(true);
+    expect(isBlacklisted({address: "0x1", is_bot: false} as any)).toBe(false);
+  });
+
+  it("resolves score thresholds from config, env, and defaults", () => {
+    const logger = {
+      warn: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      table: jest.fn(),
+      child: jest.fn()
+    };
+
+    expect(resolveScoreThreshold(77, logger as any)).toBe(77);
+
+    process.env.GNOSIS_GROUP_SCORE_THRESHOLD = "55";
+    expect(resolveScoreThreshold(undefined, logger as any)).toBe(55);
+
+    process.env.GNOSIS_GROUP_SCORE_THRESHOLD = "invalid";
+    expect(resolveScoreThreshold(undefined, logger as any)).toBe(100);
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("extracts scores from mixed-case keys", () => {
+    expect(getScoreForAddress({"0xabc": 1}, "0xabc")).toBe(1);
+    expect(getScoreForAddress({"0xabc": 2}, "0xAbC")).toBe(2);
+    expect(getScoreForAddress({"0XABC": 3}, "0xabc")).toBe(3);
+    expect(getScoreForAddress({}, "0xabc")).toBe(0);
+  });
+
+  it("formats non-Error values safely", () => {
+    expect(formatErrorMessage(new Error("boom"))).toBe("boom");
+    expect(formatErrorMessage("plain")).toBe("plain");
+    expect(formatErrorMessage({code: 42})).toBe("[object Object]");
+  });
+
+  it("stores and expires cached scores", () => {
+    const cache = new ScoreCache();
+    jest.spyOn(Date, "now").mockReturnValue(1_000);
+    cache.set("0xABC", 42);
+
+    expect(cache.get("0xabc")).toEqual({score: 42, fetchedAt: 1_000});
+    expect(cache.getValidScore("0xabc", 100)).toBe(42);
+
+    jest.spyOn(Date, "now").mockReturnValue(2_000);
+    expect(cache.getValidScore("0xabc", 100)).toBeUndefined();
+    expect(cache.size).toBe(1);
+  });
+
+  it("normalizes and deduplicates helper address inputs", () => {
+    const first = "0x1000000000000000000000000000000000000001";
+    const second = "0x1000000000000000000000000000000000000002";
+
+    expect(normalizeAddress("")).toBeNull();
+    expect(normalizeAddress("bad-address")).toBeNull();
+    expect(uniqueNormalizedAddresses([first, first.toLowerCase(), second, "bad-address", 123 as any])).toEqual([
+      "0x1000000000000000000000000000000000000001",
+      "0x1000000000000000000000000000000000000002"
+    ]);
+  });
+
+  it("parses relative trust score responses and skips malformed entries", async () => {
+    const valid = "0x4000000000000000000000000000000000000004";
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        status: "success",
+        batches: {
+          "0": [
+            {address: valid, relative_score: 42},
+            {},
+            {address: "not-an-address", relative_score: 99},
+            {address: valid, relative_score: "44"},
+            {address: valid, relative_score: "oops"}
+          ],
+          "1": "invalid-batch"
+        }
+      })
+    });
+
+    const results = await fetchRelativeTrustScores("https://scores.local", [valid], [valid]);
+    expect(results.get("0x4000000000000000000000000000000000000004")).toBe(44);
+  });
+
+  it("throws on non-200 or malformed relative trust score responses", async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      statusText: "Unavailable"
+    });
+
+    await expect(
+      fetchRelativeTrustScores("https://scores.local", [], [])
+    ).rejects.toThrow("HTTP 503 Unavailable");
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({status: "error"})
+    });
+
+    await expect(
+      fetchRelativeTrustScores("https://scores.local", [], [])
+    ).rejects.toThrow("response malformed");
   });
 });

--- a/tests/apps/gnosis-group/runOnce.spec.ts
+++ b/tests/apps/gnosis-group/runOnce.spec.ts
@@ -4,7 +4,9 @@ import {
   type Deps,
   type RunConfig,
   DEFAULT_BACKERS_GROUP_ADDRESS,
-  DEFAULT_GP_CRC_GROUP_ADDRESS
+  DEFAULT_GP_CRC_GROUP_ADDRESS,
+  HISTORIC_AUTO_TRUST_GROUP_ADDRESS,
+  HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER
 } from "../../../src/apps/gnosis-group/logic";
 import {FakeBlacklist, FakeCirclesRpc, FakeGroupService, FakeLogger} from "../../../fakes/fakes";
 import {IGroupService} from "../../../src/interfaces/IGroupService";
@@ -69,6 +71,7 @@ describe("gnosis-group runOnce", () => {
   const targetGroup = getAddress("0x2000000000000000000000000000000000000002");
   const trustedTarget = getAddress("0x3000000000000000000000000000000000000003");
   const gpCrcGroup = getAddress(DEFAULT_GP_CRC_GROUP_ADDRESS);
+  const historicAutoTrustGroup = getAddress(HISTORIC_AUTO_TRUST_GROUP_ADDRESS);
 
   it("fetches relative trust scores when running in dry-run mode", async () => {
     const highScoreRaw = "0x4000000000000000000000000000000000000004";
@@ -710,5 +713,553 @@ describe("gnosis-group runOnce", () => {
     const requestBody = JSON.parse((fetchInit?.body ?? "{}") as string);
     expect(requestBody.target_sets).toEqual([[trustedTarget]]);
     expect(outcome.untrustTxHashes).toEqual([]);
+  });
+
+  it("trusts below-threshold avatars guaranteed by the historical auto-trust snapshot", async () => {
+    const autoTrusted = getAddress("0xd00000000000000000000000000000000000000d");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [autoTrusted];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+    circlesRpc.activeGroupMembersAtBlock[`${historicAutoTrustGroup.toLowerCase()}@${HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER}`] = [autoTrusted];
+
+    const groupService = new FakeGroupService();
+
+    const deps: Deps = {
+      blacklistingService: new FakeBlacklist(),
+      circlesRpc,
+      logger: new FakeLogger(true),
+      groupService
+    };
+
+    const cfg: RunConfig = {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: false,
+      scoreThreshold: 50,
+      scoreBatchSize: 10,
+      groupBatchSize: 10
+    };
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        status: "success",
+        batches: {
+          "0": [{address: autoTrusted, relative_score: 25}]
+        }
+      })
+    });
+
+    const outcome = await runOnce(deps, cfg);
+
+    expect(groupService.trustCalls).toBe(1);
+    expect(outcome.addressesAboveThresholdToTrust).toEqual([]);
+    expect(outcome.addressesAutoTrustedByGroups).toEqual([autoTrusted, trustedTarget]);
+    expect(outcome.addressesQueuedForTrust).toEqual([autoTrusted, trustedTarget]);
+    expect(outcome.addressesToUntrust).toEqual([]);
+  });
+
+  it("keeps historical auto-trust snapshot members trusted unless blacklisted", async () => {
+    const snapshotMember = getAddress("0xe00000000000000000000000000000000000000e");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [snapshotMember];
+    circlesRpc.activeGroupMembersAtBlock[`${historicAutoTrustGroup.toLowerCase()}@${HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER}`] = [snapshotMember];
+
+    const deps: Deps = {
+      blacklistingService: new FakeBlacklist(),
+      circlesRpc,
+      logger: new FakeLogger(true)
+    };
+
+    const cfg: RunConfig = {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: true
+    };
+
+    const outcome = await runOnce(deps, cfg);
+
+    expect(outcome.addressesQueuedForTrust).toEqual([trustedTarget]);
+    expect(outcome.addressesToUntrust).toEqual([]);
+    expect(outcome.untrustBatches).toEqual([]);
+  });
+
+  it("untrusts blacklisted historical auto-trust snapshot members", async () => {
+    const snapshotMember = getAddress("0xf00000000000000000000000000000000000000f");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [snapshotMember];
+    circlesRpc.activeGroupMembersAtBlock[`${historicAutoTrustGroup.toLowerCase()}@${HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER}`] = [snapshotMember];
+
+    const deps: Deps = {
+      blacklistingService: new FakeBlacklist(new Set([snapshotMember.toLowerCase()])),
+      circlesRpc,
+      logger: new FakeLogger(true)
+    };
+
+    const cfg: RunConfig = {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: true
+    };
+
+    const outcome = await runOnce(deps, cfg);
+
+    expect(outcome.addressesQueuedForTrust).toEqual([trustedTarget]);
+    expect(outcome.addressesToUntrust).toEqual([snapshotMember]);
+    expect(outcome.untrustBatches).toEqual([[snapshotMember]]);
+  });
+
+  it("throws when every backers-group trustee is blacklisted", async () => {
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [trustedTarget];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+
+    const deps: Deps = {
+      blacklistingService: new FakeBlacklist(new Set([trustedTarget.toLowerCase()])),
+      circlesRpc,
+      logger: new FakeLogger(true)
+    };
+
+    await expect(runOnce(deps, {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: true
+    })).rejects.toThrow("No non-blacklisted trusted addresses found in backers group");
+  });
+
+  it("uses cached scores and skips network scoring when the cache is warm", async () => {
+    const cached = getAddress("0x1111000000000000000000000000000000000011");
+    const scoreCache = new Map([[cached.toLowerCase(), {score: 88, fetchedAt: Date.now()}]]);
+    const deps: Deps = {
+      blacklistingService: new FakeBlacklist(),
+      circlesRpc: Object.assign(new FakeCirclesRpc(), {
+        humanAvatars: [cached],
+        trusteesByTruster: {
+          [circlesBackerGroup.toLowerCase()]: [trustedTarget],
+          [targetGroup.toLowerCase()]: []
+        }
+      }),
+      logger: new FakeLogger(true),
+      scoreCache: {
+        get: (address: string) => scoreCache.get(address.toLowerCase()),
+        set: jest.fn(),
+        getValidScore: (address: string) => scoreCache.get(address.toLowerCase())?.score,
+        get size() {
+          return scoreCache.size;
+        }
+      } as any
+    };
+
+    const outcome = await runOnce(deps, {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: true
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(outcome.scores[cached]).toBe(88);
+    expect(outcome.scoredAddresses).toBe(1);
+  });
+
+  it("reports when the scoring service returns no scores in live mode", async () => {
+    const candidate = getAddress("0x1515000000000000000000000000000000000015");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [candidate];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+    const logger = new FakeLogger(true);
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({status: "success", batches: {}})
+    });
+
+    const outcome = await runOnce({
+      blacklistingService: new FakeBlacklist(),
+      circlesRpc,
+      logger,
+      groupService: new FakeGroupService()
+    }, {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: false
+    });
+
+    expect(outcome.scoredAddresses).toBe(0);
+    expect(logger.logs.some((entry) =>
+      entry.level === "warn" && entry.args.some((arg) => String(arg).includes("returned no scores"))
+    )).toBe(true);
+  });
+
+  it("reports when the scoring service returns no scores in dry-run mode", async () => {
+    const candidate = getAddress("0x1717000000000000000000000000000000000017");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [candidate];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+    const logger = new FakeLogger(true);
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({status: "success", batches: {}})
+    });
+
+    const outcome = await runOnce({
+      blacklistingService: new FakeBlacklist(),
+      circlesRpc,
+      logger
+    }, {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: true
+    });
+
+    expect(outcome.scoredAddresses).toBe(0);
+    expect(logger.logs.some((entry) =>
+      entry.level === "info" && entry.args.some((arg) => String(arg).includes("returned no scores"))
+    )).toBe(true);
+  });
+
+  it("skips live scoring when no avatars survive blacklist evaluation", async () => {
+    const blocked = getAddress("0x1212000000000000000000000000000000000012");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [blocked];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+
+    const outcome = await runOnce({
+      blacklistingService: new FakeBlacklist(new Set([blocked.toLowerCase()])),
+      circlesRpc,
+      logger: new FakeLogger(true),
+      groupService: new FakeGroupService()
+    }, {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: false
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(outcome.allowedAvatars).toEqual([]);
+    expect(outcome.scoredAddresses).toBe(0);
+  });
+
+  it("treats missing blacklist verdicts as allowed", async () => {
+    const allowed = getAddress("0x1313000000000000000000000000000000000013");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [allowed];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+
+    const deps: Deps = {
+      blacklistingService: {
+        loadBlacklist: async () => undefined,
+        getBlacklistCount: () => 0,
+        checkBlacklist: async () => []
+      } as any,
+      circlesRpc,
+      logger: new FakeLogger(true)
+    };
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        status: "success",
+        batches: {"0": [{address: allowed, relative_score: 75}]}
+      })
+    });
+
+    const outcome = await runOnce(deps, {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: true
+    });
+
+    expect(outcome.allowedAvatars).toEqual([allowed]);
+  });
+
+  it("skips invalid allowed avatar addresses while summarizing threshold counts", async () => {
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = ["bad-address"];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({status: "success", batches: {}})
+    });
+
+    const outcome = await runOnce({
+      blacklistingService: new FakeBlacklist(),
+      circlesRpc,
+      logger: new FakeLogger(true)
+    }, {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: true
+    });
+
+    expect(outcome.allowedAvatars).toEqual(["bad-address"]);
+    expect(outcome.aboveThresholdCount).toBe(0);
+  });
+
+  it("surfaces string-based group service failures as unknown batch errors", async () => {
+    const eligible = getAddress("0x1414000000000000000000000000000000000014");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [eligible];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+
+    const deps: Deps = {
+      blacklistingService: new FakeBlacklist(),
+      circlesRpc,
+      logger: new FakeLogger(true),
+      groupService: {
+        trustBatchWithConditions: async () => {
+          throw "boom";
+        },
+        untrustBatch: async () => "0xnoop",
+        fetchGroupOwnerAndService: async () => {
+          throw new Error("not used");
+        }
+      }
+    };
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        status: "success",
+        batches: {"0": [{address: eligible, relative_score: 75}]}
+      })
+    });
+
+    jest.useFakeTimers();
+    try {
+      const runPromise = runOnce(deps, {
+        rpcUrl: "https://rpc.local",
+        scoringServiceUrl: "https://scores.local",
+        targetGroupAddress: targetGroup,
+        dryRun: false,
+        groupBatchSize: 1
+      });
+      const expectation = expect(runPromise).rejects.toThrow(/Unknown error while processing group batch/);
+      await jest.runOnlyPendingTimersAsync();
+      await jest.runOnlyPendingTimersAsync();
+      await expectation;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("retries blacklist failures before succeeding", async () => {
+    const candidate = getAddress("0x1616000000000000000000000000000000000016");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [candidate];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+
+    class FlakyBlacklist extends FakeBlacklist {
+      attempts = 0;
+      override async checkBlacklist(addresses: string[]) {
+        this.attempts += 1;
+        if (this.attempts < 3) {
+          const error = new Error("temporary network issue");
+          (error as any).code = "NETWORK_ERROR";
+          throw error;
+        }
+        return super.checkBlacklist(addresses);
+      }
+    }
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        status: "success",
+        batches: {"0": [{address: candidate, relative_score: 75}]}
+      })
+    });
+
+    const blacklistingService = new FlakyBlacklist();
+    await runOnce({
+      blacklistingService,
+      circlesRpc,
+      logger: new FakeLogger(true)
+    }, {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: true
+    });
+
+    expect(blacklistingService.attempts).toBe(3);
+  });
+
+  it("retries relative trust score fetches before succeeding", async () => {
+    const candidate = getAddress("0x1818000000000000000000000000000000000018");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [candidate];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockRejectedValueOnce(Object.assign(new Error("network"), {code: "NETWORK_ERROR"}))
+      .mockRejectedValueOnce(Object.assign(new Error("network"), {code: "NETWORK_ERROR"}))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          status: "success",
+          batches: {"0": [{address: candidate, relative_score: 75}]}
+        })
+      });
+
+    jest.useFakeTimers();
+    try {
+      const runPromise = runOnce({
+        blacklistingService: new FakeBlacklist(),
+        circlesRpc,
+        logger: new FakeLogger(true)
+      }, {
+        rpcUrl: "https://rpc.local",
+        scoringServiceUrl: "https://scores.local",
+        targetGroupAddress: targetGroup,
+        dryRun: true
+      });
+      await jest.runOnlyPendingTimersAsync();
+      await jest.runOnlyPendingTimersAsync();
+      const outcome = await runPromise;
+      expect(outcome.scores[candidate]).toBe(75);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("wraps terminal string scoring failures in an Error", async () => {
+    const candidate = getAddress("0x1919000000000000000000000000000000000019");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [candidate];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockRejectedValue("boom");
+
+    jest.useFakeTimers();
+    try {
+      const runPromise = runOnce({
+        blacklistingService: new FakeBlacklist(),
+        circlesRpc,
+        logger: new FakeLogger(true)
+      }, {
+        rpcUrl: "https://rpc.local",
+        scoringServiceUrl: "https://scores.local",
+        targetGroupAddress: targetGroup,
+        dryRun: true
+      });
+      const expectation = expect(runPromise).rejects.toThrow("boom");
+      await jest.runOnlyPendingTimersAsync();
+      await jest.runOnlyPendingTimersAsync();
+      await expectation;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("wraps terminal string blacklist failures in an Error", async () => {
+    const candidate = getAddress("0x1A1A00000000000000000000000000000000001A");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [candidate];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+
+    const blacklistingService = {
+      loadBlacklist: async () => undefined,
+      getBlacklistCount: () => 0,
+      checkBlacklist: async () => {
+        throw "boom";
+      }
+    };
+
+    jest.useFakeTimers();
+    try {
+      const runPromise = runOnce({
+        blacklistingService: blacklistingService as any,
+        circlesRpc,
+        logger: new FakeLogger(true)
+      }, {
+        rpcUrl: "https://rpc.local",
+        scoringServiceUrl: "https://scores.local",
+        targetGroupAddress: targetGroup,
+        dryRun: true
+      });
+      const expectation = expect(runPromise).rejects.toThrow("boom");
+      await jest.runOnlyPendingTimersAsync();
+      await jest.runOnlyPendingTimersAsync();
+      await expectation;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("does not prepare trust batches when the target group already satisfies the plan", async () => {
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [trustedTarget];
+
+    const outcome = await runOnce({
+      blacklistingService: new FakeBlacklist(),
+      circlesRpc,
+      logger: new FakeLogger(true)
+    }, {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: true
+    });
+
+    expect(outcome.trustBatches).toEqual([]);
+    expect(outcome.addressesQueuedForTrust).toEqual([]);
   });
 });

--- a/tests/apps/gnosis-group/runOnce.spec.ts
+++ b/tests/apps/gnosis-group/runOnce.spec.ts
@@ -534,6 +534,43 @@ describe("gnosis-group runOnce", () => {
     expect(outcome.untrustTxHashes).toEqual([]);
   });
 
+  it("simulates dry-run trust batches when a group service is provided", async () => {
+    const eligible = getAddress("0x5555000000000000000000000000000000000005");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [eligible];
+    circlesRpc.trusteesByTruster[circlesBackerGroup.toLowerCase()] = [trustedTarget];
+    circlesRpc.trusteesByTruster[targetGroup.toLowerCase()] = [];
+    const groupService = new FakeGroupService();
+
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        status: "success",
+        batches: {"0": [{address: eligible, relative_score: 75}]}
+      })
+    });
+
+    const outcome = await runOnce({
+      blacklistingService: new FakeBlacklist(),
+      circlesRpc,
+      logger: new FakeLogger(true),
+      groupService
+    }, {
+      rpcUrl: "https://rpc.local",
+      scoringServiceUrl: "https://scores.local",
+      targetGroupAddress: targetGroup,
+      dryRun: true,
+      groupBatchSize: 1
+    });
+
+    expect(outcome.trustTxHashes).toEqual([]);
+    expect(groupService.calls).toHaveLength(0);
+    expect(groupService.trustSimulations).toBe(1);
+  });
+
   it("summarizes failed untrust batches after exhausting retries", async () => {
     const stale = getAddress("0xe00000000000000000000000000000000000000e");
     const active = getAddress("0xf00000000000000000000000000000000000000f");

--- a/tests/apps/gp-crc/logic.spec.ts
+++ b/tests/apps/gp-crc/logic.spec.ts
@@ -1,5 +1,5 @@
 import {getAddress} from "ethers";
-import {runOnce, type Deps, type RunConfig} from "../../../src/apps/gp-crc/logic";
+import {runOnce, type Deps, type RunConfig, __testables} from "../../../src/apps/gp-crc/logic";
 import {
   FakeAvatarSafeService,
   FakeAvatarSafeMappingStore,
@@ -8,6 +8,18 @@ import {
   FakeGroupService,
   FakeLogger
 } from "../../../fakes/fakes";
+
+const {
+  compareTimestamp,
+  formatErrorMessage,
+  isBlacklisted,
+  isRetryableFetchError,
+  isRetryableTrustError,
+  normalizeAddress,
+  normalizeSwitchCount,
+  toComparableBigInt,
+  uniqueNormalizedAddresses
+} = __testables;
 
 const RPC_URL = "https://rpc.stub";
 const GROUP_ADDRESS = "0x1000000000000000000000000000000000000000";
@@ -401,5 +413,468 @@ describe("gp-crc runOnce (query-based)", () => {
       trustedTimestamp: "300",
       switchCount: 2
     });
+  });
+
+  it("returns early when neither human avatars nor trustees produce evaluation candidates", async () => {
+    const circlesRpc = new FakeCirclesRpc();
+    const outcome = await runOnce(makeDeps({circlesRpc}), makeConfig({dryRun: true, fetchPageSize: 0, groupBatchSize: 0}));
+
+    expect(outcome.uniqueAvatarCount).toBe(0);
+    expect(outcome.allowedAvatars).toEqual([]);
+    expect(outcome.trustedAvatars).toEqual([]);
+  });
+
+  it("uses default fetch and batch sizes when config leaves them undefined", async () => {
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = ["0x6767000000000000000000000000000000000000"];
+
+    const outcome = await runOnce(
+      makeDeps({circlesRpc}),
+      makeConfig({dryRun: true, fetchPageSize: undefined, groupBatchSize: undefined})
+    );
+
+    expect(outcome.uniqueAvatarCount).toBe(1);
+  });
+
+  it("ignores invalid trustee addresses returned from the group service", async () => {
+    const validAvatar = "0x6666000000000000000000000000000000000000";
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [validAvatar];
+    circlesRpc.trusteesByTruster[GROUP_ADDRESS.toLowerCase()] = ["bad-address"];
+
+    const outcome = await runOnce(makeDeps({circlesRpc}), makeConfig({dryRun: true}));
+
+    expect(outcome.allowedAvatars).toEqual([getAddress(validAvatar)]);
+  });
+
+  it("updates safe state when the same avatar remains selected for a safe", async () => {
+    const avatarInput = "0x7777000000000000000000000000000000000000";
+    const sharedSafe = "0xSAFE000000000000000000000000000000000777";
+    const avatar = getAddress(avatarInput);
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [avatarInput];
+    const avatarSafeService = new FakeAvatarSafeService({
+      [avatarInput]: {safe: sharedSafe, timestamp: "2025-03-01T00:00:00.000Z"}
+    });
+    const mappingStore = new FakeAvatarSafeMappingStore(
+      {[avatarInput]: sharedSafe},
+      {
+        [sharedSafe]: {
+          trustedAvatar: avatar,
+          trustedTimestamp: "2025-02-01T00:00:00.000Z",
+          switchCount: Number.NaN
+        }
+      }
+    );
+
+    await runOnce(
+      makeDeps({circlesRpc, avatarSafeService, avatarSafeMappingStore: mappingStore}),
+      makeConfig({dryRun: true})
+    );
+
+    expect(mappingStore.getSavedSafeTrustState().get(sharedSafe)).toEqual({
+      trustedAvatar: avatar,
+      trustedTimestamp: "2025-03-01T00:00:00.000Z",
+      switchCount: 0
+    });
+  });
+
+  it("keeps the previous trusted timestamp when the same avatar is selected with an older timestamp", async () => {
+    const avatarInput = "0x7878000000000000000000000000000000000001";
+    const sharedSafe = "0xSAFE000000000000000000000000000000000781";
+    const avatar = getAddress(avatarInput);
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [avatarInput];
+    const avatarSafeService = new FakeAvatarSafeService({
+      [avatarInput]: {safe: sharedSafe, timestamp: "100"}
+    });
+    const mappingStore = new FakeAvatarSafeMappingStore(
+      {[avatarInput]: sharedSafe},
+      {
+        [sharedSafe]: {
+          trustedAvatar: avatar,
+          trustedTimestamp: "200",
+          switchCount: 1
+        }
+      }
+    );
+
+    await runOnce(
+      makeDeps({circlesRpc, avatarSafeService, avatarSafeMappingStore: mappingStore}),
+      makeConfig({dryRun: true})
+    );
+
+    expect(mappingStore.getSavedSafeTrustState().get(sharedSafe)).toEqual({
+      trustedAvatar: avatar,
+      trustedTimestamp: "200",
+      switchCount: 1
+    });
+  });
+
+  it("preserves the existing switch count when the same avatar stays trusted without a prior timestamp", async () => {
+    const avatarInput = "0x7979000000000000000000000000000000000000";
+    const sharedSafe = "0xSAFE000000000000000000000000000000000779";
+    const avatar = getAddress(avatarInput);
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [avatarInput];
+    const avatarSafeService = new FakeAvatarSafeService({
+      [avatarInput]: {safe: sharedSafe, timestamp: "250"}
+    });
+    const mappingStore = new FakeAvatarSafeMappingStore(
+      {[avatarInput]: sharedSafe},
+      {
+        [sharedSafe]: {
+          trustedAvatar: avatar,
+          trustedTimestamp: "" as any,
+          switchCount: 1
+        }
+      }
+    );
+
+    await runOnce(
+      makeDeps({circlesRpc, avatarSafeService, avatarSafeMappingStore: mappingStore}),
+      makeConfig({dryRun: true})
+    );
+
+    expect(mappingStore.getSavedSafeTrustState().get(sharedSafe)).toEqual({
+      trustedAvatar: avatar,
+      trustedTimestamp: "250",
+      switchCount: 1
+    });
+  });
+
+  it("keeps the selected avatar and timestamp when a stored mapping exists without prior safe state", async () => {
+    const avatarInput = "0x7878000000000000000000000000000000000000";
+    const sharedSafe = "0xSAFE000000000000000000000000000000000778";
+    const avatar = getAddress(avatarInput);
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [avatarInput];
+    const avatarSafeService = new FakeAvatarSafeService({
+      [avatarInput]: {safe: sharedSafe, timestamp: "200"}
+    });
+    const mappingStore = new FakeAvatarSafeMappingStore({[avatarInput]: sharedSafe});
+
+    await runOnce(
+      makeDeps({circlesRpc, avatarSafeService, avatarSafeMappingStore: mappingStore}),
+      makeConfig({dryRun: true})
+    );
+
+    expect(mappingStore.getSavedSafeTrustState().get(sharedSafe)).toEqual({
+      trustedAvatar: avatar,
+      trustedTimestamp: "200",
+      switchCount: 0
+    });
+  });
+
+  it("keeps the mapped owner when there is no prior safe trust timestamp to compare against", async () => {
+    const oldAvatarInput = "0x7A7A000000000000000000000000000000000000";
+    const newAvatarInput = "0x7B7B000000000000000000000000000000000000";
+    const sharedSafe = "0xSAFE00000000000000000000000000000000077A";
+    const oldAvatar = getAddress(oldAvatarInput);
+    const newAvatar = getAddress(newAvatarInput);
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [newAvatarInput];
+    circlesRpc.trusteesByTruster[GROUP_ADDRESS.toLowerCase()] = [oldAvatarInput];
+    const avatarSafeService = new FakeAvatarSafeService({
+      [newAvatarInput]: {safe: sharedSafe, timestamp: "300"}
+    });
+    const mappingStore = new FakeAvatarSafeMappingStore({[oldAvatarInput]: sharedSafe});
+
+    const outcome = await runOnce(
+      makeDeps({circlesRpc, avatarSafeService, avatarSafeMappingStore: mappingStore}),
+      makeConfig({dryRun: true})
+    );
+
+    expect(outcome.safeReassignmentUntrustedAvatars).toEqual([]);
+    expect(mappingStore.getSavedSafeTrustState().get(sharedSafe)).toEqual({
+      trustedAvatar: oldAvatar,
+      trustedTimestamp: "300",
+      switchCount: 0
+    });
+  });
+
+  it("treats missing blacklist verdicts as allowed", async () => {
+    const avatarInput = "0x8888000000000000000000000000000000000000";
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [avatarInput];
+
+    const blacklistingService = {
+      loadBlacklist: async () => undefined,
+      getBlacklistCount: () => 0,
+      checkBlacklist: async () => []
+    };
+
+    const outcome = await runOnce(
+      makeDeps({circlesRpc, blacklistingService: blacklistingService as any}),
+      makeConfig({dryRun: true})
+    );
+
+    expect(outcome.allowedAvatars).toEqual([getAddress(avatarInput)]);
+  });
+
+  it("persists a first-time safe owner when no previous mapping exists", async () => {
+    const avatarInput = "0x8989000000000000000000000000000000000000";
+    const sharedSafe = "0xSAFE000000000000000000000000000000000898";
+    const avatar = getAddress(avatarInput);
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [avatarInput];
+    const avatarSafeService = new FakeAvatarSafeService({
+      [avatarInput]: {safe: sharedSafe, timestamp: "123"}
+    });
+    const mappingStore = new FakeAvatarSafeMappingStore();
+
+    await runOnce(
+      makeDeps({circlesRpc, avatarSafeService, avatarSafeMappingStore: mappingStore}),
+      makeConfig({dryRun: true})
+    );
+
+    expect(mappingStore.getSavedSafeTrustState().get(sharedSafe)).toEqual({
+      trustedAvatar: avatar,
+      trustedTimestamp: "123",
+      switchCount: 0
+    });
+  });
+
+  it("logs dry-run untrust batches when trusted avatars are no longer eligible", async () => {
+    const avatarInput = "0xA0A0000000000000000000000000000000000000";
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.trusteesByTruster[GROUP_ADDRESS.toLowerCase()] = [avatarInput];
+    const groupService = new FakeGroupService();
+
+    const outcome = await runOnce(
+      makeDeps({
+        circlesRpc,
+        avatarSafeService: new FakeAvatarSafeService({}),
+        groupService
+      }),
+      makeConfig({dryRun: true})
+    );
+
+    expect(outcome.untrustedAvatars).toEqual([getAddress(avatarInput)]);
+    expect(groupService.calls).toHaveLength(0);
+  });
+
+  it("surfaces non-retryable trust failures immediately", async () => {
+    const avatarInput = "0x9999000000000000000000000000000000000000";
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [avatarInput];
+
+    class FatalTrustGroupService extends FakeGroupService {
+      override async trustBatchWithConditions(): Promise<string> {
+        const error = new Error("insufficient funds");
+        (error as any).code = "INSUFFICIENT_FUNDS";
+        throw error;
+      }
+    }
+
+    await expect(
+      runOnce(
+        makeDeps({circlesRpc, groupService: new FatalTrustGroupService()}),
+        makeConfig()
+      )
+    ).rejects.toThrow("insufficient funds");
+  });
+
+  it("wraps string trust failures in an Error", async () => {
+    const avatarInput = "0x9A9A000000000000000000000000000000000000";
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [avatarInput];
+
+    class StringTrustGroupService extends FakeGroupService {
+      override async trustBatchWithConditions(): Promise<string> {
+        throw "boom";
+      }
+    }
+
+    await expect(
+      runOnce(
+        makeDeps({circlesRpc, groupService: new StringTrustGroupService()}),
+        makeConfig()
+      )
+    ).rejects.toThrow("boom");
+  });
+
+  it("surfaces non-retryable untrust failures immediately", async () => {
+    const avatarInput = "0xAAAA000000000000000000000000000000000000";
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.trusteesByTruster[GROUP_ADDRESS.toLowerCase()] = [avatarInput];
+
+    class FatalUntrustGroupService extends FakeGroupService {
+      override async untrustBatch(): Promise<string> {
+        const error = new Error("fatal");
+        (error as any).code = "CALL_EXCEPTION";
+        throw error;
+      }
+    }
+
+    await expect(
+      runOnce(
+        makeDeps({
+          circlesRpc,
+          avatarSafeService: new FakeAvatarSafeService({}),
+          groupService: new FatalUntrustGroupService()
+        }),
+        makeConfig()
+      )
+    ).rejects.toThrow("fatal");
+  });
+
+  it("wraps string untrust failures in an Error", async () => {
+    const avatarInput = "0xABAB000000000000000000000000000000000000";
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.trusteesByTruster[GROUP_ADDRESS.toLowerCase()] = [avatarInput];
+
+    class StringUntrustGroupService extends FakeGroupService {
+      override async untrustBatch(): Promise<string> {
+        throw "boom";
+      }
+    }
+
+    await expect(
+      runOnce(
+        makeDeps({
+          circlesRpc,
+          avatarSafeService: new FakeAvatarSafeService({}),
+          groupService: new StringUntrustGroupService()
+        }),
+        makeConfig()
+      )
+    ).rejects.toThrow("boom");
+  });
+
+  it("surfaces non-retryable blacklist failures", async () => {
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = ["0xBBBB000000000000000000000000000000000000"];
+
+    const blacklistingService = {
+      loadBlacklist: async () => undefined,
+      getBlacklistCount: () => 0,
+      checkBlacklist: async () => {
+        throw new Error("permanent");
+      }
+    };
+
+    await expect(
+      runOnce(
+        makeDeps({circlesRpc, blacklistingService: blacklistingService as any}),
+        makeConfig({dryRun: true})
+      )
+    ).rejects.toThrow("permanent");
+  });
+
+  it("wraps string blacklist failures in an Error", async () => {
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = ["0xBCBC000000000000000000000000000000000000"];
+
+    const blacklistingService = {
+      loadBlacklist: async () => undefined,
+      getBlacklistCount: () => 0,
+      checkBlacklist: async () => {
+        throw "boom";
+      }
+    };
+
+    await expect(
+      runOnce(
+        makeDeps({circlesRpc, blacklistingService: blacklistingService as any}),
+        makeConfig({dryRun: true})
+      )
+    ).rejects.toThrow("boom");
+  });
+
+  it("retries untrust batches on retryable errors before succeeding", async () => {
+    const avatarInput = "0xACAC000000000000000000000000000000000000";
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.trusteesByTruster[GROUP_ADDRESS.toLowerCase()] = [avatarInput];
+
+    class FlakyUntrustGroupService extends FakeGroupService {
+      attempts = 0;
+      override async untrustBatch(groupAddress: string, trusteeAddresses: string[]): Promise<string> {
+        this.attempts += 1;
+        if (this.attempts === 1) {
+          const error = new Error("temporary network issue");
+          (error as any).code = "NETWORK_ERROR";
+          throw error;
+        }
+        return super.untrustBatch(groupAddress, trusteeAddresses);
+      }
+    }
+
+    const groupService = new FlakyUntrustGroupService();
+    const outcome = await runOnce(
+      makeDeps({
+        circlesRpc,
+        avatarSafeService: new FakeAvatarSafeService({}),
+        groupService
+      }),
+      makeConfig()
+    );
+
+    expect(groupService.attempts).toBe(2);
+    expect(outcome.untrustTxHashes).toEqual(["0xuntrust_1"]);
+  });
+});
+
+describe("gp-crc helpers", () => {
+  it("normalizes, deduplicates, and skips invalid addresses", () => {
+    const first = getAddress("0x1000000000000000000000000000000000000100");
+    const second = getAddress("0x1000000000000000000000000000000000000101");
+
+    expect(normalizeAddress("")).toBeNull();
+    expect(normalizeAddress("not-an-address")).toBeNull();
+    expect(uniqueNormalizedAddresses([first, first.toLowerCase(), "bad-address", second])).toEqual([
+      first,
+      second
+    ]);
+  });
+
+  it("classifies retryable fetch errors", () => {
+    expect(isRetryableFetchError("temporary")).toBe(true);
+    expect(isRetryableFetchError({name: "AbortError"})).toBe(true);
+    expect(isRetryableFetchError({code: "NETWORK_ERROR"})).toBe(true);
+    expect(isRetryableFetchError({message: "network timeout"})).toBe(true);
+    expect(isRetryableFetchError({message: "fatal"})).toBe(false);
+  });
+
+  it("classifies retryable trust errors", () => {
+    expect(isRetryableTrustError("temporary")).toBe(true);
+    expect(isRetryableTrustError({code: "NETWORK_ERROR"})).toBe(true);
+    expect(isRetryableTrustError({message: "temporary network timeout"})).toBe(true);
+    expect(isRetryableTrustError({message: "nonce too low"})).toBe(false);
+    expect(isRetryableTrustError({code: "CALL_EXCEPTION"})).toBe(false);
+    expect(isRetryableTrustError({message: "fatal"})).toBe(false);
+  });
+
+  it("formats errors and compares timestamps across numeric, date, and string values", () => {
+    const circular: any = {};
+    circular.self = circular;
+
+    expect(formatErrorMessage(new Error("boom"))).toBe("boom");
+    expect(formatErrorMessage("plain")).toBe("plain");
+    expect(formatErrorMessage(circular)).toBe("[object Object]");
+
+    expect(normalizeSwitchCount(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(normalizeSwitchCount(2.9)).toBe(2);
+
+    expect(compareTimestamp("10", "10")).toBe(0);
+    expect(compareTimestamp("11", "10")).toBe(1);
+    expect(compareTimestamp("2025-03-01T00:00:00.000Z", "2025-02-01T00:00:00.000Z")).toBe(1);
+    expect(compareTimestamp("beta", "alpha")).toBe(1);
+
+    expect(toComparableBigInt("42")).toBe(42n);
+    expect(toComparableBigInt("2025-03-01T00:00:00.000Z")).not.toBeNull();
+    expect(toComparableBigInt("not-a-date")).toBeNull();
+  });
+
+  it("classifies blacklist verdicts consistently", () => {
+    expect(isBlacklisted({address: "0x1", is_bot: true} as any)).toBe(true);
+    expect(isBlacklisted({address: "0x1", is_bot: false, category: "flagged"} as any)).toBe(true);
+    expect(isBlacklisted({address: "0x1", is_bot: false} as any)).toBe(false);
   });
 });

--- a/tests/apps/gp-crc/logic.spec.ts
+++ b/tests/apps/gp-crc/logic.spec.ts
@@ -160,6 +160,7 @@ describe("gp-crc runOnce (query-based)", () => {
     expect(outcome.trustedAvatars).toEqual([avatar]);
     expect(outcome.trustTxHashes).toEqual([]);
     expect(groupService.calls).toHaveLength(0);
+    expect(groupService.trustSimulations).toBe(1);
   });
 
   it("retries trust batches on retryable errors before succeeding", async () => {

--- a/tests/apps/oic/logic.spec.ts
+++ b/tests/apps/oic/logic.spec.ts
@@ -165,6 +165,48 @@ describe("oic.runOnce", () => {
     expect(grp.calls.length).toBe(1);
     expect(grp.calls[0].trusteeAddresses.map(x => x.toLowerCase()).sort()).toEqual([extra]);
   });
+
+  it("logs dry-run untrust details without calling the group service", async () => {
+    const deps = makeDeps();
+    const cfg = makeCfg({dryRun: true});
+    const rpc = deps.circlesRpc as FakeCirclesRpc;
+    const grp = deps.groupService as FakeGroupService;
+    const logger = deps.logger as FakeLogger;
+
+    const stale = "0xC0FFEE".padEnd(42, "0");
+    rpc.trusteesByTruster[META_ORG.toLowerCase()] = [];
+    rpc.trusteesByTruster[GROUP.toLowerCase()] = [
+      stale,
+      ...Array.from(ALWAYS_TRUSTED_ADDRESSES),
+    ];
+
+    await runOnce(deps, cfg);
+
+    expect(grp.calls).toHaveLength(0);
+    const infoMessages = logger.logs
+      .filter((entry) => entry.level === "info")
+      .flatMap((entry) => entry.args.map((arg) => String(arg)));
+    expect(infoMessages.some((message) =>
+      message.includes("DRY RUN untrust:") && message.toLowerCase().includes(stale.toLowerCase())
+    )).toBe(true);
+  });
+
+  it("skips affiliate fetches when the deployment block is still ahead of the safe head", async () => {
+    const deps = makeDeps();
+    const cfg = makeCfg({deployedAtBlock: HEAD.blockNumber + 100});
+    const registry = deps.affiliateRegistry as FakeAffiliateGroupEvents;
+    const rpc = deps.circlesRpc as FakeCirclesRpc;
+
+    rpc.trusteesByTruster[META_ORG.toLowerCase()] = [];
+    rpc.trusteesByTruster[GROUP.toLowerCase()] = [];
+    registry.events = [
+      mkAffJoin("0xA".padEnd(42, "0"), GROUP, {blockNumber: HEAD.blockNumber + 101, txHash: "0xskip"}),
+    ];
+
+    await runOnce(deps, cfg);
+
+    expect((deps.groupService as FakeGroupService).calls).toHaveLength(1);
+  });
 });
 
 describe("oic.runIncremental", () => {
@@ -263,5 +305,27 @@ describe("oic.runIncremental", () => {
     // First untrust C, then trust A
     expect(grp.calls[0].trusteeAddresses.map(x => x.toLowerCase())).toEqual([C.toLowerCase()]);
     expect(grp.calls[1].trusteeAddresses.map(x => x.toLowerCase())).toEqual([A.toLowerCase()]);
+  });
+
+  it("logs an empty incremental scan when the range advances but no affiliate events are found", async () => {
+    const state: IncrementalState = {
+      initialized: true,
+      lastSafeHeadScanned: SAFE_HEAD - 1,
+      affiliates: new Set<string>(),
+    };
+    const deps = makeDeps();
+    const logger = deps.logger as FakeLogger;
+    const rpc = deps.circlesRpc as FakeCirclesRpc;
+
+    rpc.trusteesByTruster[META_ORG.toLowerCase()] = [];
+    rpc.trusteesByTruster[GROUP.toLowerCase()] = [];
+
+    await runIncremental(deps, makeCfg(), state);
+
+    const infoMessages = logger.logs
+      .filter((entry) => entry.level === "info")
+      .flatMap((entry) => entry.args.map((arg) => String(arg)));
+    expect(infoMessages).toContain("AffiliateGroupChanged affecting group: total=0 added=0 removed=0");
+    expect(state.lastSafeHeadScanned).toBe(SAFE_HEAD);
   });
 });

--- a/tests/apps/oic/logic.spec.ts
+++ b/tests/apps/oic/logic.spec.ts
@@ -130,6 +130,7 @@ describe("oic.runOnce", () => {
 
     await runOnce(deps, cfg);
     expect(grp.calls.length).toBe(0);
+    expect(grp.trustSimulations).toBe(1);
   });
 
   it("always trusts whitelisted addresses even without meta org coverage", async () => {

--- a/tests/apps/router-tms/logic.spec.ts
+++ b/tests/apps/router-tms/logic.spec.ts
@@ -3,7 +3,8 @@ import {
   runOnce,
   type Deps,
   type RunConfig,
-  DEFAULT_BASE_GROUP_ADDRESS
+  DEFAULT_BASE_GROUP_ADDRESS,
+  __testables
 } from "../../../src/apps/router-tms/logic";
 import {
   FakeBlacklist,
@@ -12,6 +13,17 @@ import {
   FakeRouterService,
   FakeRouterEnablementStore
 } from "../../../fakes/fakes";
+
+const {
+  buildAvatarBaseGroupAssignments,
+  buildBaseGroupEnableTargets,
+  chunkArray,
+  createIsHumanChecker,
+  filterHumanAvatars,
+  normalizeAddress,
+  normalizeAddressArray,
+  validateEnableTargets
+} = __testables;
 
 const ROUTER_ADDRESS = "0xDC287474114cC0551a81DdC2EB51783fBF34802F";
 
@@ -58,6 +70,13 @@ describe("router-tms runOnce", () => {
     const cfg = makeConfig({dryRun: false});
 
     await expect(runOnce(deps, cfg)).rejects.toThrow("Router service dependency is required");
+  });
+
+  it("throws when configured base group address is invalid", async () => {
+    const deps = makeDeps();
+    const cfg = makeConfig({baseGroupAddress: "not-an-address"});
+
+    await expect(runOnce(deps, cfg)).rejects.toThrow("Invalid base group address configured");
   });
 
   it("enables routing for every allowed non-blacklisted human avatar", async () => {
@@ -111,13 +130,32 @@ describe("router-tms runOnce", () => {
     circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
 
     const deps = makeDeps({circlesRpc});
-    const cfg = makeConfig({dryRun: true});
+    const cfg = makeConfig({dryRun: true, enableBatchSize: 0, fetchPageSize: 0});
 
     const outcome = await runOnce(deps, cfg);
 
     expect(outcome.pendingEnableCount).toBe(2);
     expect(outcome.executedEnableCount).toBe(0);
     expect(outcome.txHashes).toEqual([]);
+  });
+
+  it("uses default config values when optional settings are omitted", async () => {
+    const humanAlice = getAddress("0x2000000000000000000000000000000000000012");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [humanAlice];
+    circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
+
+    const outcome = await runOnce(
+      makeDeps({circlesRpc}),
+      makeConfig({
+        dryRun: true,
+        baseGroupAddress: undefined,
+        enableBatchSize: undefined,
+        fetchPageSize: undefined
+      })
+    );
+
+    expect(outcome.pendingEnableCount).toBe(1);
   });
 
   it("skips avatars flagged as non-human by the hub before enabling routing", async () => {
@@ -254,5 +292,210 @@ describe("router-tms runOnce", () => {
     expect(secondOutcome.executedEnableCount).toBe(0);
     expect(secondOutcome.txHashes).toEqual([]);
     expect(routerService.calls).toHaveLength(1);
+  });
+
+  it("returns no pending enablement when every candidate is already trusted or blacklisted", async () => {
+    const humanTrusted = getAddress("0x2000000000000000000000000000000000000700");
+    const humanBlocked = getAddress("0x2000000000000000000000000000000000000701");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [humanTrusted, humanBlocked];
+    circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [humanTrusted];
+
+    const deps = makeDeps({
+      circlesRpc,
+      blacklistingService: new FakeBlacklist(new Set(), new Set([humanBlocked.toLowerCase()]))
+    });
+
+    const outcome = await runOnce(deps, makeConfig({dryRun: true}));
+
+    expect(outcome.pendingEnableCount).toBe(0);
+    expect(outcome.executedEnableCount).toBe(0);
+    expect(outcome.txHashes).toEqual([]);
+  });
+
+  it("treats missing blacklist verdicts as allowed", async () => {
+    const humanAlice = getAddress("0x2000000000000000000000000000000000000800");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [humanAlice];
+
+    const blacklistingService = {
+      loadBlacklist: async () => undefined,
+      getBlacklistCount: () => 0,
+      checkBlacklist: async () => []
+    };
+
+    const outcome = await runOnce(
+      makeDeps({circlesRpc, blacklistingService: blacklistingService as any}),
+      makeConfig({dryRun: true})
+    );
+
+    expect(outcome.allowedHumanCount).toBe(1);
+    expect(outcome.blacklistedHumanCount).toBe(0);
+    expect(outcome.pendingEnableCount).toBe(1);
+  });
+
+  it("throws when the configured default base group is classified as human", async () => {
+    const circlesRpc = new FakeCirclesRpc();
+    const deps = makeDeps({circlesRpc});
+    circlesRpc.humanityOverrides.set(DEFAULT_BASE_GROUP_ADDRESS.toLowerCase(), true);
+
+    await expect(runOnce(deps, makeConfig({dryRun: true}))).rejects.toThrow(
+      "Base group"
+    );
+  });
+
+  it("skips non-default base groups classified as humans and still processes fallback targets", async () => {
+    const baseGroup = getAddress("0xA0000000000000000000000000000000000000BB");
+    const assignedAvatar = getAddress("0x2000000000000000000000000000000000000900");
+    const fallbackAvatar = getAddress("0x2000000000000000000000000000000000000901");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [assignedAvatar, fallbackAvatar];
+    circlesRpc.baseGroups = [baseGroup];
+    circlesRpc.trusteesByTruster[baseGroup.toLowerCase()] = [assignedAvatar];
+    circlesRpc.humanityOverrides.set(baseGroup.toLowerCase(), true);
+
+    const outcome = await runOnce(makeDeps({circlesRpc}), makeConfig({dryRun: true}));
+
+    expect(outcome.pendingEnableCount).toBe(1);
+  });
+
+  it("throws when a fallback target contains an invalid avatar address", async () => {
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = ["not-an-address"];
+
+    await expect(runOnce(makeDeps({circlesRpc}), makeConfig({dryRun: true}))).rejects.toThrow(
+      "Invalid address passed to isHuman check"
+    );
+  });
+});
+
+describe("router-tms helpers", () => {
+  it("normalizes addresses and removes invalid or duplicate values", () => {
+    const first = getAddress("0x2000000000000000000000000000000000000A00");
+    const second = getAddress("0x2000000000000000000000000000000000000A01");
+
+    expect(normalizeAddress(null as any)).toBeUndefined();
+    expect(normalizeAddress("bad-address")).toBeUndefined();
+    expect(normalizeAddressArray([first, first.toLowerCase(), "bad-address", second])).toEqual([
+      first.toLowerCase(),
+      second.toLowerCase()
+    ]);
+  });
+
+  it("chunks values and keeps zero-sized chunks as a single batch", () => {
+    expect(chunkArray([1, 2, 3], 2)).toEqual([[1, 2], [3]]);
+    expect(chunkArray([1, 2, 3], 0)).toEqual([[1, 2, 3]]);
+  });
+
+  it("caches humanity lookups and clears the cache on failures", async () => {
+    const circlesRpc = new FakeCirclesRpc();
+    const human = getAddress("0x2000000000000000000000000000000000000B00");
+    const flaky = getAddress("0x2000000000000000000000000000000000000B01");
+    class FlakyCirclesRpc extends FakeCirclesRpc {
+      override async isHuman(address: string): Promise<boolean> {
+        if (address === flaky.toLowerCase()) {
+          throw new Error("temporary");
+        }
+        return super.isHuman(address);
+      }
+    }
+
+    const checker = createIsHumanChecker(Object.assign(new FlakyCirclesRpc(), circlesRpc));
+
+    await expect(checker("bad-address")).rejects.toThrow("Invalid address passed to isHuman check");
+    await expect(checker(flaky)).rejects.toThrow("temporary");
+    await expect(checker(flaky)).rejects.toThrow("temporary");
+
+    expect(await checker(human)).toBe(true);
+    expect(await checker(human)).toBe(true);
+  });
+
+  it("filters human avatars and groups eligible base group assignments", async () => {
+    const humanA = getAddress("0x2000000000000000000000000000000000000C00");
+    const humanB = getAddress("0x2000000000000000000000000000000000000C01");
+    const baseGroup = getAddress("0xA0000000000000000000000000000000000000CC");
+    const result = await filterHumanAvatars(
+      [humanA, humanB],
+      async (address) => address === humanA,
+      1
+    );
+
+    expect(result).toEqual({humans: [humanA], nonHumans: [humanB]});
+
+    const grouped = buildBaseGroupEnableTargets(
+      new Map([
+        [humanA, baseGroup.toLowerCase()],
+        [humanB, baseGroup.toLowerCase()],
+        [getAddress("0x2000000000000000000000000000000000000C02"), baseGroup.toLowerCase()]
+      ]),
+      new Set([humanA, humanB, getAddress("0x2000000000000000000000000000000000000C02")]),
+      new Set([humanB]),
+      (avatar) => avatar !== getAddress("0x2000000000000000000000000000000000000C02")
+    );
+
+    expect(grouped.targets).toEqual([
+      {baseGroup: baseGroup.toLowerCase(), addresses: [humanA], source: "base-group"}
+    ]);
+    expect(grouped.scheduledAvatars).toEqual(new Set([humanA]));
+  });
+
+  it("creates grouped enable targets for eligible avatars", () => {
+    const baseGroup = getAddress("0xA0000000000000000000000000000000000000DE").toLowerCase();
+    const avatarA = getAddress("0x2000000000000000000000000000000000000F00").toLowerCase();
+    const avatarB = getAddress("0x2000000000000000000000000000000000000F01").toLowerCase();
+
+    const grouped = buildBaseGroupEnableTargets(
+      new Map([
+        [avatarA, baseGroup],
+        [avatarB, baseGroup]
+      ]),
+      new Set([avatarA, avatarB]),
+      new Set(),
+      () => true
+    );
+
+    expect(grouped.targets).toEqual([
+      {baseGroup, addresses: [avatarA, avatarB], source: "base-group"}
+    ]);
+  });
+
+  it("preserves the first base-group assignment for duplicate trustees", async () => {
+    const logger = new FakeLogger(true);
+    const baseGroupA = getAddress("0xA0000000000000000000000000000000000000EA");
+    const baseGroupB = getAddress("0xB0000000000000000000000000000000000000EB");
+    const trustee = getAddress("0x2000000000000000000000000000000000000E00");
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.baseGroups = [baseGroupA, baseGroupB];
+    circlesRpc.trusteesByTruster[baseGroupA.toLowerCase()] = [trustee];
+    circlesRpc.trusteesByTruster[baseGroupB.toLowerCase()] = [trustee];
+
+    const assignments = await buildAvatarBaseGroupAssignments(circlesRpc, logger);
+    expect(assignments.get(trustee.toLowerCase())).toBe(baseGroupA.toLowerCase());
+  });
+
+  it("validates base groups and skips targets with no humans left", async () => {
+    const logger = new FakeLogger(true);
+    const defaultBaseGroup = DEFAULT_BASE_GROUP_ADDRESS.toLowerCase();
+    const otherBaseGroup = getAddress("0xA0000000000000000000000000000000000000DD").toLowerCase();
+    const human = getAddress("0x2000000000000000000000000000000000000D00").toLowerCase();
+
+    await expect(validateEnableTargets(
+      [{baseGroup: defaultBaseGroup, addresses: [human], source: "fallback"}],
+      async (address) => address === defaultBaseGroup,
+      defaultBaseGroup,
+      logger
+    )).rejects.toThrow("Base group");
+
+    const filtered = await validateEnableTargets(
+      [{baseGroup: otherBaseGroup, addresses: [human], source: "base-group"}],
+      async (address) => address !== otherBaseGroup && false,
+      defaultBaseGroup,
+      logger
+    );
+
+    expect(filtered.validTargets).toEqual([]);
+    expect(filtered.nonHumanAvatars).toEqual(new Set([human]));
   });
 });

--- a/tests/apps/router-tms/logic.spec.ts
+++ b/tests/apps/router-tms/logic.spec.ts
@@ -18,6 +18,8 @@ const {
   buildAvatarBaseGroupAssignments,
   buildBaseGroupEnableTargets,
   chunkArray,
+  createHumanityChecker,
+  createIsHumanBatchChecker,
   createIsHumanChecker,
   filterHumanAvatars,
   normalizeAddress,
@@ -412,13 +414,45 @@ describe("router-tms helpers", () => {
     expect(await checker(human)).toBe(true);
   });
 
+  it("shares the humanity cache between single and batched lookups", async () => {
+    const human = getAddress("0x2000000000000000000000000000000000000B10");
+    const otherHuman = getAddress("0x2000000000000000000000000000000000000B11");
+
+    class CountingCirclesRpc extends FakeCirclesRpc {
+      singleCalls = 0;
+      batchCalls: string[][] = [];
+
+      override async isHuman(address: string): Promise<boolean> {
+        this.singleCalls += 1;
+        return super.isHuman(address);
+      }
+
+      override async isHumanBatch(addresses: string[]): Promise<Map<string, boolean>> {
+        this.batchCalls.push([...addresses]);
+        return new Map(addresses.map((address) => [address, true]));
+      }
+    }
+
+    const circlesRpc = new CountingCirclesRpc();
+    const checker = createHumanityChecker(circlesRpc);
+
+    expect(await checker.isHumanBatch([human, otherHuman, human])).toEqual(new Map([
+      [human.toLowerCase(), true],
+      [otherHuman.toLowerCase(), true]
+    ]));
+    expect(await checker.isHuman(human)).toBe(true);
+
+    expect(circlesRpc.batchCalls).toEqual([[human.toLowerCase(), otherHuman.toLowerCase()]]);
+    expect(circlesRpc.singleCalls).toBe(0);
+  });
+
   it("filters human avatars and groups eligible base group assignments", async () => {
     const humanA = getAddress("0x2000000000000000000000000000000000000C00");
     const humanB = getAddress("0x2000000000000000000000000000000000000C01");
     const baseGroup = getAddress("0xA0000000000000000000000000000000000000CC");
     const result = await filterHumanAvatars(
       [humanA, humanB],
-      async (address) => address === humanA,
+      async (addresses) => new Map(addresses.map((address) => [address.toLowerCase(), address === humanA])),
       1
     );
 
@@ -484,6 +518,7 @@ describe("router-tms helpers", () => {
     await expect(validateEnableTargets(
       [{baseGroup: defaultBaseGroup, addresses: [human], source: "fallback"}],
       async (address) => address === defaultBaseGroup,
+      async (addresses) => new Map(addresses.map((address) => [address.toLowerCase(), address === human])),
       defaultBaseGroup,
       logger
     )).rejects.toThrow("Base group");
@@ -491,6 +526,12 @@ describe("router-tms helpers", () => {
     const filtered = await validateEnableTargets(
       [{baseGroup: otherBaseGroup, addresses: [human], source: "base-group"}],
       async (address) => address !== otherBaseGroup && false,
+      (() => {
+        const circlesRpc = new FakeCirclesRpc();
+        circlesRpc.baseGroups = [otherBaseGroup];
+        circlesRpc.humanityOverrides.set(human, false);
+        return createIsHumanBatchChecker(circlesRpc);
+      })(),
       defaultBaseGroup,
       logger
     );

--- a/tests/apps/router-tms/logic.spec.ts
+++ b/tests/apps/router-tms/logic.spec.ts
@@ -235,7 +235,7 @@ describe("router-tms runOnce", () => {
     ]);
   });
 
-  it("enables base group members that are missing from RegisterHuman before defaulting remaining humans", async () => {
+  it("only enables base group members when they are present in RegisterHuman", async () => {
     const baseGroup = getAddress("0xA0000000000000000000000000000000000000AA");
     const baseGroupMember = getAddress("0x2000000000000000000000000000000000000300");
     const humanBob = getAddress("0x2000000000000000000000000000000000000301");
@@ -246,7 +246,7 @@ describe("router-tms runOnce", () => {
     circlesRpc.trusteesByTruster[baseGroup.toLowerCase()] = [baseGroupMember];
     circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
 
-    const routerService = new FakeRouterService(["0xtx_group", "0xtx_fallback"]);
+    const routerService = new FakeRouterService(["0xtx_fallback"]);
 
     const deps = makeDeps({
       circlesRpc,
@@ -262,12 +262,11 @@ describe("router-tms runOnce", () => {
 
     expect(outcome.allowedHumanCount).toBe(1);
     expect(outcome.blacklistedHumanCount).toBe(0);
-    expect(outcome.pendingEnableCount).toBe(2);
-    expect(outcome.executedEnableCount).toBe(2);
-    expect(outcome.txHashes).toEqual(["0xtx_group", "0xtx_fallback"]);
+    expect(outcome.pendingEnableCount).toBe(1);
+    expect(outcome.executedEnableCount).toBe(1);
+    expect(outcome.txHashes).toEqual(["0xtx_fallback"]);
 
     expect(routerService.calls).toEqual([
-      {baseGroup: baseGroup.toLowerCase(), crcAddresses: [baseGroupMember.toLowerCase()]},
       {baseGroup: DEFAULT_BASE_GROUP_ADDRESS.toLowerCase(), crcAddresses: [humanBob.toLowerCase()]}
     ]);
   });

--- a/tests/apps/router-tms/logic.spec.ts
+++ b/tests/apps/router-tms/logic.spec.ts
@@ -130,8 +130,9 @@ describe("router-tms runOnce", () => {
     const circlesRpc = new FakeCirclesRpc();
     circlesRpc.humanAvatars = [humanAlice, humanBob];
     circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
+    const routerService = new FakeRouterService();
 
-    const deps = makeDeps({circlesRpc});
+    const deps = makeDeps({circlesRpc, routerService});
     const cfg = makeConfig({dryRun: true, enableBatchSize: 0, fetchPageSize: 0});
 
     const outcome = await runOnce(deps, cfg);
@@ -139,6 +140,8 @@ describe("router-tms runOnce", () => {
     expect(outcome.pendingEnableCount).toBe(2);
     expect(outcome.executedEnableCount).toBe(0);
     expect(outcome.txHashes).toEqual([]);
+    expect(routerService.calls).toHaveLength(0);
+    expect(routerService.simulationCalls).toBe(2);
   });
 
   it("uses default config values when optional settings are omitted", async () => {

--- a/tests/services/circlesRpcService.spec.ts
+++ b/tests/services/circlesRpcService.spec.ts
@@ -54,6 +54,24 @@ function buildService(): CirclesRpcService {
   return new CirclesRpcService(RPC_URL);
 }
 
+function makeRawBackingCompletedEvent(blockNumber: number, suffix: string) {
+  const hex = (value: number) => `0x${value.toString(16)}`;
+  return {
+    event: "CrcV2_CirclesBackingCompleted",
+    values: {
+      blockNumber: hex(blockNumber),
+      timestamp: hex(blockNumber + 1000),
+      transactionIndex: "0x1",
+      logIndex: "0x2",
+      transactionHash: `0xtx${suffix}`,
+      backer: `0xbacker${suffix}`,
+      circlesBackingInstance: `0xinst${suffix}`,
+      lbp: `0xlbp${suffix}`,
+      emitter: FACTORY,
+    },
+  };
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 beforeEach(() => jest.clearAllMocks());
 
@@ -78,13 +96,43 @@ describe("CirclesRpcService", () => {
     });
 
     it("passes toBlock=null when toBlock is omitted", async () => {
-      mockClientCall.mockResolvedValueOnce({ events: [] });
+      mockClientCall
+        .mockResolvedValueOnce("0x32")
+        .mockResolvedValueOnce({ events: [] });
       const svc = buildService();
       await svc.fetchBackingCompletedEvents(FACTORY, 50);
 
-      const args = mockClientCall.mock.calls[0][1];
+      expect(mockClientCall.mock.calls[0]).toEqual(["eth_blockNumber", []]);
+      const args = mockClientCall.mock.calls[1][1];
       expect(args[0]).toBeUndefined();   // address
-      expect(args[2]).toBeNull();         // toBlock
+      expect(args[2]).toBe(50);           // resolved head block
+    });
+
+    it("splits ranges when circles_events returns the capped result size", async () => {
+      mockClientCall
+        .mockResolvedValueOnce(Array.from({ length: 100 }, (_, index) => makeRawBackingCompletedEvent(1000 - index, `cap${index}`)))
+        .mockResolvedValueOnce([makeRawBackingCompletedEvent(12, "left")])
+        .mockResolvedValueOnce([
+          makeRawBackingCompletedEvent(18, "right-a"),
+          makeRawBackingCompletedEvent(16, "right-b"),
+        ]);
+
+      const svc = buildService();
+      const events = await svc.fetchBackingCompletedEvents(FACTORY, 10, 18);
+
+      expect(mockClientCall).toHaveBeenCalledTimes(3);
+      expect(mockClientCall.mock.calls[0]).toEqual(["circles_events", [
+        undefined,
+        10,
+        18,
+        ["CrcV2_CirclesBackingCompleted"],
+        [{ Type: "FilterPredicate", FilterType: "Equals", Column: "emitter", Value: FACTORY }],
+      ]]);
+      expect(mockClientCall.mock.calls[1][1][1]).toBe(10);
+      expect(mockClientCall.mock.calls[1][1][2]).toBe(14);
+      expect(mockClientCall.mock.calls[2][1][1]).toBe(15);
+      expect(mockClientCall.mock.calls[2][1][2]).toBe(18);
+      expect(events.map((event) => event.blockNumber)).toEqual([18, 16, 12]);
     });
   });
 
@@ -108,6 +156,35 @@ describe("CirclesRpcService", () => {
   // Event transformation: hex → number parsing
   // ────────────────────────────────────────────────────────────────────────
   describe("event transformation", () => {
+    it("parses events when circles_events returns a bare array", async () => {
+      mockClientCall.mockResolvedValueOnce([
+        {
+          event: "CrcV2_CirclesBackingCompleted",
+          values: {
+            blockNumber: "0x1a3",
+            timestamp: "0x2710",
+            transactionIndex: "0xa",
+            logIndex: "0x1f",
+            transactionHash: "0xabc123",
+            backer: "0xbacker",
+            circlesBackingInstance: "0xinst",
+            lbp: "0xlbp",
+            emitter: "0xfactory",
+          },
+        },
+      ]);
+
+      const svc = buildService();
+      const events = await svc.fetchBackingCompletedEvents(FACTORY, 1, 999);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].blockNumber).toBe(419);
+      expect(events[0].timestamp).toBe(10000);
+      expect(events[0].backer).toBe("0xbacker");
+      expect(events[0].circlesBackingInstance).toBe("0xinst");
+      expect(events[0].lbp).toBe("0xlbp");
+    });
+
     it("parses hex blockNumber/timestamp/transactionIndex/logIndex to numbers", async () => {
       mockClientCall.mockResolvedValueOnce({
         events: [
@@ -146,23 +223,25 @@ describe("CirclesRpcService", () => {
     });
 
     it("handles already-numeric values gracefully", async () => {
-      mockClientCall.mockResolvedValueOnce({
-        events: [
-          {
-            event: "CrcV2_CirclesBackingInitiated",
-            values: {
-              blockNumber: 500,
-              timestamp: 12345,
-              transactionIndex: 2,
-              logIndex: 7,
-              transactionHash: "0xdef",
-              backer: "0xb",
-              circlesBackingInstance: "0xi",
-              emitter: "0xe",
+      mockClientCall
+        .mockResolvedValueOnce("0x64")
+        .mockResolvedValueOnce({
+          events: [
+            {
+              event: "CrcV2_CirclesBackingInitiated",
+              values: {
+                blockNumber: 500,
+                timestamp: 12345,
+                transactionIndex: 2,
+                logIndex: 7,
+                transactionHash: "0xdef",
+                backer: "0xb",
+                circlesBackingInstance: "0xi",
+                emitter: "0xe",
+              },
             },
-          },
-        ],
-      });
+          ],
+        });
 
       const svc = buildService();
       const events = await svc.fetchBackingInitiatedEvents(FACTORY, 1);
@@ -171,7 +250,9 @@ describe("CirclesRpcService", () => {
     });
 
     it("returns empty array when response has no events", async () => {
-      mockClientCall.mockResolvedValueOnce({});
+      mockClientCall
+        .mockResolvedValueOnce("0x64")
+        .mockResolvedValueOnce({});
       const svc = buildService();
       const events = await svc.fetchBackingCompletedEvents(FACTORY, 1);
       expect(events).toEqual([]);
@@ -362,10 +443,10 @@ describe("CirclesRpcService", () => {
       const svc = buildService();
       const events = await svc.fetchBackingCompletedEvents(FACTORY, 1, 999);
       expect(events).toHaveLength(2);
-      expect(events[0].blockNumber).toBe(1);
-      expect(events[1].blockNumber).toBe(16); // 0x10
-      expect(events[0].backer).toBe("0xb1");
-      expect(events[1].backer).toBe("0xb2");
+      expect(events[0].blockNumber).toBe(16); // 0x10
+      expect(events[1].blockNumber).toBe(1);
+      expect(events[0].backer).toBe("0xb2");
+      expect(events[1].backer).toBe("0xb1");
     });
   });
 });

--- a/tests/services/circlesRpcService.spec.ts
+++ b/tests/services/circlesRpcService.spec.ts
@@ -73,7 +73,10 @@ function makeRawBackingCompletedEvent(blockNumber: number, suffix: string) {
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  nextPagedQueryMock = null;
+});
 
 describe("CirclesRpcService", () => {
   // ────────────────────────────────────────────────────────────────────────
@@ -323,6 +326,87 @@ describe("CirclesRpcService", () => {
       const svc = buildService();
       const trustees = await svc.fetchAllTrustees(truster);
       expect(trustees).toEqual(["0xbbb", "0xddd"]);
+    });
+  });
+
+  describe("fetchAllTrusteesForTrusters", () => {
+    it("returns grouped trustees for multiple trusters from one paged query", async () => {
+      const trusterA = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      const trusterB = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+      nextPagedQueryMock = makeMockPagedQuery([
+        [
+          { truster: trusterA, trustee: "0x111" },
+          { truster: trusterB, trustee: "0x222" }
+        ]
+      ]);
+
+      const svc = buildService();
+      const result = await svc.fetchAllTrusteesForTrusters([trusterA, trusterB]);
+
+      expect(result).toEqual(new Map([
+        [trusterA, ["0x111"]],
+        [trusterB, ["0x222"]]
+      ]));
+      expect(svc.getLastBulkTrusteesForTrustersStats()).toEqual({
+        pagesFetched: 1,
+        rowsScanned: 2
+      });
+    });
+
+    it("initializes empty arrays for requested trusters with no rows", async () => {
+      const trusterA = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      const trusterB = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+      nextPagedQueryMock = makeMockPagedQuery([
+        [{ truster: trusterA, trustee: "0x111" }]
+      ]);
+
+      const svc = buildService();
+      const result = await svc.fetchAllTrusteesForTrusters([trusterA, trusterB]);
+
+      expect(result).toEqual(new Map([
+        [trusterA, ["0x111"]],
+        [trusterB, []]
+      ]));
+    });
+
+    it("aggregates trustees across multiple pages", async () => {
+      const trusterA = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      nextPagedQueryMock = makeMockPagedQuery([
+        [{ truster: trusterA, trustee: "0x111" }],
+        [{ truster: trusterA, trustee: "0x222" }]
+      ]);
+
+      const svc = buildService();
+      const result = await svc.fetchAllTrusteesForTrusters([trusterA]);
+
+      expect(result).toEqual(new Map([
+        [trusterA, ["0x111", "0x222"]]
+      ]));
+      expect(svc.getLastBulkTrusteesForTrustersStats()).toEqual({
+        pagesFetched: 2,
+        rowsScanned: 2
+      });
+    });
+
+    it("ignores rows whose truster is not in the requested batch", async () => {
+      const trusterA = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+      nextPagedQueryMock = makeMockPagedQuery([
+        [
+          { truster: trusterA, trustee: "0x111" },
+          { truster: "0xcccccccccccccccccccccccccccccccccccccccc", trustee: "0x999" }
+        ]
+      ]);
+
+      const svc = buildService();
+      const result = await svc.fetchAllTrusteesForTrusters([trusterA]);
+
+      expect(result).toEqual(new Map([
+        [trusterA, ["0x111"]]
+      ]));
+      expect(svc.getLastBulkTrusteesForTrustersStats()).toEqual({
+        pagesFetched: 1,
+        rowsScanned: 2
+      });
     });
   });
 

--- a/tests/services/leaderElection.spec.ts
+++ b/tests/services/leaderElection.spec.ts
@@ -1,4 +1,5 @@
 import {getEffectiveDryRun, LeaderElection} from "../../src/services/leaderElection";
+import {FakeLogger} from "../../fakes/fakes";
 
 // --- Mock pg ---
 const mockQuery = jest.fn();
@@ -33,12 +34,14 @@ describe("getEffectiveDryRun", () => {
 describe("LeaderElection", () => {
   let statusUpdates: boolean[];
   let slackMessages: string[];
+  let logger: FakeLogger;
 
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     statusUpdates = [];
     slackMessages = [];
+    logger = new FakeLogger(true);
     // Default: ensureTable succeeds
     mockQuery.mockResolvedValue({rows: [], rowCount: 0});
     mockEnd.mockResolvedValue(undefined);
@@ -52,6 +55,7 @@ describe("LeaderElection", () => {
     return new LeaderElection(
       "postgres://test",
       instanceId,
+      logger,
       {notifySlackStartOrCrash: async (msg: string) => { slackMessages.push(msg); }},
       (isLeader: boolean) => { statusUpdates.push(isLeader); }
     );
@@ -102,7 +106,6 @@ describe("LeaderElection", () => {
     });
 
     it("PG error during tryAcquire → falls back to non-leader (safe)", async () => {
-      const consoleSpy = jest.spyOn(console, "error").mockImplementation();
       mockQuery
         .mockResolvedValueOnce({rows: [], rowCount: 0})  // CREATE TABLE
         .mockRejectedValueOnce(new Error("connection refused")); // tryAcquire fails
@@ -111,12 +114,13 @@ describe("LeaderElection", () => {
       await le.start();
 
       expect(le.isLeader).toBe(false);
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("PG error"),
-        expect.stringContaining("connection refused")
-      );
-
-      consoleSpy.mockRestore();
+      expect(logger.logs).toContainEqual({
+        level: "error",
+        args: [
+          expect.stringContaining("PG error"),
+          expect.stringContaining("connection refused")
+        ]
+      });
       await le.stop();
     });
 
@@ -208,7 +212,6 @@ describe("LeaderElection", () => {
     });
 
     it("PG error during stop release → warns but doesn't throw", async () => {
-      const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
       mockQuery
         .mockResolvedValueOnce({rows: [], rowCount: 0})
         .mockResolvedValueOnce({rows: [{instance_id: "host-1"}], rowCount: 1});
@@ -219,27 +222,34 @@ describe("LeaderElection", () => {
       mockQuery.mockRejectedValueOnce(new Error("pg gone"));
       await le.stop(); // should not throw
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to release"),
-        expect.stringContaining("pg gone")
-      );
-      consoleSpy.mockRestore();
+      expect(logger.logs).toContainEqual({
+        level: "warn",
+        args: [
+          expect.stringContaining("Failed to release"),
+          expect.stringContaining("pg gone")
+        ]
+      });
     });
   });
 
   describe("LeaderElection.create", () => {
     it("returns null when dbUrl is missing", async () => {
-      const result = await LeaderElection.create(undefined, "host-1");
+      const result = await LeaderElection.create(undefined, "host-1", logger);
       expect(result).toBeNull();
     });
 
     it("returns null when instanceId is missing", async () => {
-      const result = await LeaderElection.create("postgres://test", undefined);
+      const result = await LeaderElection.create("postgres://test", undefined, logger);
       expect(result).toBeNull();
     });
 
     it("returns null when both are missing", async () => {
-      const result = await LeaderElection.create(undefined, undefined);
+      const result = await LeaderElection.create(undefined, undefined, logger);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when logger is missing", async () => {
+      const result = await LeaderElection.create("postgres://test", "host-1");
       expect(result).toBeNull();
     });
   });

--- a/tests/services/metriSafeService.spec.ts
+++ b/tests/services/metriSafeService.spec.ts
@@ -143,6 +143,47 @@ describe("MetriSafeService", () => {
     expect(result.selectedOwnersBySafe.get(safeChecksum)?.avatar).toBe(getAddress(owner2));
   });
 
+  it("breaks equal-timestamp ties deterministically instead of depending on API order", async () => {
+    const owner1 = "0xb00e2ed54bed3e4df0656781d36609c0b0138e98";
+    const owner2 = "0x13b0d6834e7d0a014166da74acdc277bce0bd365";
+    const safe = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+    const expectedOwner = getAddress(owner2);
+
+    mockFetchOk({
+      data: {
+        Metri_Pay_DelayModule: [{
+          safeAddress: safe,
+          owners: [
+            {ownerAddress: owner1, timestamp: "1000"},
+            {ownerAddress: owner2, timestamp: "1000"},
+          ],
+        }],
+      },
+    });
+
+    const serviceA = new MetriSafeService(endpoint, undefined);
+    const resultA = await serviceA.findAvatarsWithSafes([owner1, owner2]);
+
+    mockFetchOk({
+      data: {
+        Metri_Pay_DelayModule: [{
+          safeAddress: safe,
+          owners: [
+            {ownerAddress: owner2, timestamp: "1000"},
+            {ownerAddress: owner1, timestamp: "1000"},
+          ],
+        }],
+      },
+    });
+
+    const serviceB = new MetriSafeService(endpoint, undefined);
+    const resultB = await serviceB.findAvatarsWithSafes([owner1, owner2]);
+
+    const safeChecksum = getAddress(safe);
+    expect(resultA.selectedOwnersBySafe.get(safeChecksum)?.avatar).toBe(expectedOwner);
+    expect(resultB.selectedOwnersBySafe.get(safeChecksum)?.avatar).toBe(expectedOwner);
+  });
+
   // --- Edge cases: null/invalid data in modules ---
 
   it("module with null safeAddress → skipped", async () => {
@@ -249,6 +290,33 @@ describe("MetriSafeService", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(result.mappings.size).toBe(2);
+  });
+
+  it("default chunk size splits requests above 500 addresses", async () => {
+    const addresses = Array.from({length: 501}, (_, index) =>
+      getAddress(`0x${(index + 1).toString(16).padStart(40, "0")}`)
+    );
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({data: {Metri_Pay_DelayModule: []}}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({data: {Metri_Pay_DelayModule: []}}),
+      });
+    global.fetch = fetchMock as typeof fetch;
+
+    const service = new MetriSafeService(endpoint, undefined);
+    await service.findAvatarsWithSafes(addresses);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    const secondBody = JSON.parse(String(fetchMock.mock.calls[1][1]?.body));
+
+    expect(firstBody.variables.addresses).toHaveLength(500);
+    expect(secondBody.variables.addresses).toHaveLength(1);
   });
 
   // --- Edge cases: input normalization ---

--- a/tests/services/transactionRpc.spec.ts
+++ b/tests/services/transactionRpc.spec.ts
@@ -1,0 +1,15 @@
+import {resolveTransactionRpcUrl} from "../../src/services/transactionRpc";
+
+describe("resolveTransactionRpcUrl", () => {
+  it("falls back to the read RPC when TX_RPC_URL is unset", () => {
+    expect(resolveTransactionRpcUrl("https://read.rpc", {})).toBe("https://read.rpc");
+  });
+
+  it("falls back to the read RPC when TX_RPC_URL is blank", () => {
+    expect(resolveTransactionRpcUrl("https://read.rpc", {TX_RPC_URL: "   "})).toBe("https://read.rpc");
+  });
+
+  it("prefers TX_RPC_URL when configured", () => {
+    expect(resolveTransactionRpcUrl("https://read.rpc", {TX_RPC_URL: " https://write.rpc "})).toBe("https://write.rpc");
+  });
+});


### PR DESCRIPTION
## Summary

Gas estimation for Safe `execTransaction` intermittently fails on the public Gnosis RPC with:
- `evm timeout` (code -32009)
- `CALL_EXCEPTION` with `data=null, reason=null` (RPC failed to simulate)

These are transient — the same call succeeds on retry. But `estimateGas` in `SafeTransactionExecutor` had no retry, so one transient failure killed the entire batch.

## Changes

**retryWithBackoff.ts**:
- Added `-32009` (evm timeout) to `TRANSIENT_CODES`
- Added `"evm timeout"` and `"missing revert data"` to `TRANSIENT_MESSAGES`
- Added: ethers `CALL_EXCEPTION` with no `data` treated as transient

**safeTransactionExecutor.ts**:
- Wrapped `estimateGas` in `retryWithBackoff`

## Deployment note

On staging, also set `TX_RPC_URL` to use our Nethermind with public fallback:
```
TX_RPC_URL=https://rpc.staging.aboutcircles.com/chain-rpc,https://rpc.gnosischain.com
```

## Test plan

- [x] Build passes
- [ ] Deploy to staging, monitor for gas estimation errors over 24h