### PR TITLE
fix: detect Safe-level errors in batch fallback, prevent false quarantine

### DIFF
--- a/src/apps/router-tms/logic.ts
+++ b/src/apps/router-tms/logic.ts
@@ -58,6 +58,22 @@ type BulkTrusteesStatsProvider = {
   getLastBulkTrusteesForTrustersStats: () => BulkTrusteesStats;
 };
 
+/** Safe-level error codes that are NOT address-specific — they affect ALL transactions
+ *  regardless of the addresses in the batch payload.
+ *  - GS013: execTransaction failure when gasPrice=0 and safeTxGas=0
+ *  - GS020-GS026: checkNSignatures signature validation failures
+ *  These should NOT trigger per-address probing or quarantine since every address
+ *  would fail identically. */
+const SAFE_LEVEL_ERROR_CODES = ["GS013", "GS020", "GS021", "GS022", "GS023", "GS024", "GS025", "GS026"];
+const SAFE_LEVEL_PATTERN = new RegExp(SAFE_LEVEL_ERROR_CODES.join("|"));
+
+function isSafeLevelError(err: unknown): boolean {
+  if (err == null) return false;
+  const msg = String((err as any)?.message ?? "");
+  const reason = String((err as any)?.reason ?? "");
+  return SAFE_LEVEL_PATTERN.test(msg) || SAFE_LEVEL_PATTERN.test(reason);
+}
+
 export const DEFAULT_ENABLE_BATCH_SIZE = 10;
 export const DEFAULT_FETCH_PAGE_SIZE = 1_000;
 export const DEFAULT_BASE_GROUP_ADDRESS = "0x1ACA75e38263c79d9D4F10dF0635cc6FCfe6F026";
@@ -304,6 +320,23 @@ async function executeBatchWithFallback(
     logger.warn(
       `enableCRCForRouting FAILED (${batchLabel}) for ${batch.length} avatar(s) in base group ${baseGroup}: ${errMsg}`
     );
+
+    // Safe-level errors (e.g. GS026 "Invalid owner") are NOT address-specific.
+    // Probing individual addresses would produce the same error and wrongly
+    // quarantine them all. Fail fast with a clear message instead.
+    if (isSafeLevelError(batchError)) {
+      logger.error(
+        `Safe-level error in ${batchLabel}: ${errMsg}. ` +
+        `This is NOT address-specific — skipping per-address probing. ` +
+        `Check Safe signer configuration (GS026 = signature validation failed, typically signer not an owner or chainId/nonce mismatch).`
+      );
+      return {
+        txHashes: [],
+        enabledCount: 0,
+        quarantinedInThisBatch: [],
+        failedBatchEntry: {baseGroup, batchIndex, batchSize: batch.length, addresses: batch, error: errMsg}
+      };
+    }
 
     // No simulation available — record as failed batch (existing behavior)
     if (!routerService.simulateEnableCRCForRouting) {
@@ -721,6 +754,7 @@ export const __testables = {
   createIsHumanBatchChecker,
   filterHumanAvatars,
   isBlacklisted,
+  isSafeLevelError,
   normalizeAddress,
   normalizeAddressArray,
   validateEnableTargets

--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -242,6 +242,20 @@ async function mainLoop(): Promise<void> {
 }
 
 async function start(): Promise<void> {
+  if (routerService) {
+    try {
+      await routerService.validateSafeOwnership();
+      rootLogger.info("Safe ownership validation passed — signer is a registered owner.");
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      rootLogger.error(`Safe ownership validation FAILED: ${errorMessage}`);
+      await slackService.notifySlackStartOrCrash(
+        `🚨 *Router-TMS Safe ownership check failed*\n\n${errorMessage}`,
+        SlackSeverity.CRITICAL
+      );
+      process.exit(1);
+    }
+  }
   await mainLoop();
 }
 

--- a/src/services/routerService.ts
+++ b/src/services/routerService.ts
@@ -23,6 +23,10 @@ export class RouterService implements IRouterService {
     this.executor = new SafeTransactionExecutor(txRpcUrl, signerPrivateKey, safeAddress);
   }
 
+  async validateSafeOwnership(): Promise<void> {
+    return this.executor.validateOwnership();
+  }
+
   async enableCRCForRouting(baseGroup: string, crcAddresses: string[]): Promise<string> {
     if (crcAddresses.length === 0) {
       throw new Error("enableCRCForRouting requires at least one CRC address.");

--- a/src/services/safeTransactionExecutor.ts
+++ b/src/services/safeTransactionExecutor.ts
@@ -4,6 +4,20 @@ import {TransactionSimulationResult} from "../interfaces/ITransactionSimulation"
 import { retryWithBackoff } from "./retryWithBackoff";
 import { createProvider, primaryRpcUrl } from "./rpcProvider";
 
+export class SafeOwnershipError extends Error {
+  constructor(
+    public readonly signerAddress: string,
+    public readonly safeAddress: string
+  ) {
+    super(
+      `Signer ${signerAddress} is not an owner of Safe ${safeAddress}. ` +
+      `Safe transactions via execTransaction will fail with GS026 until ownership is restored. ` +
+      `Check SAFE_SIGNER_PRIVATE_KEY and SAFE_ADDRESS configuration.`
+    );
+    this.name = "SafeOwnershipError";
+  }
+}
+
 /** Default timeout for waiting on tx confirmation (5 minutes). */
 const DEFAULT_TX_CONFIRMATION_TIMEOUT_MS = 5 * 60 * 1000;
 const GAS_LIMIT_BUFFER_NUMERATOR = 120n;
@@ -55,6 +69,14 @@ export class SafeTransactionExecutor {
       signer: signerPrivateKey,
       safeAddress: this.safeAddress
     });
+  }
+
+  async validateOwnership(): Promise<void> {
+    const safe = await this.safePromise;
+    const isOwner = await safe.isOwner(this.signerAddress);
+    if (!isOwner) {
+      throw new SafeOwnershipError(this.signerAddress, this.safeAddress);
+    }
   }
 
   async execute(

--- a/src/services/safeTransactionExecutor.ts
+++ b/src/services/safeTransactionExecutor.ts
@@ -23,6 +23,19 @@ const DEFAULT_TX_CONFIRMATION_TIMEOUT_MS = 5 * 60 * 1000;
 const GAS_LIMIT_BUFFER_NUMERATOR = 120n;
 const GAS_LIMIT_BUFFER_DENOMINATOR = 100n;
 
+/** Max retries for the create→sign→estimate cycle when a nonce race causes GS026.
+ *  The Safe contract reads nonce from storage (not calldata); if it changed since
+ *  createTransaction fetched it, ecrecover returns a garbage address → GS026. */
+const MAX_NONCE_RACE_RETRIES = 3;
+const GS026_PATTERN = /GS026/;
+
+function isNonceRaceError(err: unknown): boolean {
+  if (err == null) return false;
+  const msg = String((err as any)?.message ?? "");
+  const reason = String((err as any)?.reason ?? "");
+  return GS026_PATTERN.test(msg) || GS026_PATTERN.test(reason);
+}
+
 export class TransactionConfirmationTimeoutError extends Error {
   constructor(public readonly txHash: string, public readonly timeoutMs: number) {
     super(`Tx ${txHash} confirmation timed out after ${timeoutMs}ms`);
@@ -111,17 +124,27 @@ export class SafeTransactionExecutor {
     const normalizedTo = getAddress(to);
     const normalizedValue = typeof value === "bigint" ? value.toString() : value ?? "0";
 
-    const unsignedSafeTx = await safe.createTransaction({
-      transactions: [
-        {
-          to: normalizedTo,
-          value: normalizedValue,
-          data
+    // Retry create→sign→estimate on nonce race (GS026). The Safe contract reads nonce
+    // from storage; if it changed since createTransaction fetched it, ecrecover returns
+    // a garbage address and the Safe reverts with GS026. Re-creating the transaction
+    // fetches the fresh nonce and produces a valid signature.
+    let signedSafeTx!: Awaited<ReturnType<Safe["signTransaction"]>>;
+    let gasLimit!: bigint;
+    for (let attempt = 1; attempt <= MAX_NONCE_RACE_RETRIES; attempt++) {
+      const unsignedSafeTx = await safe.createTransaction({
+        transactions: [{ to: normalizedTo, value: normalizedValue, data }]
+      });
+      signedSafeTx = await safe.signTransaction(unsignedSafeTx);
+      try {
+        gasLimit = await this.estimateExecutionGasLimit(safe, signedSafeTx);
+        break;
+      } catch (err) {
+        if (attempt < MAX_NONCE_RACE_RETRIES && isNonceRaceError(err)) {
+          continue;
         }
-      ]
-    });
-    const signedSafeTx = await safe.signTransaction(unsignedSafeTx);
-    const gasLimit = await this.estimateExecutionGasLimit(safe, signedSafeTx);
+        throw err;
+      }
+    }
 
     // Do NOT retry executeTransaction — if the first attempt reaches the mempool but
     // the response is lost (timeout), a retry would send a second tx with a new EOA nonce,
@@ -157,26 +180,32 @@ export class SafeTransactionExecutor {
     const normalizedTo = getAddress(to);
     const normalizedValue = typeof value === "bigint" ? value.toString() : value ?? "0";
 
-    const unsignedSafeTx = await safe.createTransaction({
-      transactions: [
-        {
-          to: normalizedTo,
-          value: normalizedValue,
-          data
+    // Same nonce-race retry as _executeInner — simulation also reads nonce from storage.
+    for (let attempt = 1; attempt <= MAX_NONCE_RACE_RETRIES; attempt++) {
+      const unsignedSafeTx = await safe.createTransaction({
+        transactions: [{ to: normalizedTo, value: normalizedValue, data }]
+      });
+      const signedSafeTx = await safe.signTransaction(unsignedSafeTx);
+      try {
+        const gasEstimate = await this.estimateExecutionGasLimit(safe, signedSafeTx);
+        const encodedSafeTx = await safe.getEncodedTransaction(signedSafeTx);
+
+        await retryWithBackoff(() => this.provider.call({
+          from: this.signerAddress,
+          to: this.safeAddress,
+          data: encodedSafeTx
+        }));
+
+        return {gasEstimate};
+      } catch (err) {
+        if (attempt < MAX_NONCE_RACE_RETRIES && isNonceRaceError(err)) {
+          continue;
         }
-      ]
-    });
-    const signedSafeTx = await safe.signTransaction(unsignedSafeTx);
-    const gasEstimate = await this.estimateExecutionGasLimit(safe, signedSafeTx);
-    const encodedSafeTx = await safe.getEncodedTransaction(signedSafeTx);
-
-    await retryWithBackoff(() => this.provider.call({
-      from: this.signerAddress,
-      to: this.safeAddress,
-      data: encodedSafeTx
-    }));
-
-    return {gasEstimate};
+        throw err;
+      }
+    }
+    // Unreachable — loop always breaks or throws
+    throw new Error("Nonce race retry loop exited unexpectedly");
   }
 
   private async estimateExecutionGasLimit(safe: Safe, safeTx: Awaited<ReturnType<Safe["createTransaction"]>>): Promise<bigint> {

--- a/src/services/safeTransactionExecutor.ts
+++ b/src/services/safeTransactionExecutor.ts
@@ -140,6 +140,11 @@ export class SafeTransactionExecutor {
         break;
       } catch (err) {
         if (attempt < MAX_NONCE_RACE_RETRIES && isNonceRaceError(err)) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          console.warn(
+            `[SafeExecutor] GS026 nonce race on attempt ${attempt}/${MAX_NONCE_RACE_RETRIES}, ` +
+            `retrying create→sign→estimate: ${errMsg}`
+          );
           continue;
         }
         throw err;
@@ -199,6 +204,11 @@ export class SafeTransactionExecutor {
         return {gasEstimate};
       } catch (err) {
         if (attempt < MAX_NONCE_RACE_RETRIES && isNonceRaceError(err)) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          console.warn(
+            `[SafeExecutor] GS026 nonce race during simulation on attempt ${attempt}/${MAX_NONCE_RACE_RETRIES}, ` +
+            `retrying create→sign→estimate: ${errMsg}`
+          );
           continue;
         }
         throw err;

--- a/tests/apps/router-tms/logic.spec.ts
+++ b/tests/apps/router-tms/logic.spec.ts
@@ -22,6 +22,7 @@ const {
   createIsHumanBatchChecker,
   createIsHumanChecker,
   filterHumanAvatars,
+  isSafeLevelError,
   normalizeAddress,
   normalizeAddressArray,
   validateEnableTargets
@@ -649,6 +650,121 @@ describe("router-tms runOnce", () => {
     const enabled = await enablementStore.loadEnabledAddresses();
     expect(enabled.map(a => a.toLowerCase())).toContain(humanCarol.toLowerCase());
     expect(enabled.map(a => a.toLowerCase())).not.toContain(humanBob.toLowerCase());
+  });
+});
+
+describe("isSafeLevelError", () => {
+  it("returns true for GS026 in error message", () => {
+    expect(isSafeLevelError(new Error('execution reverted: "GS026"'))).toBe(true);
+  });
+
+  it("returns true for GS013 in error reason field", () => {
+    const err = new Error("CALL_EXCEPTION");
+    (err as any).reason = "GS013";
+    expect(isSafeLevelError(err)).toBe(true);
+  });
+
+  it("returns true for other GS02x signature validation codes", () => {
+    expect(isSafeLevelError(new Error("GS020"))).toBe(true);
+    expect(isSafeLevelError(new Error("GS021"))).toBe(true);
+    expect(isSafeLevelError(new Error("GS024"))).toBe(true);
+    expect(isSafeLevelError(new Error("GS025"))).toBe(true);
+  });
+
+  it("returns false for generic revert errors", () => {
+    expect(isSafeLevelError(new Error("execution reverted"))).toBe(false);
+    expect(isSafeLevelError(new Error("CALL_EXCEPTION for 0xabc"))).toBe(false);
+  });
+
+  it("returns false for transient RPC errors", () => {
+    expect(isSafeLevelError(new Error("evm timeout"))).toBe(false);
+    expect(isSafeLevelError(new Error("rate limit exceeded"))).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isSafeLevelError(null)).toBe(false);
+    expect(isSafeLevelError(undefined)).toBe(false);
+  });
+});
+
+describe("Safe-level error short-circuit in batch fallback", () => {
+  it("skips per-address probing and does not quarantine on GS026", async () => {
+    const humanAlice = getAddress("0x2000000000000000000000000000000000000BA0");
+    const humanBob = getAddress("0x2000000000000000000000000000000000000BA1");
+    const humanCarol = getAddress("0x2000000000000000000000000000000000000BA2");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [humanAlice, humanBob, humanCarol];
+    circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
+
+    const routerService = new FakeRouterService();
+    routerService.failWith = new Error('execution reverted: "GS026"');
+
+    const enablementStore = new FakeRouterEnablementStore();
+    const deps = makeDeps({circlesRpc, routerService, enablementStore});
+    const cfg = makeConfig({dryRun: false, enableBatchSize: 10});
+
+    const outcome = await runOnce(deps, cfg);
+
+    // No addresses should be quarantined — GS026 is a Safe-level error
+    expect(outcome.quarantinedAddresses).toHaveLength(0);
+    // Batch should be recorded as failed
+    expect(outcome.failedBatches).toHaveLength(1);
+    expect(outcome.executedEnableCount).toBe(0);
+    // No simulation calls — probing was skipped entirely
+    expect(routerService.simulationCalls).toBe(0);
+  });
+
+  it("skips probing on GS026 even for multi-batch runs", async () => {
+    const humans = [
+      getAddress("0x2000000000000000000000000000000000000BB0"),
+      getAddress("0x2000000000000000000000000000000000000BB1"),
+      getAddress("0x2000000000000000000000000000000000000BB2"),
+      getAddress("0x2000000000000000000000000000000000000BB3"),
+      getAddress("0x2000000000000000000000000000000000000BB4"),
+    ];
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = humans;
+    circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
+
+    const routerService = new FakeRouterService();
+    routerService.failWith = new Error('execution reverted: "GS026"');
+
+    const deps = makeDeps({circlesRpc, routerService});
+    const cfg = makeConfig({dryRun: false, enableBatchSize: 2});
+
+    const outcome = await runOnce(deps, cfg);
+
+    // All batches fail but NO addresses quarantined
+    expect(outcome.quarantinedAddresses).toHaveLength(0);
+    expect(outcome.failedBatches.length).toBeGreaterThan(0);
+    expect(routerService.simulationCalls).toBe(0);
+  });
+
+  it("still quarantines on non-Safe-level errors (existing behavior)", async () => {
+    const humanAlice = getAddress("0x2000000000000000000000000000000000000BC0");
+    const humanBob = getAddress("0x2000000000000000000000000000000000000BC1");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [humanAlice, humanBob];
+    circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
+
+    const routerService = new FakeRouterService();
+    routerService.failWith = new Error("execution reverted: some inner contract error");
+    // Simulation also fails for both — they get quarantined (non-Safe error)
+    routerService.simulationFailAddresses.add(humanAlice.toLowerCase());
+    routerService.simulationFailAddresses.add(humanBob.toLowerCase());
+
+    const deps = makeDeps({circlesRpc, routerService});
+    const cfg = makeConfig({dryRun: false, enableBatchSize: 10});
+
+    const outcome = await runOnce(deps, cfg);
+
+    // Both addresses should be quarantined (non-Safe-level error, existing behavior)
+    expect(outcome.quarantinedAddresses).toHaveLength(2);
+    // Probing DID happen
+    expect(routerService.simulationCalls).toBe(2);
   });
 });
 

--- a/tests/services/safeOwnershipError.spec.ts
+++ b/tests/services/safeOwnershipError.spec.ts
@@ -1,0 +1,18 @@
+import {SafeOwnershipError} from "../../src/services/safeTransactionExecutor";
+
+describe("SafeOwnershipError", () => {
+  it("stores signer and safe addresses", () => {
+    const err = new SafeOwnershipError("0xSignerAddress", "0xSafeAddress");
+    expect(err.signerAddress).toBe("0xSignerAddress");
+    expect(err.safeAddress).toBe("0xSafeAddress");
+    expect(err.name).toBe("SafeOwnershipError");
+  });
+
+  it("includes actionable guidance in error message", () => {
+    const err = new SafeOwnershipError("0xABC", "0xDEF");
+    expect(err.message).toContain("GS026");
+    expect(err.message).toContain("0xABC");
+    expect(err.message).toContain("0xDEF");
+    expect(err.message).toContain("SAFE_SIGNER_PRIVATE_KEY");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `isSafeLevelError()` classifier detecting GS013/GS020-GS026 Safe signature-validation errors
- Short-circuit `executeBatchWithFallback()` before Phase 2 probing on Safe-level errors — **no false quarantine**, no wasted simulation calls
- Add `SafeOwnershipError` + `validateOwnership()` on `SafeTransactionExecutor` with startup validation in router-tms
- Fixes the production incident where GS026 caused every address to be wrongly quarantined as "revert-causing"

## Context
PR #73 added per-address probing to isolate revert-causing addresses in batch transactions. However, Safe-level errors (e.g. GS026 "Invalid owner") are not address-specific — they fire at the signature validation layer before the inner call executes. The probing mechanism classified every individual probe as "bad" and quarantined all addresses, when none were actually problematic.

## Test plan
- [x] `isSafeLevelError` classifier: true for GS026/GS013/GS020-GS025, false for generic reverts and transient errors
- [x] GS026 short-circuit: no quarantine, batch recorded as failed, zero simulation calls
- [x] Multi-batch GS026: all batches fail cleanly, no addresses quarantined
- [x] Non-Safe errors: existing quarantine behavior preserved (regression test)
- [x] `SafeOwnershipError` stores addresses and actionable message
- [x] 369/369 tests pass, 98.51% coverage