### PR TITLE
fix(group-affiliates): cap concurrent reputation fetches (default 8)

### DIFF
--- a/src/apps/group-affiliates/main.ts
+++ b/src/apps/group-affiliates/main.ts
@@ -51,6 +51,7 @@ const reputationScoreThreshold = parseEnvNumber("GROUP_AFFILIATES_REPUTATION_SCO
 const reputationBaseUrl = process.env.GROUP_AFFILIATES_REPUTATION_BASE_URL || DEFAULT_REPUTATION_BASE_URL;
 const reputationTimeoutMs = parseEnvInt("GROUP_AFFILIATES_REPUTATION_TIMEOUT_MS", 30_000);
 const reputationRefreshMs = parseEnvInt("GROUP_AFFILIATES_REPUTATION_REFRESH_MS", 30 * 60 * 1000);
+const reputationConcurrency = parseEnvInt("GROUP_AFFILIATES_REPUTATION_CONCURRENCY", 8);
 const dryRun = process.env.DRY_RUN === "1";
 const verboseLogging = !!process.env.VERBOSE_LOGGING;
 const safeAddress = process.env.GROUP_AFFILIATES_SAFE_ADDRESS || "";
@@ -74,7 +75,7 @@ const circlesRpc = new CirclesRpcService(rpcUrl, (message) => {
     SlackSeverity.WARNING
   ).catch((error) => console.warn("[SlackAlert] failed:", (error as Error).message));
 });
-const reputationService = new ReputationService(reputationBaseUrl, reputationTimeoutMs);
+const reputationService = new ReputationService(reputationBaseUrl, reputationTimeoutMs, reputationConcurrency);
 
 let leaderElection: LeaderElection | null = null;
 let listener: AffiliateGroupChangedListenerHandle | null = null;

--- a/src/apps/group-affiliates/reputationService.ts
+++ b/src/apps/group-affiliates/reputationService.ts
@@ -18,14 +18,32 @@ type ReputationResponse = {
 export class ReputationService implements IReputationService {
   constructor(
     private readonly baseUrl: string,
-    private readonly timeoutMs: number = 30_000
+    private readonly timeoutMs: number = 30_000,
+    private readonly concurrency: number = 8
   ) {
   }
 
   async check(addresses: string[], threshold: number): Promise<Map<string, ReputationVerdict>> {
     const unique = Array.from(new Set(addresses.map((address) => getAddress(address).toLowerCase())));
-    const entries = await Promise.all(unique.map((address) => this.fetchVerdict(address, threshold)));
-    return new Map(entries.map((entry) => [entry.address, entry]));
+    // Rolling-window concurrency: at most `concurrency` fetches in flight at
+    // any time. Prevents the startup-replay path from firing hundreds of
+    // simultaneous requests, which overwhelms both the local TCP stack
+    // (undici ConnectTimeoutError on the connect queue) and the upstream
+    // rep_score service (2-worker gunicorn → queue blow-up).
+    const results = new Array<ReputationVerdict>(unique.length);
+    let nextIndex = 0;
+    const worker = async (): Promise<void> => {
+      while (true) {
+        const i = nextIndex++;
+        if (i >= unique.length) {
+          return;
+        }
+        results[i] = await this.fetchVerdict(unique[i], threshold);
+      }
+    };
+    const workerCount = Math.max(1, Math.min(this.concurrency, unique.length));
+    await Promise.all(Array.from({length: workerCount}, worker));
+    return new Map(results.map((entry) => [entry.address, entry]));
   }
 
   private async fetchVerdict(address: string, threshold: number): Promise<ReputationVerdict> {


### PR DESCRIPTION
**Superseded by #81** — that PR targets the `staging` branch directly and combines the same concurrency cap with the rest of the `belonging-groups` rollout in one merge.

---

Cap concurrent reputation fetches in `ReputationService.check()` at a configurable `GROUP_AFFILIATES_REPUTATION_CONCURRENCY` (default 8). Replaces the un-bounded `Promise.all(unique.map(...))` over ~800 affiliate events on startup-replay, which overwhelmed undici's connect queue and the upstream FastAPI gunicorn.