### PR TITLE
fix: route crc-backers dry-run summary to info channel

### DIFF
--- a/src/apps/crc-backers/logic.ts
+++ b/src/apps/crc-backers/logic.ts
@@ -2,7 +2,7 @@ import {ICirclesRpc} from "../../interfaces/ICirclesRpc";
 import {IBlacklistingService} from "../../interfaces/IBlacklistingService";
 import {IGroupService} from "../../interfaces/IGroupService";
 import {IBackingInstanceService, ResetCowSwapOrderResult, CreateLBPResult} from "../../interfaces/IBackingInstanceService";
-import {ISlackService} from "../../interfaces/ISlackService";
+import {ISlackService, SlackSeverity} from "../../interfaces/ISlackService";
 import {IChainRpc} from "../../interfaces/IChainRpc";
 import {ILoggerService} from "../../interfaces/ILoggerService";
 import {BackingCompletedEvent, BackingInitiatedEvent} from "../../interfaces/ICirclesRpc";
@@ -376,7 +376,7 @@ async function notifySlackTrustSummary(
   }
 
   try {
-    await slackService.notifySlackStartOrCrash(lines.join("\n"));
+    await slackService.notifySlackStartOrCrash(lines.join("\n"), SlackSeverity.INFO);
   } catch (error) {
     LOG.warn("Failed to send Slack trust/untrust summary:", error);
   }


### PR DESCRIPTION
## Summary
- crc-backers `notifySlackTrustSummary()` called `notifySlackStartOrCrash()` without severity, defaulting to `CRITICAL` → routed to alerts webhook
- Added `SlackSeverity.INFO` so dry-run/wet summaries go to the info/production channel (matching gnosis-group and dublin-tms behavior)

## Test plan
- [x] `npx tsc --noEmit` — no new errors (pre-existing FakeSlack issue unrelated)
- [x] All 190 runtime tests pass
- [ ] After deploy: verify summary appears in `-production` channel, not `-alerts`