### PR TITLE
fix: GS026 audit tech debt — silent failures, ownership validation, quarantine TTL

### DIFF
--- a/fakes/fakes.ts
+++ b/fakes/fakes.ts
@@ -414,6 +414,7 @@ export class FakeRouterService implements IRouterService {
 
 export class FakeRouterEnablementStore implements IRouterEnablementStore {
   private readonly enabled = new Set<string>();
+  readonly quarantined = new Set<string>();
 
   constructor(initial?: string[]) {
     if (initial) {
@@ -428,6 +429,16 @@ export class FakeRouterEnablementStore implements IRouterEnablementStore {
   async markEnabled(addresses: string[]): Promise<void> {
     for (const address of addresses) {
       this.enabled.add(address.toLowerCase());
+    }
+  }
+
+  async loadQuarantinedAddresses(): Promise<string[]> {
+    return Array.from(this.quarantined);
+  }
+
+  async markQuarantined(addresses: string[]): Promise<void> {
+    for (const address of addresses) {
+      this.quarantined.add(address.toLowerCase());
     }
   }
 }

--- a/src/apps/crc-backers/main.ts
+++ b/src/apps/crc-backers/main.ts
@@ -99,7 +99,9 @@ process.on('uncaughtException', async (err) => {
   rootLogger.error("Uncaught exception:", formatErrorWithCauses(err instanceof Error ? err : new Error(String(err))));
   try {
     await slackService.notifySlackStartOrCrash(`💥 *crc-backers* Uncaught exception: ${err?.message || err}`, SlackSeverity.CRITICAL);
-  } catch {}
+  } catch (slackErr) {
+    console.error("Failed to send Slack crash notification:", slackErr);
+  }
   process.exit(1);
 });
 
@@ -108,7 +110,9 @@ process.on('unhandledRejection', async (reason) => {
   rootLogger.error("Unhandled rejection:", formatErrorWithCauses(error));
   try {
     await slackService.notifySlackStartOrCrash(`💥 *crc-backers* Unhandled rejection: ${error.message}`, SlackSeverity.CRITICAL);
-  } catch {}
+  } catch (slackErr) {
+    console.error("Failed to send Slack crash notification:", slackErr);
+  }
   process.exit(1);
 });
 
@@ -214,7 +218,7 @@ async function loop(leaderElection: LeaderElection | null) {
         void slackService.notifySlackStartOrCrash(
           `🚨 *crc-backers* crashing after ${consecutiveErrors} consecutive failures.\nLast error: ${baseError.message}`,
           SlackSeverity.CRITICAL
-        ).catch(() => {});
+        ).catch((e) => rootLogger.warn("Failed to send Slack notification:", e));
         setTimeout(() => process.exit(1), 3000).unref();
         return;
       }
@@ -247,6 +251,24 @@ async function refreshBlacklist(): Promise<void> {
 
 async function main() {
   startMetricsServer("crc-backers");
+  if (groupService?.validateSafeOwnership) {
+    try {
+      await groupService.validateSafeOwnership();
+      rootLogger.info("Safe ownership validation passed — signer is a registered owner.");
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      rootLogger.error(`Safe ownership validation FAILED: ${errorMessage}`);
+      try {
+        await slackService.notifySlackStartOrCrash(
+          `🚨 *crc-backers Safe ownership check failed*\n\n${errorMessage}`,
+          SlackSeverity.CRITICAL
+        );
+      } catch (slackErr) {
+        rootLogger.warn("Failed to send Slack ownership failure notification:", slackErr);
+      }
+      process.exit(1);
+    }
+  }
   leaderElection = await LeaderElection.create(
     process.env.LEADER_DB_URL,
     process.env.INSTANCE_ID,

--- a/src/apps/gnosis-group/main.ts
+++ b/src/apps/gnosis-group/main.ts
@@ -221,7 +221,7 @@ async function mainLoop(): Promise<void> {
       rootLogger.error(formatErrorWithCauses(error));
       if (errorTracker.shouldAlert()) {
         rootLogger.error("Consecutive error threshold reached. Exiting with code 1.");
-        void notifySlackRunError(error, consecutiveErrors).catch(() => {});
+        void notifySlackRunError(error, consecutiveErrors).catch((e) => rootLogger.warn("Failed to send Slack notification:", e));
         setTimeout(() => process.exit(1), 3000).unref();
         return;
       }
@@ -310,6 +310,24 @@ async function refreshBlacklist(): Promise<void> {
 }
 
 async function start(): Promise<void> {
+  if (groupService?.validateSafeOwnership) {
+    try {
+      await groupService.validateSafeOwnership();
+      rootLogger.info("Safe ownership validation passed — signer is a registered owner.");
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      rootLogger.error(`Safe ownership validation FAILED: ${errorMessage}`);
+      try {
+        await slackService.notifySlackStartOrCrash(
+          `🚨 *gnosis-group Safe ownership check failed*\n\n${errorMessage}`,
+          SlackSeverity.CRITICAL
+        );
+      } catch (slackErr) {
+        rootLogger.warn("Failed to send Slack ownership failure notification:", slackErr);
+      }
+      process.exit(1);
+    }
+  }
   await mainLoop();
 }
 
@@ -317,7 +335,7 @@ start().catch((cause) => {
   const error = cause instanceof Error ? cause : new Error(String(cause));
   rootLogger.error("gnosis-group run encountered an unrecoverable error:");
   rootLogger.error(formatErrorWithCauses(error));
-  void notifySlackFatal(error).catch(() => {});
+  void notifySlackFatal(error).catch((e) => rootLogger.warn("Failed to send Slack notification:", e));
   setTimeout(() => process.exit(1), 3000).unref();
 });
 

--- a/src/apps/gp-crc/main.ts
+++ b/src/apps/gp-crc/main.ts
@@ -132,7 +132,9 @@ process.on("uncaughtException", async (error) => {
   rootLogger.error("Uncaught exception:", formatErrorWithCauses(error instanceof Error ? error : new Error(String(error))));
   try {
     await slackService.notifySlackStartOrCrash(`💥 *gp-crc* Uncaught exception: ${error?.message || error}`, SlackSeverity.CRITICAL);
-  } catch {}
+  } catch (slackErr) {
+    console.error("Failed to send Slack crash notification:", slackErr);
+  }
   process.exit(1);
 });
 
@@ -141,7 +143,9 @@ process.on("unhandledRejection", async (reason) => {
   rootLogger.error("Unhandled rejection:", formatErrorWithCauses(error));
   try {
     await slackService.notifySlackStartOrCrash(`💥 *gp-crc* Unhandled rejection: ${error.message}`, SlackSeverity.CRITICAL);
-  } catch {}
+  } catch (slackErr) {
+    console.error("Failed to send Slack crash notification:", slackErr);
+  }
   process.exit(1);
 });
 
@@ -197,7 +201,7 @@ async function mainLoop(): Promise<void> {
       rootLogger.error(formatErrorWithCauses(error));
       if (errorTracker.shouldAlert()) {
         rootLogger.error("Consecutive error threshold reached. Exiting with code 1.");
-        void notifySlackRunError(error, consecutiveErrors).catch(() => {});
+        void notifySlackRunError(error, consecutiveErrors).catch((e) => rootLogger.warn("Failed to send Slack notification:", e));
         setTimeout(() => process.exit(1), 3000).unref();
         return;
       }
@@ -248,6 +252,24 @@ async function refreshBlacklist(): Promise<void> {
 }
 
 async function start(): Promise<void> {
+  if (groupService?.validateSafeOwnership) {
+    try {
+      await groupService.validateSafeOwnership();
+      rootLogger.info("Safe ownership validation passed — signer is a registered owner.");
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      rootLogger.error(`Safe ownership validation FAILED: ${errorMessage}`);
+      try {
+        await slackService.notifySlackStartOrCrash(
+          `🚨 *gp-crc Safe ownership check failed*\n\n${errorMessage}`,
+          SlackSeverity.CRITICAL
+        );
+      } catch (slackErr) {
+        rootLogger.warn("Failed to send Slack ownership failure notification:", slackErr);
+      }
+      process.exit(1);
+    }
+  }
   await mainLoop();
 }
 

--- a/src/apps/oic/main.ts
+++ b/src/apps/oic/main.ts
@@ -106,7 +106,9 @@ process.on('SIGINT', () => { void gracefulShutdown('SIGINT'); });
 process.on('uncaughtException', async (err) => {
   try {
     await slackService.notifySlackStartOrCrash(`💥 Uncaught exception: ${err?.message || err}`, SlackSeverity.CRITICAL);
-  } catch {}
+  } catch (slackErr) {
+    console.error("Failed to send Slack crash notification:", slackErr);
+  }
   rootLogger.error(err);
   process.exit(1);
 });
@@ -114,7 +116,9 @@ process.on('uncaughtException', async (err) => {
 process.on('unhandledRejection', async (reason: any) => {
   try {
     await slackService.notifySlackStartOrCrash(`💥 Unhandled rejection: ${reason?.message || String(reason)}`, SlackSeverity.CRITICAL);
-  } catch {}
+  } catch (slackErr) {
+    console.error("Failed to send Slack crash notification:", slackErr);
+  }
   rootLogger.error(reason);
   process.exit(1);
 });
@@ -234,7 +238,7 @@ async function loop() {
       rootLogger.error(formatErrorWithCauses(error));
       if (errorTracker.shouldAlert()) {
         rootLogger.error("Consecutive error threshold reached. Exiting with code 1.");
-        void notifySlackRunError(error, consecutiveErrors).catch(() => {});
+        void notifySlackRunError(error, consecutiveErrors).catch((e) => rootLogger.warn("Failed to send Slack notification:", e));
         setTimeout(() => process.exit(1), 3000).unref();
         return;
       }

--- a/src/apps/router-tms/enablementStore.ts
+++ b/src/apps/router-tms/enablementStore.ts
@@ -2,14 +2,19 @@ import {getAddress} from "ethers";
 
 import {IRouterEnablementStore} from "../../interfaces/IRouterEnablementStore";
 
+const DEFAULT_QUARANTINE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
 function normalize(address: string): string {
   return getAddress(address).toLowerCase();
 }
 
 export class InMemoryRouterEnablementStore implements IRouterEnablementStore {
   private readonly enabled = new Set<string>();
+  private readonly quarantined = new Map<string, number>();
+  private readonly quarantineTtlMs: number;
 
-  constructor(initialAddresses: string[] = []) {
+  constructor(initialAddresses: string[] = [], quarantineTtlMs: number = DEFAULT_QUARANTINE_TTL_MS) {
+    this.quarantineTtlMs = quarantineTtlMs;
     this.addAddresses(initialAddresses);
   }
 
@@ -19,6 +24,31 @@ export class InMemoryRouterEnablementStore implements IRouterEnablementStore {
 
   async markEnabled(addresses: string[]): Promise<void> {
     this.addAddresses(addresses);
+  }
+
+  async loadQuarantinedAddresses(): Promise<string[]> {
+    const now = Date.now();
+    const expired: string[] = [];
+    for (const [addr, ts] of this.quarantined) {
+      if (now - ts > this.quarantineTtlMs) {
+        expired.push(addr);
+      }
+    }
+    for (const addr of expired) {
+      this.quarantined.delete(addr);
+    }
+    return Array.from(this.quarantined.keys());
+  }
+
+  async markQuarantined(addresses: string[]): Promise<void> {
+    const now = Date.now();
+    for (const address of addresses) {
+      try {
+        this.quarantined.set(normalize(address), now);
+      } catch {
+        // Ignore invalid addresses
+      }
+    }
   }
 
   private addAddresses(addresses: string[]): void {

--- a/src/apps/router-tms/logic.ts
+++ b/src/apps/router-tms/logic.ts
@@ -23,12 +23,15 @@ export type Deps = {
   enablementStore: IRouterEnablementStore;
 };
 
+export type FailureType = "safe-level" | "address-specific" | "unknown";
+
 export type FailedBatch = {
   baseGroup: string;
   batchIndex: number;
   batchSize: number;
   addresses: string[];
   error: string;
+  failureType: FailureType;
 };
 
 export type RunOutcome = {
@@ -205,17 +208,23 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
   const txHashes: string[] = [];
   let executedEnableCount = 0;
   const failedBatches: FailedBatch[] = [];
-  // Quarantine is per-run and global across base groups. This is safe because each avatar
-  // is assigned to exactly one base group (via buildAvatarBaseGroupAssignments) and cannot
-  // appear in multiple targets. If this invariant changes, quarantine should be keyed by
-  // (baseGroup, address) to avoid cross-group contamination.
-  const quarantined = new Set<string>();
+  // Quarantine is global across base groups. This is safe because each avatar is assigned
+  // to exactly one base group (via buildAvatarBaseGroupAssignments) and cannot appear in
+  // multiple targets. Persisted quarantine with TTL avoids re-probing permanently bad
+  // addresses every run cycle.
+  const persistedQuarantined = new Set(
+    (await enablementStore.loadQuarantinedAddresses()).map(a => a.toLowerCase())
+  );
+  const quarantined = new Set<string>(persistedQuarantined);
+  if (persistedQuarantined.size > 0) {
+    logger.info(`Loaded ${persistedQuarantined.size} previously quarantined address(es).`);
+  }
 
   for (const target of validTargets) {
     const batches = chunkArray(target.addresses, enableBatchSize);
     for (let batchIndex = 0; batchIndex < batches.length; batchIndex += 1) {
       const rawBatch = batches[batchIndex];
-      const batch = rawBatch.filter((addr) => !quarantined.has(addr));
+      const batch = rawBatch.filter((addr) => !quarantined.has(addr.toLowerCase()));
       if (batch.length === 0) {
         logger.info(
           `Skipping batch ${batchIndex + 1}/${batches.length} for base group ${target.baseGroup} — all addresses quarantined.`
@@ -246,7 +255,8 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
               batchIndex: batchIndex + 1,
               batchSize: batch.length,
               addresses: batch,
-              error: errMsg
+              error: errMsg,
+              failureType: "unknown"
             });
           }
         } else {
@@ -264,12 +274,18 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
       txHashes.push(...result.txHashes);
       executedEnableCount += result.enabledCount;
       for (const addr of result.quarantinedInThisBatch) {
-        quarantined.add(addr);
+        quarantined.add(addr.toLowerCase());
       }
       if (result.failedBatchEntry) {
         failedBatches.push(result.failedBatchEntry);
       }
     }
+  }
+
+  // Persist newly quarantined addresses (don't reset TTL on previously known ones)
+  const newlyQuarantined = Array.from(quarantined).filter(a => !persistedQuarantined.has(a));
+  if (newlyQuarantined.length > 0) {
+    await enablementStore.markQuarantined(newlyQuarantined);
   }
 
   return {
@@ -281,7 +297,7 @@ export async function runOnce(deps: Deps, cfg: RunConfig): Promise<RunOutcome> {
     pendingEnableCount,
     executedEnableCount: dryRun ? 0 : executedEnableCount,
     failedBatches,
-    quarantinedAddresses: Array.from(quarantined),
+    quarantinedAddresses: newlyQuarantined,
     dryRun,
     txHashes
   };
@@ -334,7 +350,7 @@ async function executeBatchWithFallback(
         txHashes: [],
         enabledCount: 0,
         quarantinedInThisBatch: [],
-        failedBatchEntry: {baseGroup, batchIndex, batchSize: batch.length, addresses: batch, error: errMsg}
+        failedBatchEntry: {baseGroup, batchIndex, batchSize: batch.length, addresses: batch, error: errMsg, failureType: "safe-level"}
       };
     }
 
@@ -345,7 +361,7 @@ async function executeBatchWithFallback(
         txHashes: [],
         enabledCount: 0,
         quarantinedInThisBatch: [],
-        failedBatchEntry: {baseGroup, batchIndex, batchSize: batch.length, addresses: batch, error: errMsg}
+        failedBatchEntry: {baseGroup, batchIndex, batchSize: batch.length, addresses: batch, error: errMsg, failureType: "unknown"}
       };
     }
 
@@ -357,7 +373,7 @@ async function executeBatchWithFallback(
         txHashes: [],
         enabledCount: 0,
         quarantinedInThisBatch: newlyQuarantined,
-        failedBatchEntry: {baseGroup, batchIndex, batchSize: 1, addresses: batch, error: errMsg}
+        failedBatchEntry: {baseGroup, batchIndex, batchSize: 1, addresses: batch, error: errMsg, failureType: "address-specific"}
       };
     }
 
@@ -396,7 +412,7 @@ async function executeBatchWithFallback(
         txHashes: [],
         enabledCount: 0,
         quarantinedInThisBatch: newlyQuarantined,
-        failedBatchEntry: {baseGroup, batchIndex, batchSize: batch.length, addresses: batch, error: errMsg}
+        failedBatchEntry: {baseGroup, batchIndex, batchSize: batch.length, addresses: batch, error: errMsg, failureType: "address-specific"}
       };
     }
 
@@ -417,7 +433,7 @@ async function executeBatchWithFallback(
         txHashes: [],
         enabledCount: 0,
         quarantinedInThisBatch: newlyQuarantined,
-        failedBatchEntry: {baseGroup, batchIndex, batchSize: batch.length, addresses: batch, error: retryMsg}
+        failedBatchEntry: {baseGroup, batchIndex, batchSize: good.length, addresses: good, error: retryMsg, failureType: "unknown"}
       };
     }
   }

--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -52,7 +52,8 @@ const blacklistTimeoutMs = (() => {
   return parsed;
 })();
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl, blacklistTimeoutMs);
-const enablementStore = new InMemoryRouterEnablementStore();
+const quarantineTtlHours = parseEnvInt("ROUTER_QUARANTINE_TTL_HOURS", 24);
+const enablementStore = new InMemoryRouterEnablementStore([], quarantineTtlHours * 60 * 60 * 1000);
 const errorsBeforeCrash = Math.max(1, parseEnvInt("ERRORS_BEFORE_CRASH", 5));
 const errorTracker = new ConsecutiveErrorTracker(errorsBeforeCrash);
 let leaderElection: LeaderElection | null = null;
@@ -124,7 +125,9 @@ process.on("uncaughtException", async (error) => {
   rootLogger.error("Uncaught exception:", formatErrorWithCauses(error instanceof Error ? error : new Error(String(error))));
   try {
     await slackService.notifySlackStartOrCrash(`💥 *router-tms* Uncaught exception: ${error?.message || error}`, SlackSeverity.CRITICAL);
-  } catch {}
+  } catch (slackErr) {
+    console.error("Failed to send Slack crash notification:", slackErr);
+  }
   process.exit(1);
 });
 
@@ -133,7 +136,9 @@ process.on("unhandledRejection", async (reason) => {
   rootLogger.error("Unhandled rejection:", formatErrorWithCauses(error));
   try {
     await slackService.notifySlackStartOrCrash(`💥 *router-tms* Unhandled rejection: ${error.message}`, SlackSeverity.CRITICAL);
-  } catch {}
+  } catch (slackErr) {
+    console.error("Failed to send Slack crash notification:", slackErr);
+  }
   process.exit(1);
 });
 
@@ -179,7 +184,7 @@ async function mainLoop(): Promise<void> {
         rootLogger.error(`All ${outcome.failedBatches.length} batch(es) failed — counting as error ${consecutiveErrors} of ${errorsBeforeCrash}`);
         if (errorTracker.shouldAlert()) {
           rootLogger.error("Consecutive error threshold reached. Exiting with code 1.");
-          void notifySlackRunError(new Error(`All batches failed: ${outcome.failedBatches.map(fb => fb.error).join("; ")}`), consecutiveErrors).catch(() => {});
+          void notifySlackRunError(new Error(`All batches failed: ${outcome.failedBatches.map(fb => fb.error).join("; ")}`), consecutiveErrors).catch((e) => rootLogger.warn("Failed to send Slack notification:", e));
           setTimeout(() => process.exit(1), 3000).unref();
           return;
         }
@@ -210,12 +215,12 @@ async function mainLoop(): Promise<void> {
           `Quarantined ${outcome.quarantinedAddresses.length} address(es) that cause on-chain reverts: ` +
           outcome.quarantinedAddresses.join(", ")
         );
-        void notifySlackQuarantine(outcome.quarantinedAddresses).catch(() => {});
+        void notifySlackQuarantine(outcome.quarantinedAddresses).catch((e) => rootLogger.warn("Failed to send Slack notification:", e));
       }
       if (outcome.failedBatches.length > 0) {
         for (const fb of outcome.failedBatches) {
           runLogger.warn(
-            `Failed batch ${fb.batchIndex} (${fb.batchSize} addresses) for base group ${fb.baseGroup}: ${fb.error}`
+            `Failed batch ${fb.batchIndex} (${fb.batchSize} addresses, ${fb.failureType}) for base group ${fb.baseGroup}: ${fb.error}`
           );
         }
       }
@@ -230,7 +235,7 @@ async function mainLoop(): Promise<void> {
       rootLogger.error(formatErrorWithCauses(error));
       if (errorTracker.shouldAlert()) {
         rootLogger.error("Consecutive error threshold reached. Exiting with code 1.");
-        void notifySlackRunError(error, consecutiveErrors).catch(() => {});
+        void notifySlackRunError(error, consecutiveErrors).catch((e) => rootLogger.warn("Failed to send Slack notification:", e));
         setTimeout(() => process.exit(1), 3000).unref();
         return;
       }
@@ -249,10 +254,14 @@ async function start(): Promise<void> {
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
       rootLogger.error(`Safe ownership validation FAILED: ${errorMessage}`);
-      await slackService.notifySlackStartOrCrash(
-        `🚨 *Router-TMS Safe ownership check failed*\n\n${errorMessage}`,
-        SlackSeverity.CRITICAL
-      );
+      try {
+        await slackService.notifySlackStartOrCrash(
+          `🚨 *Router-TMS Safe ownership check failed*\n\n${errorMessage}`,
+          SlackSeverity.CRITICAL
+        );
+      } catch (slackErr) {
+        rootLogger.warn("Failed to send Slack ownership failure notification:", slackErr);
+      }
       process.exit(1);
     }
   }
@@ -335,6 +344,7 @@ function parseEnvInt(name: string, fallback: number): number {
 
   const value = Number.parseInt(raw, 10);
   if (Number.isNaN(value)) {
+    rootLogger.warn(`Invalid integer for ${name}='${raw}', using fallback ${fallback}.`);
     return fallback;
   }
   return value;

--- a/src/interfaces/IGroupService.ts
+++ b/src/interfaces/IGroupService.ts
@@ -11,4 +11,5 @@ export interface IGroupService {
     fetchGroupOwnerAndService(groupAddress: string): Promise<GroupOwnerAndServiceAddress>;
     simulateTrustBatchWithConditions?(groupAddress: string, trusteeAddresses: string[]): Promise<TransactionSimulationResult>;
     simulateUntrustBatch?(groupAddress: string, trusteeAddresses: string[]): Promise<TransactionSimulationResult>;
+    validateSafeOwnership?(): Promise<void>;
 }

--- a/src/interfaces/IRouterEnablementStore.ts
+++ b/src/interfaces/IRouterEnablementStore.ts
@@ -8,5 +8,17 @@ export interface IRouterEnablementStore {
    * Records the provided avatar addresses as having been enabled for routing.
    */
   markEnabled(addresses: string[]): Promise<void>;
+
+  /**
+   * Returns addresses currently quarantined (not yet expired).
+   * Implementations should evict entries whose TTL has elapsed.
+   */
+  loadQuarantinedAddresses(): Promise<string[]>;
+
+  /**
+   * Records the provided addresses as quarantined (cause on-chain reverts).
+   * Each entry starts a fresh TTL from the time of this call.
+   */
+  markQuarantined(addresses: string[]): Promise<void>;
 }
 

--- a/src/services/safeGroupService.ts
+++ b/src/services/safeGroupService.ts
@@ -17,6 +17,10 @@ export class SafeGroupService implements IGroupService {
     this.executor = new SafeTransactionExecutor(txRpcUrl, signerPrivateKey, safeAddress);
   }
 
+  async validateSafeOwnership(): Promise<void> {
+    return this.executor.validateOwnership();
+  }
+
   async trustBatchWithConditions(groupAddress: string, trusteeAddresses: string[]): Promise<string> {
     const data = GROUP_INTERFACE.encodeFunctionData("trustBatchWithConditions", [
       trusteeAddresses,

--- a/src/services/safeTransactionExecutor.ts
+++ b/src/services/safeTransactionExecutor.ts
@@ -29,7 +29,7 @@ const GAS_LIMIT_BUFFER_DENOMINATOR = 100n;
 const MAX_NONCE_RACE_RETRIES = 3;
 const GS026_PATTERN = /GS026/;
 
-function isNonceRaceError(err: unknown): boolean {
+export function isNonceRaceError(err: unknown): boolean {
   if (err == null) return false;
   const msg = String((err as any)?.message ?? "");
   const reason = String((err as any)?.reason ?? "");

--- a/tests/apps/router-tms/enablementStore.spec.ts
+++ b/tests/apps/router-tms/enablementStore.spec.ts
@@ -1,0 +1,113 @@
+import {InMemoryRouterEnablementStore} from "../../../src/apps/router-tms/enablementStore";
+
+describe("InMemoryRouterEnablementStore", () => {
+  let originalDateNow: () => number;
+  let fakeTime: number;
+
+  beforeEach(() => {
+    originalDateNow = Date.now;
+    fakeTime = 1_000_000;
+    Date.now = () => fakeTime;
+  });
+
+  afterEach(() => {
+    Date.now = originalDateNow;
+  });
+
+  it("stores and retrieves enabled addresses", async () => {
+    const store = new InMemoryRouterEnablementStore();
+    await store.markEnabled(["0x1000000000000000000000000000000000000001"]);
+
+    const enabled = await store.loadEnabledAddresses();
+    expect(enabled).toHaveLength(1);
+  });
+
+  it("initializes with addresses from constructor", async () => {
+    const store = new InMemoryRouterEnablementStore([
+      "0x1000000000000000000000000000000000000001",
+      "0x1000000000000000000000000000000000000002"
+    ]);
+
+    const enabled = await store.loadEnabledAddresses();
+    expect(enabled).toHaveLength(2);
+  });
+
+  it("stores and retrieves quarantined addresses", async () => {
+    const store = new InMemoryRouterEnablementStore();
+    await store.markQuarantined(["0x2000000000000000000000000000000000000001"]);
+
+    const quarantined = await store.loadQuarantinedAddresses();
+    expect(quarantined).toHaveLength(1);
+    expect(quarantined[0]).toBe("0x2000000000000000000000000000000000000001".toLowerCase());
+  });
+
+  it("evicts quarantined addresses after TTL expires", async () => {
+    const store = new InMemoryRouterEnablementStore([], 50);
+    await store.markQuarantined(["0x2000000000000000000000000000000000000002"]);
+
+    // Immediately available
+    let quarantined = await store.loadQuarantinedAddresses();
+    expect(quarantined).toHaveLength(1);
+
+    // Advance past TTL
+    fakeTime += 51;
+
+    // Should be evicted
+    quarantined = await store.loadQuarantinedAddresses();
+    expect(quarantined).toHaveLength(0);
+  });
+
+  it("does not evict quarantined addresses before TTL expires", async () => {
+    const store = new InMemoryRouterEnablementStore([], 5000);
+    await store.markQuarantined(["0x2000000000000000000000000000000000000003"]);
+
+    fakeTime += 4999;
+    const quarantined = await store.loadQuarantinedAddresses();
+    expect(quarantined).toHaveLength(1);
+  });
+
+  it("re-marking a quarantined address resets its TTL", async () => {
+    const store = new InMemoryRouterEnablementStore([], 100);
+    await store.markQuarantined(["0x2000000000000000000000000000000000000004"]);
+
+    // Advance 60ms, then re-quarantine
+    fakeTime += 60;
+    await store.markQuarantined(["0x2000000000000000000000000000000000000004"]);
+
+    // Advance another 60ms — original TTL would have expired, but re-mark extended it
+    fakeTime += 60;
+
+    const quarantined = await store.loadQuarantinedAddresses();
+    expect(quarantined).toHaveLength(1);
+  });
+
+  it("normalizes quarantined addresses via checksum then lowercase", async () => {
+    const store = new InMemoryRouterEnablementStore();
+    // Mixed case — should be normalized
+    await store.markQuarantined(["0x2000000000000000000000000000000000000005"]);
+
+    const quarantined = await store.loadQuarantinedAddresses();
+    expect(quarantined[0]).toBe("0x2000000000000000000000000000000000000005");
+  });
+
+  it("ignores invalid addresses in markQuarantined", async () => {
+    const store = new InMemoryRouterEnablementStore();
+    await store.markQuarantined(["not-an-address", "0x2000000000000000000000000000000000000006"]);
+
+    const quarantined = await store.loadQuarantinedAddresses();
+    expect(quarantined).toHaveLength(1);
+  });
+
+  it("keeps enabled and quarantined sets independent", async () => {
+    const store = new InMemoryRouterEnablementStore();
+    const addr = "0x2000000000000000000000000000000000000007";
+    await store.markEnabled([addr]);
+    await store.markQuarantined([addr]);
+
+    const enabled = await store.loadEnabledAddresses();
+    const quarantined = await store.loadQuarantinedAddresses();
+
+    expect(enabled).toHaveLength(1);
+    expect(quarantined).toHaveLength(1);
+  });
+});

--- a/tests/apps/router-tms/logic.spec.ts
+++ b/tests/apps/router-tms/logic.spec.ts
@@ -708,8 +708,9 @@ describe("Safe-level error short-circuit in batch fallback", () => {
 
     // No addresses should be quarantined — GS026 is a Safe-level error
     expect(outcome.quarantinedAddresses).toHaveLength(0);
-    // Batch should be recorded as failed
+    // Batch should be recorded as failed with safe-level failureType
     expect(outcome.failedBatches).toHaveLength(1);
+    expect(outcome.failedBatches[0].failureType).toBe("safe-level");
     expect(outcome.executedEnableCount).toBe(0);
     // No simulation calls — probing was skipped entirely
     expect(routerService.simulationCalls).toBe(0);
@@ -742,7 +743,7 @@ describe("Safe-level error short-circuit in batch fallback", () => {
     expect(routerService.simulationCalls).toBe(0);
   });
 
-  it("still quarantines on non-Safe-level errors (existing behavior)", async () => {
+  it("still quarantines on non-Safe-level errors (existing behavior) with address-specific failureType", async () => {
     const humanAlice = getAddress("0x2000000000000000000000000000000000000BC0");
     const humanBob = getAddress("0x2000000000000000000000000000000000000BC1");
 
@@ -756,15 +757,79 @@ describe("Safe-level error short-circuit in batch fallback", () => {
     routerService.simulationFailAddresses.add(humanAlice.toLowerCase());
     routerService.simulationFailAddresses.add(humanBob.toLowerCase());
 
-    const deps = makeDeps({circlesRpc, routerService});
+    const enablementStore = new FakeRouterEnablementStore();
+    const deps = makeDeps({circlesRpc, routerService, enablementStore});
     const cfg = makeConfig({dryRun: false, enableBatchSize: 10});
 
     const outcome = await runOnce(deps, cfg);
 
     // Both addresses should be quarantined (non-Safe-level error, existing behavior)
     expect(outcome.quarantinedAddresses).toHaveLength(2);
+    // FailedBatch should have address-specific failureType
+    expect(outcome.failedBatches).toHaveLength(1);
+    expect(outcome.failedBatches[0].failureType).toBe("address-specific");
     // Probing DID happen
     expect(routerService.simulationCalls).toBe(2);
+    // Quarantine was persisted to the store
+    const persistedQuarantine = await enablementStore.loadQuarantinedAddresses();
+    expect(persistedQuarantine).toHaveLength(2);
+  });
+});
+
+describe("Quarantine persistence across runs", () => {
+  it("loads previously quarantined addresses and skips them in batch processing", async () => {
+    const humanAlice = getAddress("0x2000000000000000000000000000000000000BD0");
+    const humanBob = getAddress("0x2000000000000000000000000000000000000BD1");
+    const humanCarol = getAddress("0x2000000000000000000000000000000000000BD2");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [humanAlice, humanBob, humanCarol];
+    circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
+
+    const routerService = new FakeRouterService();
+    const enablementStore = new FakeRouterEnablementStore();
+    // Pre-quarantine Alice from a previous run
+    await enablementStore.markQuarantined([humanAlice]);
+
+    const deps = makeDeps({circlesRpc, routerService, enablementStore});
+    const cfg = makeConfig({dryRun: false, enableBatchSize: 10});
+
+    const outcome = await runOnce(deps, cfg);
+
+    // Alice was already quarantined, so only Bob and Carol should be enabled
+    expect(outcome.executedEnableCount).toBe(2);
+    // No NEW quarantine this run
+    expect(outcome.quarantinedAddresses).toHaveLength(0);
+  });
+
+  it("persists newly quarantined addresses for subsequent runs", async () => {
+    const humanAlice = getAddress("0x2000000000000000000000000000000000000BE0");
+    const humanBob = getAddress("0x2000000000000000000000000000000000000BE1");
+
+    const circlesRpc = new FakeCirclesRpc();
+    circlesRpc.humanAvatars = [humanAlice, humanBob];
+    circlesRpc.trusteesByTruster[ROUTER_ADDRESS.toLowerCase()] = [];
+
+    const routerService = new FakeRouterService();
+    // Alice causes the batch to fail (address-specific), Bob is fine
+    routerService.enableFailAddresses.add(humanAlice.toLowerCase());
+    routerService.simulationFailAddresses.add(humanAlice.toLowerCase());
+
+    const enablementStore = new FakeRouterEnablementStore();
+    const deps = makeDeps({circlesRpc, routerService, enablementStore});
+    const cfg = makeConfig({dryRun: false, enableBatchSize: 10});
+
+    const outcome = await runOnce(deps, cfg);
+
+    // Alice quarantined from simulation probe, Bob succeeded via retry
+    expect(outcome.quarantinedAddresses.map(a => a.toLowerCase())).toContain(humanAlice.toLowerCase());
+    expect(outcome.quarantinedAddresses.map(a => a.toLowerCase())).not.toContain(humanBob.toLowerCase());
+    expect(outcome.executedEnableCount).toBe(1); // Only Bob executed
+
+    // Alice should be persisted in quarantine store
+    const quarantined = await enablementStore.loadQuarantinedAddresses();
+    expect(quarantined.map(a => a.toLowerCase())).toContain(humanAlice.toLowerCase());
+    expect(quarantined.map(a => a.toLowerCase())).not.toContain(humanBob.toLowerCase());
   });
 });
 

--- a/tests/services/safeTransactionExecutor.spec.ts
+++ b/tests/services/safeTransactionExecutor.spec.ts
@@ -1,4 +1,7 @@
-import {TransactionConfirmationTimeoutError} from "../../src/services/safeTransactionExecutor";
+import {
+  TransactionConfirmationTimeoutError,
+  isNonceRaceError
+} from "../../src/services/safeTransactionExecutor";
 
 describe("TransactionConfirmationTimeoutError", () => {
   it("stores txHash and timeoutMs", () => {
@@ -51,5 +54,52 @@ describe("SafeTransactionExecutor.execute timeout", () => {
     ]);
 
     expect(result).toEqual({status: 1, hash: "0x123"});
+  });
+});
+
+describe("isNonceRaceError", () => {
+  it("returns true for error with GS026 in message", () => {
+    expect(isNonceRaceError(new Error("execution reverted: GS026"))).toBe(true);
+  });
+
+  it("returns true for error with GS026 in reason", () => {
+    const err = new Error("transaction failed");
+    (err as any).reason = "GS026";
+    expect(isNonceRaceError(err)).toBe(true);
+  });
+
+  it("returns true when GS026 appears mid-string", () => {
+    expect(isNonceRaceError(new Error("Safe call reverted with GS026: invalid owner provided"))).toBe(true);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isNonceRaceError(null)).toBe(false);
+    expect(isNonceRaceError(undefined)).toBe(false);
+  });
+
+  it("returns false for non-GS026 Safe errors", () => {
+    expect(isNonceRaceError(new Error("execution reverted: GS013"))).toBe(false);
+    expect(isNonceRaceError(new Error("execution reverted: GS025"))).toBe(false);
+  });
+
+  it("returns false for generic errors", () => {
+    expect(isNonceRaceError(new Error("network timeout"))).toBe(false);
+    expect(isNonceRaceError(new Error("insufficient funds"))).toBe(false);
+  });
+
+  it("returns false for non-Error objects without message/reason", () => {
+    expect(isNonceRaceError(42)).toBe(false);
+    expect(isNonceRaceError("some string")).toBe(false);
+    expect(isNonceRaceError({})).toBe(false);
+  });
+
+  it("handles objects with reason property but no message", () => {
+    const err = { reason: "GS026" };
+    expect(isNonceRaceError(err)).toBe(true);
+  });
+
+  it("handles objects with message but not Error instances", () => {
+    const err = { message: "reverted: GS026" };
+    expect(isNonceRaceError(err)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Addresses 7 tech debt items from the 24-agent audit of PR #78, plus 3 additional fixes found during 12-agent review of this PR itself.

**Bug fixes:**
- Replace empty `catch {}` in crash handlers with `console.error` (4 apps, 8 instances)
- Replace `.catch(() => {})` on Slack calls with `.catch(e => warn)` (5 apps, 8 instances)
- Add warning to `parseEnvInt` on NaN fallback (router-tms)
- Fix pre-existing case-sensitivity bug in quarantine filter (checksummed vs lowercase)
- Fix Phase 3 retry `FailedBatch` reporting original batch instead of retry set

**Improvements:**
- Add `validateSafeOwnership()` startup check to crc-backers, gp-crc, gnosis-group (catches GS026 misconfiguration at startup)
- Add `failureType` discriminant to `FailedBatch` (`"safe-level"` | `"address-specific"` | `"unknown"`)
- Add quarantine persistence with TTL to `IRouterEnablementStore` (24h default, avoids re-probing permanently bad addresses every 30min)
- Export `isNonceRaceError` for testing + comprehensive test coverage
- Ownership validation catch blocks wrap Slack in try/catch to prevent error masking

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 389 tests pass (20 new)
- [x] 12-agent multi-angle audit completed — 2 critical findings fixed, 3 high addressed
- [ ] Verify on staging with `DRY_RUN=1`