### PR TITLE
feat: switch gnosis-group to cached scoring endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,15 +239,17 @@ GNOSIS_GROUP_SAFE_SIGNER_PRIVATE_KEY=     # Private key of a 1/n Safe signer
 
 # External services
 BLACKLISTING_SERVICE_URL=https://squid-app-3gxnl.ondigitalocean.app/aboutcircles-advanced-analytics2/bot-analytics/blacklist
-GNOSIS_GROUP_SCORING_URL=https://squid-app-3gxnl.ondigitalocean.app/aboutcircles-advanced-analytics2/scoring/relative_trustscore/batch
+GNOSIS_GROUP_SCORING_URL=https://walrus-app-2-iod58.ondigitalocean.app/aboutcircles-advanced-analytics2/scoring/relative_trustscore
+GNOSIS_GROUP_SCORING_TARGET_SET_NAME=all_backers  # Server-side named target set for scoring
 
 # Scan window / timing
 GNOSIS_GROUP_RUN_INTERVAL_MINUTES=30      # Run interval in minutes
 GNOSIS_GROUP_FETCH_PAGE_SIZE=             # Fetch page size
-GNOSIS_GROUP_SCORE_BATCH_SIZE=            # Score batch size
+GNOSIS_GROUP_SCORE_BATCH_SIZE=            # Score batch size (default 200)
 GNOSIS_GROUP_SCORE_THRESHOLD=             # Score threshold for membership
 GNOSIS_GROUP_BATCH_SIZE=                  # Transaction batch size
 GNOSIS_GROUP_SCORE_CACHE_TTL_MINUTES=240  # Score cache TTL in minutes
+GNOSIS_GROUP_SCORE_FETCH_TIMEOUT_MS=      # Timeout per scoring request (default 90000)
 
 # Operation mode
 DRY_RUN=0                              # Set to "1" to skip blacklist & scoring requests

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ GNOSIS_GROUP_SCORING_TARGET_SET_NAME=all_backers  # Server-side named target set
 # Scan window / timing
 GNOSIS_GROUP_RUN_INTERVAL_MINUTES=30      # Run interval in minutes
 GNOSIS_GROUP_FETCH_PAGE_SIZE=             # Fetch page size
-GNOSIS_GROUP_SCORE_BATCH_SIZE=            # Score batch size (default 200)
+GNOSIS_GROUP_SCORE_BATCH_SIZE=            # Score batch size (default 20)
 GNOSIS_GROUP_SCORE_THRESHOLD=             # Score threshold for membership
 GNOSIS_GROUP_BATCH_SIZE=                  # Transaction batch size
 GNOSIS_GROUP_SCORE_CACHE_TTL_MINUTES=240  # Score cache TTL in minutes

--- a/src/apps/gnosis-group/logic.ts
+++ b/src/apps/gnosis-group/logic.ts
@@ -89,7 +89,7 @@ export class ScoreCache {
 }
 
 export const DEFAULT_FETCH_PAGE_SIZE = 1_000;
-export const DEFAULT_SCORE_BATCH_SIZE = 200;
+export const DEFAULT_SCORE_BATCH_SIZE = 20;
 export const DEFAULT_SCORE_THRESHOLD = 100;
 export const DEFAULT_GROUP_BATCH_SIZE = 10;
 export const DEFAULT_SCORING_TARGET_SET_NAME = "all_backers";

--- a/src/apps/gnosis-group/logic.ts
+++ b/src/apps/gnosis-group/logic.ts
@@ -14,7 +14,7 @@ type RelativeTrustScoreEntry = {
 
 type RelativeTrustScoreResponse = {
   status?: string;
-  batches?: Record<string, RelativeTrustScoreEntry[]>;
+  results?: RelativeTrustScoreEntry[];
 };
 
 export type RunConfig = {
@@ -28,6 +28,7 @@ export type RunConfig = {
   scoreThreshold?: number;
   groupBatchSize?: number;
   scoreCacheTtlMs?: number;
+  scoringTargetSetName?: string;
   dryRun?: boolean;
 };
 
@@ -88,9 +89,10 @@ export class ScoreCache {
 }
 
 export const DEFAULT_FETCH_PAGE_SIZE = 1_000;
-export const DEFAULT_SCORE_BATCH_SIZE = 20;
+export const DEFAULT_SCORE_BATCH_SIZE = 200;
 export const DEFAULT_SCORE_THRESHOLD = 100;
 export const DEFAULT_GROUP_BATCH_SIZE = 10;
+export const DEFAULT_SCORING_TARGET_SET_NAME = "all_backers";
 export const DEFAULT_BACKERS_GROUP_ADDRESS = "0x1aca75e38263c79d9d4f10df0635cc6fcfe6f026";
 export const DEFAULT_GP_CRC_GROUP_ADDRESS = "0xb629a1e86F3eFada0F87C83494Da8Cc34C3F84ef";
 export const HISTORIC_AUTO_TRUST_GROUP_ADDRESS = "0x86533d1ada8ffbe7b6f7244f9a1b707f7f3e239b";
@@ -117,6 +119,7 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
   const scoreFetchTimeoutMs = Math.max(1000, cfg.scoreFetchTimeoutMs ?? DEFAULT_SCORE_FETCH_TIMEOUT_MS);
   const scoreThreshold = resolveScoreThreshold(cfg.scoreThreshold, logger);
   const groupBatchSize = Math.max(1, cfg.groupBatchSize ?? DEFAULT_GROUP_BATCH_SIZE);
+  const targetSetName = cfg.scoringTargetSetName ?? DEFAULT_SCORING_TARGET_SET_NAME;
   const dryRun = !!cfg.dryRun;
 
   const targetGroupAddress = normalizeAddress(cfg.targetGroupAddress);
@@ -332,7 +335,7 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
       const batchScores = await fetchRelativeTrustScoresWithRetry(
         cfg.scoringServiceUrl,
         batch,
-        trustedTargets,
+        targetSetName,
         scoreFetchTimeoutMs,
         loggerScores
       );
@@ -789,13 +792,13 @@ async function partitionBlacklistedAddresses(
 async function fetchRelativeTrustScoresWithRetry(
   scoringUrl: string,
   avatars: string[],
-  trustedTargets: string[],
+  targetSetName: string,
   timeoutMs: number,
   logger: ILoggerService
 ): Promise<Map<string, number>> {
   for (let attempt = 1; attempt <= SCORE_FETCH_MAX_ATTEMPTS; attempt++) {
     try {
-      return await fetchRelativeTrustScores(scoringUrl, avatars, trustedTargets, timeoutMs);
+      return await fetchRelativeTrustScores(scoringUrl, avatars, targetSetName, timeoutMs);
     } catch (error) {
       const retryable = isRetryableFetchError(error);
       if (attempt >= SCORE_FETCH_MAX_ATTEMPTS || !retryable) {
@@ -816,7 +819,7 @@ async function fetchRelativeTrustScoresWithRetry(
 async function fetchRelativeTrustScores(
   scoringUrl: string,
   avatars: string[],
-  trustedTargets: string[],
+  targetSetName: string,
   timeoutMs: number
 ): Promise<Map<string, number>> {
   const response = await timedFetch(
@@ -828,51 +831,49 @@ async function fetchRelativeTrustScores(
         "Content-Type": "application/json"
       },
       body: JSON.stringify({
-        avatar_batches: [avatars],
-        target_sets: [trustedTargets]
+        avatars,
+        target_set_name: targetSetName,
+        include_details: false
       })
     },
     timeoutMs
   );
 
   if (!response.ok) {
-    throw new Error(`Relative trust score request failed: HTTP ${response.status} ${response.statusText}`);
+    void response.body?.cancel();
+    const err = new Error(`Relative trust score request failed: HTTP ${response.status} ${response.statusText}`);
+    if (response.status >= 500) {
+      (err as any).code = "SERVER_ERROR";
+    }
+    throw err;
   }
 
   const payload = (await response.json()) as RelativeTrustScoreResponse;
-  if (!payload || typeof payload !== "object" || payload.status !== "success" || !payload.batches) {
-    throw new Error("Relative trust score response malformed: missing success status or batches.");
+  if (!payload || typeof payload !== "object" || payload.status !== "success" || !Array.isArray(payload.results)) {
+    throw new Error("Relative trust score response malformed: missing success status or results.");
   }
 
   const results = new Map<string, number>();
-  const batches = payload.batches;
 
-  for (const batchKey of Object.keys(batches)) {
-    const entries = batches[batchKey];
-    if (!Array.isArray(entries)) {
+  for (const entry of payload.results) {
+    if (!entry || typeof entry.address !== "string") {
       continue;
     }
 
-    for (const entry of entries) {
-      if (!entry || typeof entry.address !== "string") {
-        continue;
-      }
-
-      const normalized = normalizeAddress(entry.address);
-      if (!normalized) {
-        continue;
-      }
-
-      const rawScore = typeof entry.relative_score === "number"
-        ? entry.relative_score
-        : Number(entry.relative_score);
-
-      if (!Number.isFinite(rawScore)) {
-        continue;
-      }
-
-      results.set(normalized, rawScore);
+    const normalized = normalizeAddress(entry.address);
+    if (!normalized) {
+      continue;
     }
+
+    const rawScore = typeof entry.relative_score === "number"
+      ? entry.relative_score
+      : Number(entry.relative_score);
+
+    if (!Number.isFinite(rawScore)) {
+      continue;
+    }
+
+    results.set(normalized, rawScore);
   }
 
   return results;

--- a/src/apps/gnosis-group/main.ts
+++ b/src/apps/gnosis-group/main.ts
@@ -18,6 +18,7 @@ import {
   HISTORIC_AUTO_TRUST_GROUP_ADDRESS,
   HISTORIC_AUTO_TRUST_GROUP_BLOCK_NUMBER,
   DEFAULT_SCORE_CACHE_TTL_MS,
+  DEFAULT_SCORING_TARGET_SET_NAME,
   RunOutcome
 } from "./logic";
 import {formatErrorWithCauses} from "../../formatError";
@@ -34,7 +35,7 @@ const rootLogger = new LoggerService(verboseLogging, "gnosis-group");
 const rpcUrl = process.env.RPC_URL || "https://rpc.aboutcircles.com/";
 const txRpcUrl = resolveTransactionRpcUrl(rpcUrl);
 const blacklistingServiceUrl = process.env.BLACKLISTING_SERVICE_URL || "https://squid-app-3gxnl.ondigitalocean.app/aboutcircles-advanced-analytics2/bot-analytics/blacklist";
-const scoringServiceUrl = process.env.GNOSIS_GROUP_SCORING_URL || "https://squid-app-3gxnl.ondigitalocean.app/aboutcircles-advanced-analytics2/scoring/relative_trustscore/batch";
+const scoringServiceUrl = process.env.GNOSIS_GROUP_SCORING_URL || "https://walrus-app-2-iod58.ondigitalocean.app/aboutcircles-advanced-analytics2/scoring/relative_trustscore";
 const targetGroupAddress = process.env.GNOSIS_GROUP_ADDRESS || "0xC19BC204eb1c1D5B3FE500E5E5dfaBaB625F286c";
 const safeAddress = process.env.GNOSIS_GROUP_SAFE_ADDRESS || "";
 const safeSignerPrivateKey = process.env.GNOSIS_GROUP_SAFE_SIGNER_PRIVATE_KEY || "";
@@ -55,6 +56,7 @@ const scoreFetchTimeoutMs = Math.max(1000, parseEnvInt("GNOSIS_GROUP_SCORE_FETCH
 const scoreThreshold = parseEnvNumber("GNOSIS_GROUP_SCORE_THRESHOLD", DEFAULT_SCORE_THRESHOLD);
 const groupBatchSize = parseEnvInt("GNOSIS_GROUP_BATCH_SIZE", DEFAULT_GROUP_BATCH_SIZE);
 const scoreCacheTtlMs = parseEnvInt("GNOSIS_GROUP_SCORE_CACHE_TTL_MINUTES", DEFAULT_SCORE_CACHE_TTL_MS / 60_000) * 60_000;
+const scoringTargetSetName = process.env.GNOSIS_GROUP_SCORING_TARGET_SET_NAME || DEFAULT_SCORING_TARGET_SET_NAME;
 
 const blacklistTimeoutMs = (() => {
   const raw = process.env.BLACKLIST_TIMEOUT_MS;
@@ -94,6 +96,7 @@ if (!dryRun || canSimulateTransactions) {
 const config: RunConfig = {
   rpcUrl,
   scoringServiceUrl,
+  scoringTargetSetName,
   targetGroupAddress,
   fetchPageSize,
   scoreBatchSize,
@@ -108,6 +111,7 @@ rootLogger.info("Starting gnosis-group run with config:");
 rootLogger.info(`  - rpcUrl=${rpcUrl}`);
 rootLogger.info(`  - txRpcUrl=${txRpcUrl}`);
 rootLogger.info(`  - scoringServiceUrl=${scoringServiceUrl}`);
+rootLogger.info(`  - scoringTargetSetName=${scoringTargetSetName}`);
 rootLogger.info(`  - targetGroupAddress=${targetGroupAddress}`);
 rootLogger.info(`  - fetchPageSize=${fetchPageSize}`);
 rootLogger.info(`  - scoreBatchSize=${scoreBatchSize}`);

--- a/tests/apps/gnosis-group/helpers.spec.ts
+++ b/tests/apps/gnosis-group/helpers.spec.ts
@@ -119,20 +119,17 @@ describe("gnosis-group helpers", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [
-            {address: valid, relative_score: 42},
-            {},
-            {address: "not-an-address", relative_score: 99},
-            {address: valid, relative_score: "44"},
-            {address: valid, relative_score: "oops"}
-          ],
-          "1": "invalid-batch"
-        }
+        results: [
+          {address: valid, relative_score: 42},
+          {},
+          {address: "not-an-address", relative_score: 99},
+          {address: valid, relative_score: "44"},
+          {address: valid, relative_score: "oops"}
+        ]
       })
     });
 
-    const results = await fetchRelativeTrustScores("https://scores.local", [valid], [valid], 30_000);
+    const results = await fetchRelativeTrustScores("https://scores.local", [valid], "all_backers", 30_000);
     expect(results.get("0x4000000000000000000000000000000000000004")).toBe(44);
   });
 
@@ -141,12 +138,26 @@ describe("gnosis-group helpers", () => {
     fetchMock.mockResolvedValueOnce({
       ok: false,
       status: 503,
-      statusText: "Unavailable"
+      statusText: "Unavailable",
+      body: { cancel: jest.fn() }
     });
 
-    await expect(
-      fetchRelativeTrustScores("https://scores.local", [], [], 30_000)
-    ).rejects.toThrow("HTTP 503 Unavailable");
+    const err503 = await fetchRelativeTrustScores("https://scores.local", [], "all_backers", 30_000).catch((e: any) => e);
+    expect(err503.message).toMatch("HTTP 503 Unavailable");
+    expect(err503.code).toBe("SERVER_ERROR");
+    expect(isRetryableFetchError(err503)).toBe(true);
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      body: { cancel: jest.fn() }
+    });
+
+    const err400 = await fetchRelativeTrustScores("https://scores.local", [], "all_backers", 30_000).catch((e: any) => e);
+    expect(err400.message).toMatch("HTTP 400 Bad Request");
+    expect(err400.code).toBeUndefined();
+    expect(isRetryableFetchError(err400)).toBe(false);
 
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -156,7 +167,7 @@ describe("gnosis-group helpers", () => {
     });
 
     await expect(
-      fetchRelativeTrustScores("https://scores.local", [], [], 30_000)
+      fetchRelativeTrustScores("https://scores.local", [], "all_backers", 30_000)
     ).rejects.toThrow("response malformed");
   });
 });

--- a/tests/apps/gnosis-group/runOnce.spec.ts
+++ b/tests/apps/gnosis-group/runOnce.spec.ts
@@ -107,12 +107,10 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [
-            {address: highScoreAddress, relative_score: 75},
-            {address: lowScoreAddress, relative_score: 10}
-          ]
-        }
+        results: [
+          {address: highScoreAddress, relative_score: 75},
+          {address: lowScoreAddress, relative_score: 10}
+        ]
       })
     });
 
@@ -133,7 +131,8 @@ describe("gnosis-group runOnce", () => {
     const [fetchUrl, fetchInit] = fetchMock.mock.calls[0] ?? [];
     expect(fetchUrl).toBe("https://scores.local");
     const requestBody = JSON.parse((fetchInit?.body ?? "{}") as string);
-    expect(requestBody.target_sets).toEqual([[trustedTarget]]);
+    expect(requestBody.target_set_name).toBe("all_backers");
+    expect(requestBody.avatars).toEqual([highScoreAddress, lowScoreAddress]);
   });
 
   it("uses env-defined score threshold when config omits the value", async () => {
@@ -167,9 +166,7 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [{address: trustedTarget, relative_score: 50}]
-        }
+        results: [{address: trustedTarget, relative_score: 50}]
       })
     });
 
@@ -229,9 +226,7 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [{address: allowedAddress, relative_score: 50}]
-        }
+        results: [{address: allowedAddress, relative_score: 50}]
       })
     });
 
@@ -285,12 +280,10 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [
-            {address: alreadyTrusted, relative_score: 75},
-            {address: eligible, relative_score: 80}
-          ]
-        }
+        results: [
+          {address: alreadyTrusted, relative_score: 75},
+          {address: eligible, relative_score: 80}
+        ]
       })
     });
 
@@ -346,13 +339,11 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [
-            {address: first, relative_score: 100},
-            {address: second, relative_score: 100},
-            {address: third, relative_score: 100}
-          ]
-        }
+        results: [
+          {address: first, relative_score: 100},
+          {address: second, relative_score: 100},
+          {address: third, relative_score: 100}
+        ]
       })
     });
 
@@ -409,12 +400,10 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [
-            {address: failing, relative_score: 100},
-            {address: succeeding, relative_score: 100}
-          ]
-        }
+        results: [
+          {address: failing, relative_score: 100},
+          {address: succeeding, relative_score: 100}
+        ]
       })
     });
 
@@ -472,9 +461,7 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [{address: active, relative_score: 60}]
-        }
+        results: [{address: active, relative_score: 60}]
       })
     });
 
@@ -521,9 +508,7 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [{address: active, relative_score: 80}]
-        }
+        results: [{address: active, relative_score: 80}]
       })
     });
 
@@ -549,7 +534,7 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {"0": [{address: eligible, relative_score: 75}]}
+        results: [{address: eligible, relative_score: 75}]
       })
     });
 
@@ -607,9 +592,7 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [{address: active, relative_score: 90}]
-        }
+        results: [{address: active, relative_score: 90}]
       })
     });
 
@@ -731,9 +714,7 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [{address: autoTrusted, relative_score: 25}]
-        }
+        results: [{address: autoTrusted, relative_score: 25}]
       })
     });
 
@@ -748,7 +729,7 @@ describe("gnosis-group runOnce", () => {
     expect(outcome.trustTxHashes).toEqual(["0xtrust_1"]);
     const [, fetchInit] = fetchMock.mock.calls[0] ?? [];
     const requestBody = JSON.parse((fetchInit?.body ?? "{}") as string);
-    expect(requestBody.target_sets).toEqual([[trustedTarget]]);
+    expect(requestBody.target_set_name).toBe("all_backers");
     expect(outcome.untrustTxHashes).toEqual([]);
   });
 
@@ -787,9 +768,7 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {
-          "0": [{address: autoTrusted, relative_score: 25}]
-        }
+        results: [{address: autoTrusted, relative_score: 25}]
       })
     });
 
@@ -928,7 +907,7 @@ describe("gnosis-group runOnce", () => {
       ok: true,
       status: 200,
       statusText: "OK",
-      json: async () => ({status: "success", batches: {}})
+      json: async () => ({status: "success", results: []})
     });
 
     const outcome = await runOnce({
@@ -962,7 +941,7 @@ describe("gnosis-group runOnce", () => {
       ok: true,
       status: 200,
       statusText: "OK",
-      json: async () => ({status: "success", batches: {}})
+      json: async () => ({status: "success", results: []})
     });
 
     const outcome = await runOnce({
@@ -1030,7 +1009,7 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {"0": [{address: allowed, relative_score: 75}]}
+        results: [{address: allowed, relative_score: 75}]
       })
     });
 
@@ -1055,7 +1034,7 @@ describe("gnosis-group runOnce", () => {
       ok: true,
       status: 200,
       statusText: "OK",
-      json: async () => ({status: "success", batches: {}})
+      json: async () => ({status: "success", results: []})
     });
 
     const outcome = await runOnce({
@@ -1102,7 +1081,7 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {"0": [{address: eligible, relative_score: 75}]}
+        results: [{address: eligible, relative_score: 75}]
       })
     });
 
@@ -1151,7 +1130,7 @@ describe("gnosis-group runOnce", () => {
       statusText: "OK",
       json: async () => ({
         status: "success",
-        batches: {"0": [{address: candidate, relative_score: 75}]}
+        results: [{address: candidate, relative_score: 75}]
       })
     });
 
@@ -1187,7 +1166,7 @@ describe("gnosis-group runOnce", () => {
         statusText: "OK",
         json: async () => ({
           status: "success",
-          batches: {"0": [{address: candidate, relative_score: 75}]}
+          results: [{address: candidate, relative_score: 75}]
         })
       });
 


### PR DESCRIPTION
## Summary

- Switch gnosis-group from real-time batch scoring endpoint (`/relative_trustscore/batch` on `squid-app-3gxnl`) to 5-min cached endpoint (`/relative_trustscore` on `walrus-app-2-iod58`)
- HTTP 5xx responses are now retried (tagged with `SERVER_ERROR` code) — prevents unnecessary crashes during scoring service cache rebuilds
- Response body cancelled on HTTP error to prevent TCP socket leaks
- Batch size default increased 20 → 200 (cache lookups are cheap, configurable via `GNOSIS_GROUP_SCORE_BATCH_SIZE`)
- New env var `GNOSIS_GROUP_SCORING_TARGET_SET_NAME` (default: `all_backers`) for server-side named target set

Background: the scoring service team switched the single endpoint to serve pre-computed cached scores (refreshed every 5 min globally). The batch endpoint remains real-time but causes failures under load from other consumers. Since gnosis-group polls every 30 min, the 5-min cache staleness is a non-issue.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 45 gnosis-group tests pass (helpers, runOnce, computeTrustPlan)
- [x] New test coverage for HTTP 5xx retry behavior (503 gets `SERVER_ERROR` code and is retried, 400 is not)
- [x] 7-agent audit completed (0 critical, 3 high addressed)
- [ ] Deploy to prod1 with `DRY_RUN=1`, verify scoring requests succeed in logs
- [ ] Verify score values are reasonable (non-zero for known avatars)