### PR TITLE
fix: async mutex on Safe execute, unify retry classifier, fix provider type

### DIFF
--- a/src/apps/gp-crc/logic.ts
+++ b/src/apps/gp-crc/logic.ts
@@ -5,6 +5,7 @@ import {IGroupService} from "../../interfaces/IGroupService";
 import {IAvatarSafeService} from "../../interfaces/IAvatarSafeService";
 import {IAvatarSafeMappingStore} from "../../interfaces/IAvatarSafeMappingStore";
 import {ICirclesRpc} from "../../interfaces/ICirclesRpc";
+import {isTransientRpcError} from "../../services/retryWithBackoff";
 
 export type RunConfig = {
   rpcUrl: string;
@@ -567,33 +568,11 @@ function isRetryableFetchError(error: unknown): boolean {
   return false;
 }
 
-function isRetryableTrustError(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) {
-    return true;
-  }
-
-  const anyError = error as { code?: unknown; message?: unknown };
-  const code = typeof anyError.code === "string" ? anyError.code.toUpperCase() : "";
-  const message = typeof anyError.message === "string" ? anyError.message.toLowerCase() : "";
-
-  if (code === "CALL_EXCEPTION" || code === "UNPREDICTABLE_GAS_LIMIT" || code === "INSUFFICIENT_FUNDS") {
-    return false;
-  }
-
-  if (code.includes("NETWORK") || code.includes("SERVER") || code.includes("TIMEOUT")) {
-    return true;
-  }
-
-  if (message.includes("timeout") || message.includes("network") || message.includes("econnreset") || message.includes("temporarily")) {
-    return true;
-  }
-
-  if (message.includes("insufficient funds") || message.includes("underpriced") || message.includes("nonce")) {
-    return false;
-  }
-
-  return false;
-}
+// Use the shared transient error classifier to avoid drift between retry layers.
+// The inner retryWithBackoff in GroupService/SafeTransactionExecutor handles
+// RPC-level transients; this outer retry catches errors that surface after
+// the inner retry is exhausted (e.g. confirmation timeouts).
+const isRetryableTrustError = isTransientRpcError;
 
 function formatErrorMessage(error: unknown): string {
   if (error instanceof Error) {

--- a/src/services/safeTransactionExecutor.ts
+++ b/src/services/safeTransactionExecutor.ts
@@ -1,5 +1,5 @@
 import Safe from "@safe-global/protocol-kit";
-import { getAddress, JsonRpcProvider, Wallet } from "ethers";
+import { FallbackProvider, getAddress, JsonRpcProvider, Wallet } from "ethers";
 import {TransactionSimulationResult} from "../interfaces/ITransactionSimulation";
 import { retryWithBackoff } from "./retryWithBackoff";
 import { createProvider, primaryRpcUrl } from "./rpcProvider";
@@ -26,12 +26,18 @@ function ensureSuccessfulReceipt(receipt: any, context: string) {
 
 /**
  * Thin helper around Safe Protocol Kit to execute arbitrary contract calls and wait for confirmations.
+ *
+ * execute() is serialized via an async lock to prevent nonce collisions when multiple
+ * callers share the same Safe address (e.g. gnosis-group + router-tms in separate processes
+ * won't help, but concurrent calls within a single process are safe).
  */
 export class SafeTransactionExecutor {
-  private readonly provider: JsonRpcProvider;
+  private readonly provider: JsonRpcProvider | FallbackProvider;
   private readonly safePromise: Promise<Safe>;
   private readonly safeAddress: string;
   private readonly signerAddress: string;
+  /** Async mutex: each execute() waits for the previous one to finish. */
+  private _executeLock: Promise<void> = Promise.resolve();
 
   constructor(rpcUrl: string, signerPrivateKey: string, safeAddress: string) {
     if (!signerPrivateKey || signerPrivateKey.trim().length === 0) {
@@ -41,7 +47,7 @@ export class SafeTransactionExecutor {
       throw new Error("Safe address is required");
     }
 
-    this.provider = createProvider(rpcUrl) as JsonRpcProvider;
+    this.provider = createProvider(rpcUrl);
     this.safeAddress = getAddress(safeAddress);
     this.signerAddress = getAddress(SafeTransactionExecutor.privateKeyToAddress(signerPrivateKey));
     this.safePromise = Safe.init({
@@ -57,6 +63,27 @@ export class SafeTransactionExecutor {
     confirmationsToWait = 1,
     value: string | bigint = 0n,
     confirmationTimeoutMs: number = DEFAULT_TX_CONFIRMATION_TIMEOUT_MS
+  ): Promise<string> {
+    // Serialize: wait for any in-flight execute() to finish before starting.
+    let release: () => void;
+    const gate = new Promise<void>(r => { release = r; });
+    const prev = this._executeLock;
+    this._executeLock = gate;
+    await prev;
+
+    try {
+      return await this._executeInner(to, data, confirmationsToWait, value, confirmationTimeoutMs);
+    } finally {
+      release!();
+    }
+  }
+
+  private async _executeInner(
+    to: string,
+    data: string,
+    confirmationsToWait: number,
+    value: string | bigint,
+    confirmationTimeoutMs: number
   ): Promise<string> {
     const safe = await this.safePromise;
     const normalizedTo = getAddress(to);
@@ -74,9 +101,10 @@ export class SafeTransactionExecutor {
     const signedSafeTx = await safe.signTransaction(unsignedSafeTx);
     const gasLimit = await this.estimateExecutionGasLimit(safe, signedSafeTx);
 
-    const execution = await retryWithBackoff(() =>
-      safe.executeTransaction(signedSafeTx, { gasLimit: gasLimit.toString() })
-    );
+    // Do NOT retry executeTransaction — if the first attempt reaches the mempool but
+    // the response is lost (timeout), a retry would send a second tx with a new EOA nonce,
+    // causing duplicate on-chain execution. Gas estimation (above) is safe to retry.
+    const execution = await safe.executeTransaction(signedSafeTx, { gasLimit: gasLimit.toString() });
 
     const txHash =
       (execution as any).hash ?? (execution as any).transactionResponse?.hash;
@@ -131,9 +159,10 @@ export class SafeTransactionExecutor {
 
   private async estimateExecutionGasLimit(safe: Safe, safeTx: Awaited<ReturnType<Safe["createTransaction"]>>): Promise<bigint> {
     // Estimate the fully encoded execTransaction with ethers to avoid Protocol Kit's
-    // internal viem estimate path, which is flaky on the Circles RPC.
+    // internal viem estimate path. Wrapped in retryWithBackoff because public RPCs
+    // intermittently return "evm timeout" or empty CALL_EXCEPTION on complex Safe calls.
     const encodedSafeTx = await safe.getEncodedTransaction(safeTx);
-    const gasEstimate = await retryWithBackoff(() => this.provider.estimateGas({
+    const gasEstimate = await retryWithBackoff<bigint>(() => this.provider.estimateGas({
       from: this.signerAddress,
       to: this.safeAddress,
       data: encodedSafeTx


### PR DESCRIPTION
## Summary

Fixes 4 pre-existing architectural issues found during the 6-agent audit of PR #69.

### 1. Async mutex on execute() (Critical)
Concurrent `execute()` calls on the same SafeTransactionExecutor could read the same Safe nonce, causing one tx to silently drop. Added a promise-chain lock that serializes calls within a process.

### 2. Remove retry from executeTransaction (Critical)
`retryWithBackoff` was wrapping `safe.executeTransaction` (broadcast). If the first attempt reached the mempool but the response timed out, the retry would send a SECOND tx with a new EOA nonce — causing duplicate on-chain execution. Gas estimation retry (safe, read-only) is kept.

### 3. Fix FallbackProvider type (High)
`createProvider()` returns `JsonRpcProvider | FallbackProvider`, but the executor cast it to `JsonRpcProvider`. This would crash at runtime with multi-URL `TX_RPC_URL`. Fixed to accept both types.

### 4. Unify gp-crc retry classifier (High)
`gp-crc/logic.ts` had its own `isRetryableTrustError` that contradicted the shared `isTransientRpcError` (e.g. CALL_EXCEPTION was non-retryable locally but retryable in the shared module). Replaced with an alias to the shared classifier.

## Test plan

- [x] Build passes (pre-existing FakeSlack error only)
- [ ] Deploy to staging with PR #69
- [ ] Monitor for nonce issues, duplicate txs