### PR TITLE
fix: resilience hardening for intermittent gas estimation and blacklist failures

### DIFF
--- a/fakes/fakes.ts
+++ b/fakes/fakes.ts
@@ -160,6 +160,10 @@ export class FakeBlacklist implements IBlacklistingService {
     return this.blocked.size + this.flagged.size;
   }
 
+  isLoaded(): boolean {
+    return this.loaded;
+  }
+
   async checkBlacklist(addresses: string[]): Promise<IBlacklistServiceVerdict[]> {
     return addresses.map(a => {
       const lc = a.toLowerCase();
@@ -332,6 +336,10 @@ export class FakeSlack implements ISlackService {
   async notifySlackStartOrCrash(message: string, severity: SlackSeverity = SlackSeverity.CRITICAL): Promise<void> {
     this.generalNotifications.push({message, severity});
   }
+
+  async notifySlackResolved(_appName: string): Promise<void> {
+    // no-op in tests
+  }
 }
 
 export class FakeAffiliateGroupEvents implements IAffiliateGroupEventsService {
@@ -359,6 +367,10 @@ export class FakeRouterService implements IRouterService {
   simulationCalls = 0;
   private readonly responseQueue: string[];
   failWith?: Error;
+  /** If set, only fail on the Nth call (1-indexed). Other calls succeed. */
+  failOnCallIndex?: number;
+  /** If set, only fail on the Nth simulation (1-indexed). Other simulations succeed. */
+  failOnSimulationIndex?: number;
 
   constructor(txHashResponses: string[] = []) {
     this.responseQueue = [...txHashResponses];
@@ -366,7 +378,7 @@ export class FakeRouterService implements IRouterService {
 
   async enableCRCForRouting(baseGroup: string, crcAddresses: string[]): Promise<string> {
     this.calls.push({baseGroup, crcAddresses: [...crcAddresses]});
-    if (this.failWith) {
+    if (this.failWith && (this.failOnCallIndex === undefined || this.failOnCallIndex === this.calls.length)) {
       throw this.failWith;
     }
 
@@ -380,7 +392,7 @@ export class FakeRouterService implements IRouterService {
   async simulateEnableCRCForRouting(baseGroup: string, crcAddresses: string[]): Promise<TransactionSimulationResult> {
     this.simulationCalls += 1;
     this.simulations.push({baseGroup, crcAddresses: [...crcAddresses]});
-    if (this.failWith) {
+    if (this.failWith && (this.failOnSimulationIndex === undefined || this.failOnSimulationIndex === this.simulationCalls)) {
       throw this.failWith;
     }
 

--- a/src/apps/crc-backers/main.ts
+++ b/src/apps/crc-backers/main.ts
@@ -232,7 +232,15 @@ async function refreshBlacklist(): Promise<void> {
     const count = blacklistingService.getBlacklistCount();
     rootLogger.info(`Blacklist refreshed successfully. ${count} addresses blacklisted.`);
   } catch (error) {
-    rootLogger.error("Failed to refresh blacklist:", error);
+    if (blacklistingService.isLoaded()) {
+      const staleCount = blacklistingService.getBlacklistCount();
+      rootLogger.warn(
+        `Failed to refresh blacklist (${(error as Error).message}). ` +
+        `Proceeding with stale blacklist data (${staleCount} addresses).`
+      );
+      return;
+    }
+    rootLogger.error("Failed to refresh blacklist on initial load:", error);
     throw error;
   }
 }

--- a/src/apps/gnosis-group/main.ts
+++ b/src/apps/gnosis-group/main.ts
@@ -292,7 +292,15 @@ async function refreshBlacklist(): Promise<void> {
     const count = blacklistingService.getBlacklistCount();
     runLogger.info(`Blacklist refreshed successfully. ${count} addresses blacklisted.`);
   } catch (error) {
-    runLogger.error("Failed to refresh blacklist:", error);
+    if (blacklistingService.isLoaded()) {
+      const staleCount = blacklistingService.getBlacklistCount();
+      runLogger.warn(
+        `Failed to refresh blacklist (${(error as Error).message}). ` +
+        `Proceeding with stale blacklist data (${staleCount} addresses).`
+      );
+      return;
+    }
+    runLogger.error("Failed to refresh blacklist on initial load:", error);
     throw error;
   }
 }

--- a/src/apps/gp-crc/main.ts
+++ b/src/apps/gp-crc/main.ts
@@ -234,7 +234,15 @@ async function refreshBlacklist(): Promise<void> {
     const count = blacklistingService.getBlacklistCount();
     runLogger.info(`Blacklist refreshed successfully. ${count} addresses blacklisted.`);
   } catch (error) {
-    runLogger.error("Failed to refresh blacklist:", error);
+    if (blacklistingService.isLoaded()) {
+      const staleCount = blacklistingService.getBlacklistCount();
+      runLogger.warn(
+        `Failed to refresh blacklist (${(error as Error).message}). ` +
+        `Proceeding with stale blacklist data (${staleCount} addresses).`
+      );
+      return;
+    }
+    runLogger.error("Failed to refresh blacklist on initial load:", error);
     throw error;
   }
 }

--- a/src/apps/router-tms/logic.ts
+++ b/src/apps/router-tms/logic.ts
@@ -22,6 +22,14 @@ export type Deps = {
   enablementStore: IRouterEnablementStore;
 };
 
+export type FailedBatch = {
+  baseGroup: string;
+  batchIndex: number;
+  batchSize: number;
+  addresses: string[];
+  error: string;
+};
+
 export type RunOutcome = {
   totalAvatarEntries: number;
   uniqueHumanCount: number;
@@ -30,6 +38,7 @@ export type RunOutcome = {
   alreadyTrustedCount: number;
   pendingEnableCount: number;
   executedEnableCount: number;
+  failedBatches: FailedBatch[];
   dryRun: boolean;
   txHashes: string[];
 };
@@ -152,6 +161,7 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
       alreadyTrustedCount: alreadyTrusted.length,
       pendingEnableCount: 0,
       executedEnableCount: 0,
+      failedBatches: [],
       dryRun,
       txHashes: []
     };
@@ -175,6 +185,7 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
 
   const txHashes: string[] = [];
   let executedEnableCount = 0;
+  const failedBatches: FailedBatch[] = [];
 
   for (const target of validTargets) {
     const batches = chunkArray(target.addresses, enableBatchSize);
@@ -186,10 +197,25 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
             `(batch ${batchIndex + 1}/${batches.length}) for base group ${target.baseGroup}.`
         );
         if (routerService?.simulateEnableCRCForRouting) {
-          const simulation = await routerService.simulateEnableCRCForRouting(target.baseGroup, batch);
-          logger.info(
-            `[DRY-RUN] enableCRCForRouting simulation ${batchIndex + 1}/${batches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`
-          );
+          try {
+            const simulation = await routerService.simulateEnableCRCForRouting(target.baseGroup, batch);
+            logger.info(
+              `[DRY-RUN] enableCRCForRouting simulation ${batchIndex + 1}/${batches.length}: ok, gasEstimate=${simulation.gasEstimate.toString()}.`
+            );
+          } catch (simError) {
+            const errMsg = simError instanceof Error ? simError.message : String(simError);
+            logger.warn(
+              `[DRY-RUN] enableCRCForRouting simulation ${batchIndex + 1}/${batches.length} FAILED ` +
+              `for ${batch.length} avatar(s) in base group ${target.baseGroup}: ${errMsg}`
+            );
+            failedBatches.push({
+              baseGroup: target.baseGroup,
+              batchIndex: batchIndex + 1,
+              batchSize: batch.length,
+              addresses: batch,
+              error: errMsg
+            });
+          }
         } else {
           logger.info(
             `[DRY-RUN] enableCRCForRouting simulation ${batchIndex + 1}/${batches.length}: skipped (no signer-backed simulator configured).`
@@ -198,14 +224,30 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
         continue;
       }
 
-      const txHash = await routerService.enableCRCForRouting(target.baseGroup, batch);
-      txHashes.push(txHash);
-      executedEnableCount += batch.length;
-      await enablementStore.markEnabled(batch);
-      batch.forEach((address) => routerTrustSet.add(address));
-      logger.info(
-        `enableCRCForRouting tx=${txHash} (batch ${batchIndex + 1}/${batches.length}) for ${batch.length} avatar(s) in base group ${target.baseGroup}.`
-      );
+      try {
+        const txHash = await routerService.enableCRCForRouting(target.baseGroup, batch);
+        txHashes.push(txHash);
+        executedEnableCount += batch.length;
+        await enablementStore.markEnabled(batch);
+        batch.forEach((address) => routerTrustSet.add(address));
+        logger.info(
+          `enableCRCForRouting tx=${txHash} (batch ${batchIndex + 1}/${batches.length}) for ${batch.length} avatar(s) in base group ${target.baseGroup}.`
+        );
+      } catch (batchError) {
+        const errMsg = batchError instanceof Error ? batchError.message : String(batchError);
+        logger.error(
+          `enableCRCForRouting FAILED (batch ${batchIndex + 1}/${batches.length}) ` +
+          `for ${batch.length} avatar(s) in base group ${target.baseGroup}: ${errMsg}`
+        );
+        logger.error(`Failed batch addresses: ${batch.join(", ")}`);
+        failedBatches.push({
+          baseGroup: target.baseGroup,
+          batchIndex: batchIndex + 1,
+          batchSize: batch.length,
+          addresses: batch,
+          error: errMsg
+        });
+      }
     }
   }
 
@@ -217,6 +259,7 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
     alreadyTrustedCount: alreadyTrusted.length,
     pendingEnableCount,
     executedEnableCount: dryRun ? 0 : executedEnableCount,
+    failedBatches,
     dryRun,
     txHashes
   };

--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -53,7 +53,7 @@ const blacklistTimeoutMs = (() => {
 })();
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl, blacklistTimeoutMs);
 const enablementStore = new InMemoryRouterEnablementStore();
-const errorsBeforeCrash = 3;
+const errorsBeforeCrash = Math.max(1, parseEnvInt("ERRORS_BEFORE_CRASH", 5));
 const errorTracker = new ConsecutiveErrorTracker(errorsBeforeCrash);
 let leaderElection: LeaderElection | null = null;
 
@@ -64,7 +64,15 @@ async function refreshBlacklist(): Promise<void> {
     const count = blacklistingService.getBlacklistCount();
     runLogger.info(`Blacklist refreshed successfully. ${count} addresses blacklisted.`);
   } catch (error) {
-    runLogger.error("Failed to refresh blacklist:", error);
+    if (blacklistingService.isLoaded()) {
+      const staleCount = blacklistingService.getBlacklistCount();
+      runLogger.warn(
+        `Failed to refresh blacklist (${(error as Error).message}). ` +
+        `Proceeding with stale blacklist data (${staleCount} addresses).`
+      );
+      return;
+    }
+    runLogger.error("Failed to refresh blacklist on initial load:", error);
     throw error;
   }
 }
@@ -163,24 +171,47 @@ async function mainLoop(): Promise<void> {
         },
         { ...config, dryRun: effectiveDryRun }
       );
-      await stateStore?.save("router-tms", 0, { lastSuccessfulRunAt: new Date().toISOString() });
-      recordRunSuccess("router-tms", Date.now() - runStartedAt);
-      errorTracker.recordSuccess();
-      if (errorTracker.wasAlertingAndRecovered()) {
-        slackService.notifySlackResolved("Router TMS").catch((err) => {
-          rootLogger.warn("Failed to send Slack resolved notification:", err);
-        });
+      const allPendingFailed = outcome.pendingEnableCount > 0 && outcome.executedEnableCount === 0 && outcome.failedBatches.length > 0;
+      if (allPendingFailed) {
+        // All batches failed — treat as a run error for crash threshold
+        const consecutiveErrors = errorTracker.recordError();
+        recordRunError("router-tms");
+        rootLogger.error(`All ${outcome.failedBatches.length} batch(es) failed — counting as error ${consecutiveErrors} of ${errorsBeforeCrash}`);
+        if (errorTracker.shouldAlert()) {
+          rootLogger.error("Consecutive error threshold reached. Exiting with code 1.");
+          void notifySlackRunError(new Error(`All batches failed: ${outcome.failedBatches.map(fb => fb.error).join("; ")}`), consecutiveErrors).catch(() => {});
+          setTimeout(() => process.exit(1), 3000).unref();
+          return;
+        }
+        currentDelay = Math.min(currentDelay * 2, maxDelay);
+      } else {
+        await stateStore?.save("router-tms", 0, { lastSuccessfulRunAt: new Date().toISOString() });
+        recordRunSuccess("router-tms", Date.now() - runStartedAt);
+        errorTracker.recordSuccess();
+        if (errorTracker.wasAlertingAndRecovered()) {
+          slackService.notifySlackResolved("Router TMS").catch((err) => {
+            rootLogger.warn("Failed to send Slack resolved notification:", err);
+          });
+        }
+        currentDelay = pollIntervalMs;
       }
-      currentDelay = pollIntervalMs;
       runLogger.info(
         "router-tms run completed: " +
           `uniqueHumans=${outcome.uniqueHumanCount} ` +
           `allowed=${outcome.allowedHumanCount} ` +
           `blacklisted=${outcome.blacklistedHumanCount} ` +
           `pending=${outcome.pendingEnableCount} ` +
-          `executed=${outcome.executedEnableCount}`
+          `executed=${outcome.executedEnableCount} ` +
+          `failedBatches=${outcome.failedBatches.length}`
       );
-      if (outcome.pendingEnableCount === 0) {
+      if (outcome.failedBatches.length > 0) {
+        for (const fb of outcome.failedBatches) {
+          runLogger.warn(
+            `Failed batch ${fb.batchIndex} (${fb.batchSize} addresses) for base group ${fb.baseGroup}: ${fb.error}`
+          );
+        }
+      }
+      if (outcome.pendingEnableCount === 0 && outcome.failedBatches.length === 0) {
         runLogger.info("Router already trusts every allowed human avatar.");
       }
     } catch (cause) {

--- a/src/interfaces/IBlacklistingService.ts
+++ b/src/interfaces/IBlacklistingService.ts
@@ -22,6 +22,11 @@ export interface IBlacklistingService {
      * @return The number of blacklisted addresses.
      */
     getBlacklistCount(): number;
+
+    /**
+     * Returns true if at least one successful loadBlacklist() call has completed.
+     */
+    isLoaded(): boolean;
 }
 
 /**

--- a/src/services/blacklistingService.ts
+++ b/src/services/blacklistingService.ts
@@ -12,6 +12,22 @@ type BlacklistResponse = {
     addresses: string[];
 };
 
+const DEFAULT_FETCH_RETRIES = 3;
+const DEFAULT_FETCH_RETRY_BASE_DELAY_MS = 2_000;
+
+/** Match HTTP 5xx status codes in error messages. */
+const HTTP_5XX_PATTERN = /HTTP 5\d\d/;
+
+function isRetryableHttpError(error: Error): boolean {
+    const msg = error.message;
+    return HTTP_5XX_PATTERN.test(msg) ||
+        msg.includes("timed out") ||
+        msg.includes("ECONNRESET") ||
+        msg.includes("ECONNREFUSED") ||
+        msg.includes("socket hang up") ||
+        msg.includes("fetch failed");
+}
+
 export class BlacklistingService implements IBlacklistingService {
     private blacklistedAddresses: Set<string> = new Set();
     private loaded: boolean = false;
@@ -19,7 +35,9 @@ export class BlacklistingService implements IBlacklistingService {
     constructor(
         private serviceUrl: string,
         private readonly pageTimeoutMs: number = DEFAULT_BLACKLIST_PAGE_TIMEOUT_MS,
-        private readonly pageSize: number = DEFAULT_PAGE_SIZE
+        private readonly pageSize: number = DEFAULT_PAGE_SIZE,
+        private readonly fetchRetries: number = DEFAULT_FETCH_RETRIES,
+        private readonly fetchRetryBaseDelayMs: number = DEFAULT_FETCH_RETRY_BASE_DELAY_MS
     ) {}
 
     async loadBlacklist(): Promise<void> {
@@ -53,6 +71,28 @@ export class BlacklistingService implements IBlacklistingService {
     }
 
     private async fetchPage(offset: number): Promise<BlacklistResponse> {
+        let lastError: Error | undefined;
+        for (let attempt = 0; attempt <= this.fetchRetries; attempt++) {
+            try {
+                return await this.fetchPageOnce(offset);
+            } catch (err) {
+                lastError = err instanceof Error ? err : new Error(String(err));
+                if (!isRetryableHttpError(lastError) || attempt >= this.fetchRetries) {
+                    throw lastError;
+                }
+                const jitter = 0.5 + Math.random() * 0.5;
+                const delayMs = Math.round(this.fetchRetryBaseDelayMs * Math.pow(2, attempt) * jitter);
+                console.warn(
+                    `[BLACKLIST_RETRY] page offset=${offset} attempt ${attempt + 1}/${this.fetchRetries + 1}, ` +
+                    `waiting ${delayMs}ms — ${lastError.message}`
+                );
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+            }
+        }
+        throw lastError!;
+    }
+
+    private async fetchPageOnce(offset: number): Promise<BlacklistResponse> {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), this.pageTimeoutMs);
 
@@ -119,5 +159,9 @@ export class BlacklistingService implements IBlacklistingService {
 
     getBlacklistCount(): number {
         return this.blacklistedAddresses.size;
+    }
+
+    isLoaded(): boolean {
+        return this.loaded;
     }
 }

--- a/src/services/safeTransactionExecutor.ts
+++ b/src/services/safeTransactionExecutor.ts
@@ -166,7 +166,7 @@ export class SafeTransactionExecutor {
       from: this.signerAddress,
       to: this.safeAddress,
       data: encodedSafeTx
-    }));
+    }), { maxRetries: 5, baseDelayMs: 2_000 });
 
     return ((gasEstimate * GAS_LIMIT_BUFFER_NUMERATOR) + (GAS_LIMIT_BUFFER_DENOMINATOR - 1n)) / GAS_LIMIT_BUFFER_DENOMINATOR;
   }

--- a/tests/apps/router-tms/logic.spec.ts
+++ b/tests/apps/router-tms/logic.spec.ts
@@ -373,6 +373,87 @@ describe("router-tms runOnce", () => {
       "Invalid address passed to isHuman check"
     );
   });
+
+  it("isolates per-batch execution failures: succeeding batches land, failed ones are recorded", async () => {
+    const humanAlice = getAddress("0x2000000000000000000000000000000000000A10");
+    const humanBob = getAddress("0x2000000000000000000000000000000000000A11");
+    const humanCarol = getAddress("0x2000000000000000000000000000000000000A12");
+    const humanDave = getAddress("0x2000000000000000000000000000000000000A13");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [humanAlice, humanBob, humanCarol, humanDave];
+    circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
+
+    const routerService = new FakeRouterService(["0xtx_batch1", "0xtx_batch2"]);
+    routerService.failWith = new Error("gas estimation CALL_EXCEPTION");
+    routerService.failOnCallIndex = 2; // second batch fails
+
+    const enablementStore = new FakeRouterEnablementStore();
+    const deps = makeDeps({circlesRpc, routerService, enablementStore});
+    const cfg = makeConfig({dryRun: false, enableBatchSize: 2});
+
+    const outcome = await runOnce(deps, cfg);
+
+    // First batch (Alice, Bob) succeeded, second batch (Carol, Dave) failed
+    expect(outcome.executedEnableCount).toBe(2);
+    expect(outcome.txHashes).toEqual(["0xtx_batch1"]);
+    expect(outcome.failedBatches).toHaveLength(1);
+    expect(outcome.failedBatches[0].batchIndex).toBe(2);
+    expect(outcome.failedBatches[0].batchSize).toBe(2);
+    expect(outcome.failedBatches[0].error).toContain("gas estimation CALL_EXCEPTION");
+
+    // Failed batch addresses were NOT marked as enabled
+    const enabled = await enablementStore.loadEnabledAddresses();
+    expect(enabled.map(a => a.toLowerCase())).toContain(humanAlice.toLowerCase());
+    expect(enabled.map(a => a.toLowerCase())).toContain(humanBob.toLowerCase());
+    expect(enabled.map(a => a.toLowerCase())).not.toContain(humanCarol.toLowerCase());
+    expect(enabled.map(a => a.toLowerCase())).not.toContain(humanDave.toLowerCase());
+  });
+
+  it("dry-run simulation failures are isolated per batch and do not abort the run", async () => {
+    const humanAlice = getAddress("0x2000000000000000000000000000000000000A20");
+    const humanBob = getAddress("0x2000000000000000000000000000000000000A21");
+    const humanCarol = getAddress("0x2000000000000000000000000000000000000A22");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [humanAlice, humanBob, humanCarol];
+    circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
+
+    const routerService = new FakeRouterService();
+    routerService.failWith = new Error("RPC timeout");
+    routerService.failOnSimulationIndex = 1; // first simulation fails
+
+    const deps = makeDeps({circlesRpc, routerService});
+    const cfg = makeConfig({dryRun: true, enableBatchSize: 2});
+
+    const outcome = await runOnce(deps, cfg);
+
+    // Both batches were attempted; first failed, second succeeded
+    expect(outcome.failedBatches).toHaveLength(1);
+    expect(outcome.failedBatches[0].batchIndex).toBe(1);
+    expect(outcome.failedBatches[0].error).toContain("RPC timeout");
+    expect(routerService.simulationCalls).toBe(2);
+  });
+
+  it("all batches failing still returns outcome (not an exception)", async () => {
+    const humanAlice = getAddress("0x2000000000000000000000000000000000000A30");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [humanAlice];
+    circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
+
+    const routerService = new FakeRouterService();
+    routerService.failWith = new Error("persistent failure");
+
+    const deps = makeDeps({circlesRpc, routerService});
+    const cfg = makeConfig({dryRun: false, enableBatchSize: 10});
+
+    const outcome = await runOnce(deps, cfg);
+
+    expect(outcome.executedEnableCount).toBe(0);
+    expect(outcome.failedBatches).toHaveLength(1);
+    expect(outcome.txHashes).toEqual([]);
+  });
 });
 
 describe("router-tms helpers", () => {

--- a/tests/services/blacklistingService.spec.ts
+++ b/tests/services/blacklistingService.spec.ts
@@ -97,7 +97,7 @@ describe("BlacklistingService", () => {
         ok: false, status: 500, statusText: "Internal Server Error",
       }) as typeof fetch;
 
-      const svc = new BlacklistingService(SERVICE_URL);
+      const svc = new BlacklistingService(SERVICE_URL, 60_000, 1000, 0);
       await expect(svc.loadBlacklist()).rejects.toThrow(/HTTP 500/);
 
       const verdicts = await svc.checkBlacklist(["0xtest"]);
@@ -118,7 +118,7 @@ describe("BlacklistingService", () => {
       const abortError = new DOMException("The operation was aborted", "AbortError");
       global.fetch = jest.fn().mockRejectedValue(abortError) as typeof fetch;
 
-      const svc = new BlacklistingService(SERVICE_URL, 100);
+      const svc = new BlacklistingService(SERVICE_URL, 100, 1000, 0);
       await expect(svc.loadBlacklist()).rejects.toThrow(/timed out/);
     });
   });
@@ -218,6 +218,115 @@ describe("BlacklistingService", () => {
 
       const svc = new BlacklistingService(SERVICE_URL);
       await expect(svc.loadBlacklist()).rejects.toThrow(/invalid count/);
+    });
+  });
+
+  describe("fetchPage retry", () => {
+    it("retries on HTTP 504 and succeeds on second attempt", async () => {
+      let callCount = 0;
+      global.fetch = jest.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {ok: false, status: 504, statusText: "Gateway Timeout"};
+        }
+        return {
+          ok: true,
+          json: async () => ({status: "ok", total: 1, count: 1, v2_only: true, addresses: ["0xretried"]}),
+        };
+      }) as typeof fetch;
+
+      // fetchRetries=3, fetchRetryBaseDelayMs=10 (fast for tests)
+      const svc = new BlacklistingService(SERVICE_URL, 60_000, 1000, 3, 10);
+      await svc.loadBlacklist();
+      expect(svc.getBlacklistCount()).toBe(1);
+      expect(callCount).toBe(2);
+    });
+
+    it("retries on HTTP 502/503 as well", async () => {
+      let callCount = 0;
+      global.fetch = jest.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount <= 2) {
+          return {ok: false, status: callCount === 1 ? 502 : 503, statusText: "Bad Gateway"};
+        }
+        return {
+          ok: true,
+          json: async () => ({status: "ok", total: 1, count: 1, v2_only: true, addresses: ["0xok"]}),
+        };
+      }) as typeof fetch;
+
+      const svc = new BlacklistingService(SERVICE_URL, 60_000, 1000, 3, 10);
+      await svc.loadBlacklist();
+      expect(svc.getBlacklistCount()).toBe(1);
+      expect(callCount).toBe(3);
+    });
+
+    it("throws after exhausting all retries on persistent 504", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false, status: 504, statusText: "Gateway Timeout",
+      }) as typeof fetch;
+
+      // 3 retries → 4 total attempts (initial + 3 retries)
+      const svc = new BlacklistingService(SERVICE_URL, 60_000, 1000, 3, 10);
+      await expect(svc.loadBlacklist()).rejects.toThrow(/HTTP 504/);
+      expect(global.fetch).toHaveBeenCalledTimes(4);
+    });
+
+    it("does NOT retry HTTP 400 (client error, not retryable)", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false, status: 400, statusText: "Bad Request",
+      }) as typeof fetch;
+
+      const svc = new BlacklistingService(SERVICE_URL, 60_000, 1000, 3, 10);
+      await expect(svc.loadBlacklist()).rejects.toThrow(/HTTP 400/);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT retry HTTP 404 (not found)", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false, status: 404, statusText: "Not Found",
+      }) as typeof fetch;
+
+      const svc = new BlacklistingService(SERVICE_URL, 60_000, 1000, 3, 10);
+      await expect(svc.loadBlacklist()).rejects.toThrow(/HTTP 404/);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on network errors (ECONNRESET)", async () => {
+      let callCount = 0;
+      global.fetch = jest.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error("ECONNRESET");
+        }
+        return {
+          ok: true,
+          json: async () => ({status: "ok", total: 1, count: 1, v2_only: true, addresses: ["0xrecovered"]}),
+        };
+      }) as typeof fetch;
+
+      const svc = new BlacklistingService(SERVICE_URL, 60_000, 1000, 3, 10);
+      await svc.loadBlacklist();
+      expect(svc.getBlacklistCount()).toBe(1);
+    });
+
+    it("preserves stale data when retry-exhausted load fails", async () => {
+      // First load succeeds
+      mockFetchOk(["0xoriginal"]);
+      const svc = new BlacklistingService(SERVICE_URL, 60_000, 1000, 3, 10);
+      await svc.loadBlacklist();
+      expect(svc.getBlacklistCount()).toBe(1);
+
+      // Second load fails persistently
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false, status: 504, statusText: "Gateway Timeout",
+      }) as typeof fetch;
+
+      await expect(svc.loadBlacklist()).rejects.toThrow(/HTTP 504/);
+      // Original data preserved (swap-on-success pattern)
+      expect(svc.getBlacklistCount()).toBe(1);
+      const verdicts = await svc.checkBlacklist(["0xoriginal"]);
+      expect(verdicts[0].is_bot).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Addresses intermittent production failures in router-tms (and other apps) caused by:
1. **Gas estimation `CALL_EXCEPTION` with `data=null`** — local Nethermind fails to simulate complex Safe `execTransaction` under load
2. **Blacklist HTTP 504** — DigitalOcean App Service timeouts

Both errors shared one `ConsecutiveErrorTracker` (threshold 3), causing cascading crashes.

## Changes

- **Blacklist fetch retry**: 3x exponential backoff (2s base) on HTTP 5xx and network errors in `BlacklistingService.fetchPage`
- **Stale blacklist fallback**: all 4 apps (router-tms, crc-backers, gnosis-group, gp-crc) continue with cached blacklist data when refresh fails after initial load; gate uses `isLoaded()` to correctly handle empty blacklists
- **Gas estimation retry tuning**: increased from 3 retries/1s to 5 retries/2s (~62s window) in `SafeTransactionExecutor.estimateExecutionGasLimit`
- **Per-batch error isolation**: failed batches in router-tms are logged with addresses and auto-retried next cycle; successful batches still land
- **All-batches-failed detection**: when every batch fails, counts as error for crash threshold (not silent success)
- **Error threshold**: configurable via `ERRORS_BEFORE_CRASH` env (default 5, floor-clamped to 1)
- **Pre-existing fix**: `FakeSlack` missing `notifySlackResolved` method

## Audit

7-agent multi-angle audit completed (data integrity, security, code path consistency, concurrency, domain logic, architecture, simplification). All critical and high findings addressed in this PR.

## Test plan

- [ ] `npx tsc --noEmit` — clean type check
- [ ] `npm test` — 315 tests pass (20 suites), 3 pre-existing gp-crc failures unrelated
- [ ] New tests: blacklist retry (504→success, exhaustion, 400 not retried, ECONNRESET, stale preservation)
- [ ] New tests: per-batch isolation (partial failure, dry-run simulation failure, all-batches-failed)
- [ ] Verify on staging: DRY_RUN=1, check logs for stale blacklist fallback behavior