### PR TITLE
feat(group-affiliates): roll belonging-groups + reputation concurrency cap onto staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Specialized services for Circles protocol trust management:
 * Incremental scanning with configurable refresh intervals
 * Batch processing for efficient trust operations
 
+## Group Affiliates App
+* Monitors `AffiliateGroupChanged` events from the Circles affiliate registry over WSS
+* Trusts humans into one of five managed groups when they set that group as their affiliate
+* Untrusts humans from a managed group when they switch away from it
+* Replays historical logs from a persisted cursor on startup before listening live
+* Supports dry-run mode with optional Safe transaction simulation
+
 ## Requirements
 
 * Node.js **≥ 24**
@@ -60,6 +67,7 @@ npm run start:gp-crc
 npm run start:dublin-tms
 npm run start:oic
 npm run start:all
+npm run start:group-affiliates
 ```
 
 ## Configuration (.env)
@@ -226,6 +234,38 @@ SLACK_WEBHOOK_URL_INFO=                    # Secondary webhook for informational
 VERBOSE_LOGGING=1
 ```
 
+### Group Affiliates App Configuration
+
+```dotenv
+# RPC & affiliate registry
+RPC_URL=https://rpc.aboutcircles.com/
+TX_RPC_URL=https://your-write-rpc.example/   # optional; overrides only transaction execution
+GROUP_AFFILIATES_WSS_URL=wss://rpc.aboutcircles.com/ws/chain
+GROUP_AFFILIATES_REGISTRY_ADDRESS=0xca8222e780d046707083f51377b5fd85e2866014
+
+# Safe execution (required unless dry run)
+GROUP_AFFILIATES_SAFE_ADDRESS=               # Safe that can execute trust/untrust for all managed groups
+GROUP_AFFILIATES_SAFE_SIGNER_PRIVATE_KEY=    # Private key for one Safe signer
+GROUP_AFFILIATES_SIGNER_ADDRESS=             # Optional expected signer address for key validation
+
+# Scan window / batching
+GROUP_AFFILIATES_START_BLOCK=41734312
+GROUP_AFFILIATES_BATCH_SIZE=20
+CONFIRMATION_BLOCKS=2
+
+# Operation mode
+DRY_RUN=0                                    # Set to "1" to log actions without sending Safe transactions
+
+# Notifications / coordination
+SLACK_WEBHOOK_URL=
+SLACK_WEBHOOK_URL_INFO=
+LEADER_DB_URL=                               # Optional: enables leader election and cursor persistence
+INSTANCE_ID=                                 # Required when LEADER_DB_URL is set
+
+# Logging
+VERBOSE_LOGGING=1
+```
+
 ### Gnosis Group App Configuration
 
 ```dotenv
@@ -330,6 +370,12 @@ VERBOSE_LOGGING=1
 * OIC start block is hardcoded to `41734312`
 * `OIC_META_ORG_ADDRESS` is required - this is the MetaOrg whose trustees will be monitored
 * Use `DRY_RUN=1` for testing without making actual blockchain transactions
+
+### Group Affiliates App
+* Uses one Safe for all five managed group contracts; set `GROUP_AFFILIATES_SAFE_ADDRESS` plus `GROUP_AFFILIATES_SAFE_SIGNER_PRIVATE_KEY` unless `DRY_RUN=1`
+* `GROUP_AFFILIATES_WSS_URL` defaults to the `/ws/chain` variant derived from `RPC_URL`
+* Cursor persistence uses `LEADER_DB_URL` and app name `group-affiliates`
+* `DRY_RUN=1` logs planned trust/untrust batches and simulates them when Safe credentials are configured
 * Service maintains incremental state to avoid re-processing old events
 
 ### Dublin TMS App

--- a/README.md
+++ b/README.md
@@ -253,6 +253,12 @@ GROUP_AFFILIATES_START_BLOCK=41734312
 GROUP_AFFILIATES_BATCH_SIZE=20
 CONFIRMATION_BLOCKS=2
 
+# Reputation gate
+GROUP_AFFILIATES_REPUTATION_BASE_URL=https://walrus-app-2-iod58.ondigitalocean.app/aboutcircles-advanced-analytics2/rep_score/groups/gnosis/avatars
+GROUP_AFFILIATES_REPUTATION_SCORE_THRESHOLD=40
+GROUP_AFFILIATES_REPUTATION_TIMEOUT_MS=30000
+GROUP_AFFILIATES_REPUTATION_REFRESH_MS=1800000
+
 # Operation mode
 DRY_RUN=0                                    # Set to "1" to log actions without sending Safe transactions
 
@@ -374,6 +380,8 @@ VERBOSE_LOGGING=1
 ### Group Affiliates App
 * Uses one Safe for all five managed group contracts; set `GROUP_AFFILIATES_SAFE_ADDRESS` plus `GROUP_AFFILIATES_SAFE_SIGNER_PRIVATE_KEY` unless `DRY_RUN=1`
 * `GROUP_AFFILIATES_WSS_URL` defaults to the `/ws/chain` variant derived from `RPC_URL`
+* Only trusts affiliates whose reputation endpoint returns `reputation_score > GROUP_AFFILIATES_REPUTATION_SCORE_THRESHOLD`
+* Periodically rechecks current trustees and untrusts addresses whose reputation score falls to the threshold or below
 * Cursor persistence uses `LEADER_DB_URL` and app name `group-affiliates`
 * `DRY_RUN=1` logs planned trust/untrust batches and simulates them when Safe credentials are configured
 * Service maintains incremental state to avoid re-processing old events

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,6 +15,7 @@ module.exports = {
     "<rootDir>/src/apps/oic/logic.ts",
     "<rootDir>/src/apps/gp-crc/logic.ts",
     "<rootDir>/src/apps/router-tms/logic.ts",
+    "<rootDir>/src/apps/group-affiliates/logic.ts",
     "!<rootDir>/src/main.ts",
     "!**/*.d.ts",
     "!**/__tests__/**",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start:dublin-tms": "node --env-file=.env dist/src/apps/dublin-tms/main.js",
     "start:oic": "node --env-file=.env dist/src/apps/oic/main.js",
     "start:router-tms": "node --env-file=.env dist/src/apps/router-tms/main.js",
+    "start:group-affiliates": "node --env-file=.env dist/src/apps/group-affiliates/main.js",
     "start:all": "node --env-file=.env dist/src/apps/manager.js",
     "test": "jest --config jest.config.ts",
     "test:coverage": "jest --config jest.config.ts --coverage",

--- a/src/apps/group-affiliates/logic.ts
+++ b/src/apps/group-affiliates/logic.ts
@@ -1,0 +1,291 @@
+import {getAddress} from "ethers";
+
+import {ICirclesRpc} from "../../interfaces/ICirclesRpc";
+import {IGroupService} from "../../interfaces/IGroupService";
+import {ILoggerService} from "../../interfaces/ILoggerService";
+import {AffiliateGroupChangedWithCursor, EventCursor, compareEventCursor} from "./realtime";
+
+export const DEFAULT_GROUP_AFFILIATES_BATCH_SIZE = 20;
+
+export const DEFAULT_MANAGED_GROUP_ADDRESSES = [
+  "0x1ACA75e38263c79d9D4F10dF0635cc6FCfe6F026",
+  "0xb629a1e86F3eFada0F87C83494Da8Cc34C3F84ef",
+  "0x4E2564e5df6C1Fb10C1A018538de36E4D5844DE5",
+  "0xC19BC204eb1c1D5B3FE500E5E5dfaBaB625F286c",
+  "0x86533d1ada8ffbe7b6f7244f9a1b707f7f3e239b"
+] as const;
+
+export type RunConfig = {
+  managedGroupAddresses: readonly string[];
+  batchSize: number;
+  dryRun?: boolean;
+};
+
+export type Deps = {
+  circlesRpc: ICirclesRpc;
+  groupService: IGroupService;
+  logger: ILoggerService;
+};
+
+export type GroupAffiliateOutcome = {
+  processedEvents: number;
+  ignoredEvents: number;
+  affectedGroups: string[];
+  trustedByGroup: Record<string, string[]>;
+  untrustedByGroup: Record<string, string[]>;
+  trustTxHashes: string[];
+  untrustTxHashes: string[];
+  latestCursor: EventCursor | null;
+};
+
+type GroupPlans = Map<string, Set<string>>;
+
+export async function runForAffiliateEvents(
+  deps: Deps,
+  cfg: RunConfig,
+  events: AffiliateGroupChangedWithCursor[]
+): Promise<GroupAffiliateOutcome> {
+  const {circlesRpc, groupService, logger} = deps;
+  const managedGroups = normalizeManagedGroups(cfg.managedGroupAddresses);
+  const sortedEvents = dedupeAndSortEvents(events);
+  const latestCursor = sortedEvents.length > 0
+    ? sortedEvents[sortedEvents.length - 1].cursor
+    : null;
+
+  const desiredTrustedByGroup: GroupPlans = new Map();
+  const touchedHumansByGroup: GroupPlans = new Map();
+  let ignoredEvents = 0;
+
+  for (const event of sortedEvents) {
+    const normalized = normalizeEvent(event);
+    if (!normalized || normalized.oldGroup === normalized.newGroup) {
+      ignoredEvents += 1;
+      continue;
+    }
+
+    const oldGroupManaged = managedGroups.has(normalized.oldGroup);
+    const newGroupManaged = managedGroups.has(normalized.newGroup);
+    if (!oldGroupManaged && !newGroupManaged) {
+      ignoredEvents += 1;
+      continue;
+    }
+
+    if (oldGroupManaged) {
+      addToSetMap(touchedHumansByGroup, normalized.oldGroup, normalized.human);
+      deleteFromSetMap(desiredTrustedByGroup, normalized.oldGroup, normalized.human);
+    }
+
+    if (newGroupManaged) {
+      addToSetMap(touchedHumansByGroup, normalized.newGroup, normalized.human);
+      addToSetMap(desiredTrustedByGroup, normalized.newGroup, normalized.human);
+    }
+  }
+
+  const affectedGroups = Array.from(touchedHumansByGroup.keys()).sort();
+  const trustedByGroup: Record<string, string[]> = {};
+  const untrustedByGroup: Record<string, string[]> = {};
+
+  for (const group of affectedGroups) {
+    const touchedHumans = touchedHumansByGroup.get(group) ?? new Set<string>();
+    const desiredTrusted = desiredTrustedByGroup.get(group) ?? new Set<string>();
+    const currentTrustees = new Set(
+      (await circlesRpc.fetchAllTrustees(group)).map((address) => normalizeAddress(address)).filter(Boolean) as string[]
+    );
+
+    const toUntrust = Array.from(touchedHumans)
+      .filter((human) => !desiredTrusted.has(human) && currentTrustees.has(human))
+      .sort();
+    const toTrust = Array.from(desiredTrusted)
+      .filter((human) => !currentTrustees.has(human))
+      .sort();
+
+    untrustedByGroup[group] = toUntrust;
+    trustedByGroup[group] = toTrust;
+  }
+
+  const totalTrust = Object.values(trustedByGroup).reduce((sum, list) => sum + list.length, 0);
+  const totalUntrust = Object.values(untrustedByGroup).reduce((sum, list) => sum + list.length, 0);
+  logger.info(
+    `Group affiliates decision summary: events=${sortedEvents.length} ignored=${ignoredEvents} ` +
+    `affectedGroups=${affectedGroups.length} toUntrust=${totalUntrust} toTrust=${totalTrust}`
+  );
+
+  if (cfg.dryRun) {
+    await simulatePlannedOperations(groupService, cfg.batchSize, untrustedByGroup, trustedByGroup, logger);
+    return {
+      processedEvents: sortedEvents.length,
+      ignoredEvents,
+      affectedGroups,
+      trustedByGroup,
+      untrustedByGroup,
+      trustTxHashes: [],
+      untrustTxHashes: [],
+      latestCursor
+    };
+  }
+
+  const {trustTxHashes, untrustTxHashes} = await executePlannedOperations(
+    groupService,
+    cfg.batchSize,
+    untrustedByGroup,
+    trustedByGroup,
+    logger
+  );
+
+  return {
+    processedEvents: sortedEvents.length,
+    ignoredEvents,
+    affectedGroups,
+    trustedByGroup,
+    untrustedByGroup,
+    trustTxHashes,
+    untrustTxHashes,
+    latestCursor
+  };
+}
+
+function normalizeManagedGroups(groups: readonly string[]): Set<string> {
+  const normalized = new Set<string>();
+  for (const group of groups) {
+    const address = normalizeAddress(group);
+    if (!address) {
+      throw new Error(`Invalid managed group address configured: ${group}`);
+    }
+    normalized.add(address);
+  }
+  if (normalized.size === 0) {
+    throw new Error("At least one managed group address is required");
+  }
+  return normalized;
+}
+
+function normalizeEvent(event: AffiliateGroupChangedWithCursor): {
+  human: string;
+  oldGroup: string;
+  newGroup: string;
+} | null {
+  const human = normalizeAddress(event.human);
+  const oldGroup = normalizeAddress(event.oldGroup);
+  const newGroup = normalizeAddress(event.newGroup);
+  if (!human || !oldGroup || !newGroup) {
+    return null;
+  }
+  return {human, oldGroup, newGroup};
+}
+
+function normalizeAddress(address: string): string | null {
+  try {
+    if (address.toLowerCase() === "0x0") {
+      return "0x0000000000000000000000000000000000000000";
+    }
+    return getAddress(address).toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function addToSetMap(map: GroupPlans, key: string, value: string): void {
+  const existing = map.get(key);
+  if (existing) {
+    existing.add(value);
+    return;
+  }
+  map.set(key, new Set([value]));
+}
+
+function deleteFromSetMap(map: GroupPlans, key: string, value: string): void {
+  const existing = map.get(key);
+  if (existing) {
+    existing.delete(value);
+    return;
+  }
+  map.set(key, new Set<string>());
+}
+
+async function executePlannedOperations(
+  groupService: IGroupService,
+  batchSize: number,
+  untrustedByGroup: Record<string, string[]>,
+  trustedByGroup: Record<string, string[]>,
+  logger: ILoggerService
+): Promise<{trustTxHashes: string[]; untrustTxHashes: string[]}> {
+  const trustTxHashes: string[] = [];
+  const untrustTxHashes: string[] = [];
+
+  for (const [group, addresses] of Object.entries(untrustedByGroup)) {
+    for (const batch of chunk(addresses, batchSize)) {
+      logger.info(`Untrusting ${batch.length} affiliate(s) from group ${group}: ${batch.join(", ")}`);
+      const txHash = await groupService.untrustBatch(group, batch);
+      untrustTxHashes.push(txHash);
+      logger.info(`Untrust batch submitted for group ${group}: ${txHash}`);
+    }
+  }
+
+  for (const [group, addresses] of Object.entries(trustedByGroup)) {
+    for (const batch of chunk(addresses, batchSize)) {
+      logger.info(`Trusting ${batch.length} affiliate(s) in group ${group}: ${batch.join(", ")}`);
+      const txHash = await groupService.trustBatchWithConditions(group, batch);
+      trustTxHashes.push(txHash);
+      logger.info(`Trust batch submitted for group ${group}: ${txHash}`);
+    }
+  }
+
+  return {trustTxHashes, untrustTxHashes};
+}
+
+async function simulatePlannedOperations(
+  groupService: IGroupService,
+  batchSize: number,
+  untrustedByGroup: Record<string, string[]>,
+  trustedByGroup: Record<string, string[]>,
+  logger: ILoggerService
+): Promise<void> {
+  for (const [group, addresses] of Object.entries(untrustedByGroup)) {
+    for (const batch of chunk(addresses, batchSize)) {
+      logger.info(`DRY RUN untrust group=${group} addresses=${batch.join(", ")}`);
+      if (groupService.simulateUntrustBatch) {
+        const simulation = await groupService.simulateUntrustBatch(group, batch);
+        logger.info(`DRY RUN untrust simulation group=${group}: ok, gasEstimate=${simulation.gasEstimate.toString()}`);
+      } else {
+        logger.info(`DRY RUN untrust simulation group=${group}: skipped (no signer-backed simulator configured).`);
+      }
+    }
+  }
+
+  for (const [group, addresses] of Object.entries(trustedByGroup)) {
+    for (const batch of chunk(addresses, batchSize)) {
+      logger.info(`DRY RUN trust group=${group} addresses=${batch.join(", ")}`);
+      if (groupService.simulateTrustBatchWithConditions) {
+        const simulation = await groupService.simulateTrustBatchWithConditions(group, batch);
+        logger.info(`DRY RUN trust simulation group=${group}: ok, gasEstimate=${simulation.gasEstimate.toString()}`);
+      } else {
+        logger.info(`DRY RUN trust simulation group=${group}: skipped (no signer-backed simulator configured).`);
+      }
+    }
+  }
+}
+
+function chunk<T>(values: T[], size: number): T[][] {
+  const normalizedSize = Math.max(1, size);
+  const result: T[][] = [];
+  for (let i = 0; i < values.length; i += normalizedSize) {
+    result.push(values.slice(i, i + normalizedSize));
+  }
+  return result;
+}
+
+function dedupeAndSortEvents(events: AffiliateGroupChangedWithCursor[]): AffiliateGroupChangedWithCursor[] {
+  const seen = new Set<string>();
+  const deduped: AffiliateGroupChangedWithCursor[] = [];
+
+  for (const event of events) {
+    const key = `${event.txHash}:${event.cursor.blockNumber}:${event.cursor.transactionIndex}:${event.cursor.logIndex}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(event);
+  }
+
+  return deduped.sort((left, right) => compareEventCursor(left.cursor, right.cursor));
+}

--- a/src/apps/group-affiliates/logic.ts
+++ b/src/apps/group-affiliates/logic.ts
@@ -4,8 +4,10 @@ import {ICirclesRpc} from "../../interfaces/ICirclesRpc";
 import {IGroupService} from "../../interfaces/IGroupService";
 import {ILoggerService} from "../../interfaces/ILoggerService";
 import {AffiliateGroupChangedWithCursor, EventCursor, compareEventCursor} from "./realtime";
+import {IReputationService} from "./reputationService";
 
 export const DEFAULT_GROUP_AFFILIATES_BATCH_SIZE = 20;
+export const DEFAULT_REPUTATION_SCORE_THRESHOLD = 40;
 
 export const DEFAULT_MANAGED_GROUP_ADDRESSES = [
   "0x1ACA75e38263c79d9D4F10dF0635cc6FCfe6F026",
@@ -18,12 +20,14 @@ export const DEFAULT_MANAGED_GROUP_ADDRESSES = [
 export type RunConfig = {
   managedGroupAddresses: readonly string[];
   batchSize: number;
+  reputationScoreThreshold: number;
   dryRun?: boolean;
 };
 
 export type Deps = {
   circlesRpc: ICirclesRpc;
   groupService: IGroupService;
+  reputationService: IReputationService;
   logger: ILoggerService;
 };
 
@@ -35,6 +39,7 @@ export type GroupAffiliateOutcome = {
   untrustedByGroup: Record<string, string[]>;
   trustTxHashes: string[];
   untrustTxHashes: string[];
+  ineligibleByReputation: string[];
   latestCursor: EventCursor | null;
 };
 
@@ -45,7 +50,7 @@ export async function runForAffiliateEvents(
   cfg: RunConfig,
   events: AffiliateGroupChangedWithCursor[]
 ): Promise<GroupAffiliateOutcome> {
-  const {circlesRpc, groupService, logger} = deps;
+  const {circlesRpc, groupService, reputationService, logger} = deps;
   const managedGroups = normalizeManagedGroups(cfg.managedGroupAddresses);
   const sortedEvents = dedupeAndSortEvents(events);
   const latestCursor = sortedEvents.length > 0
@@ -82,18 +87,33 @@ export async function runForAffiliateEvents(
   }
 
   const affectedGroups = Array.from(touchedHumansByGroup.keys()).sort();
+  const touchedHumans = uniqueHumansFromPlans(touchedHumansByGroup);
+  const reputationVerdicts = await reputationService.check(touchedHumans, cfg.reputationScoreThreshold);
+  const ineligibleByReputation = touchedHumans
+    .filter((human) => !reputationVerdicts.get(human)?.eligible)
+    .sort();
+  if (ineligibleByReputation.length > 0) {
+    logger.info(
+      `Reputation gate: ${ineligibleByReputation.length} touched affiliate(s) are not eligible ` +
+      `(required reputation_score > ${cfg.reputationScoreThreshold}).`
+    );
+  }
+
   const trustedByGroup: Record<string, string[]> = {};
   const untrustedByGroup: Record<string, string[]> = {};
 
   for (const group of affectedGroups) {
     const touchedHumans = touchedHumansByGroup.get(group) ?? new Set<string>();
-    const desiredTrusted = desiredTrustedByGroup.get(group) ?? new Set<string>();
+    const desiredTrusted = new Set(
+      Array.from(desiredTrustedByGroup.get(group) ?? new Set<string>())
+        .filter((human) => reputationVerdicts.get(human)?.eligible === true)
+    );
     const currentTrustees = new Set(
       (await circlesRpc.fetchAllTrustees(group)).map((address) => normalizeAddress(address)).filter(Boolean) as string[]
     );
 
     const toUntrust = Array.from(touchedHumans)
-      .filter((human) => !desiredTrusted.has(human) && currentTrustees.has(human))
+      .filter((human) => currentTrustees.has(human) && (!desiredTrusted.has(human) || reputationVerdicts.get(human)?.eligible !== true))
       .sort();
     const toTrust = Array.from(desiredTrusted)
       .filter((human) => !currentTrustees.has(human))
@@ -120,6 +140,7 @@ export async function runForAffiliateEvents(
       untrustedByGroup,
       trustTxHashes: [],
       untrustTxHashes: [],
+      ineligibleByReputation,
       latestCursor
     };
   }
@@ -140,7 +161,87 @@ export async function runForAffiliateEvents(
     untrustedByGroup,
     trustTxHashes,
     untrustTxHashes,
+    ineligibleByReputation,
     latestCursor
+  };
+}
+
+export async function runReputationReconciliation(
+  deps: Deps,
+  cfg: RunConfig
+): Promise<GroupAffiliateOutcome> {
+  const {circlesRpc, groupService, reputationService, logger} = deps;
+  const managedGroups = Array.from(normalizeManagedGroups(cfg.managedGroupAddresses)).sort();
+  const trustedByGroup: Record<string, string[]> = {};
+  const untrustedByGroup: Record<string, string[]> = {};
+  const allTrustees = new Set<string>();
+
+  for (const group of managedGroups) {
+    const trustees = (await circlesRpc.fetchAllTrustees(group))
+      .map((address) => normalizeAddress(address))
+      .filter(Boolean) as string[];
+    trustedByGroup[group] = [];
+    untrustedByGroup[group] = [];
+    for (const trustee of trustees) {
+      allTrustees.add(trustee);
+    }
+  }
+
+  const reputationVerdicts = await reputationService.check(Array.from(allTrustees), cfg.reputationScoreThreshold);
+  const ineligibleByReputation = Array.from(allTrustees)
+    .filter((trustee) => !reputationVerdicts.get(trustee)?.eligible)
+    .sort();
+
+  if (ineligibleByReputation.length === 0) {
+    logger.info(`Reputation reconciliation: all ${allTrustees.size} currently trusted affiliate(s) are eligible.`);
+  } else {
+    logger.info(
+      `Reputation reconciliation: ${ineligibleByReputation.length}/${allTrustees.size} currently trusted affiliate(s) ` +
+      `are not eligible (required reputation_score > ${cfg.reputationScoreThreshold}).`
+    );
+  }
+
+  const ineligibleSet = new Set(ineligibleByReputation);
+  for (const group of managedGroups) {
+    const trustees = (await circlesRpc.fetchAllTrustees(group))
+      .map((address) => normalizeAddress(address))
+      .filter(Boolean) as string[];
+    untrustedByGroup[group] = trustees.filter((trustee) => ineligibleSet.has(trustee)).sort();
+  }
+
+  if (cfg.dryRun) {
+    await simulatePlannedOperations(groupService, cfg.batchSize, untrustedByGroup, trustedByGroup, logger);
+    return {
+      processedEvents: 0,
+      ignoredEvents: 0,
+      affectedGroups: managedGroups,
+      trustedByGroup,
+      untrustedByGroup,
+      trustTxHashes: [],
+      untrustTxHashes: [],
+      ineligibleByReputation,
+      latestCursor: null
+    };
+  }
+
+  const {trustTxHashes, untrustTxHashes} = await executePlannedOperations(
+    groupService,
+    cfg.batchSize,
+    untrustedByGroup,
+    trustedByGroup,
+    logger
+  );
+
+  return {
+    processedEvents: 0,
+    ignoredEvents: 0,
+    affectedGroups: managedGroups,
+    trustedByGroup,
+    untrustedByGroup,
+    trustTxHashes,
+    untrustTxHashes,
+    ineligibleByReputation,
+    latestCursor: null
   };
 }
 
@@ -200,6 +301,16 @@ function deleteFromSetMap(map: GroupPlans, key: string, value: string): void {
     return;
   }
   map.set(key, new Set<string>());
+}
+
+function uniqueHumansFromPlans(plans: GroupPlans): string[] {
+  const humans = new Set<string>();
+  for (const values of plans.values()) {
+    for (const value of values) {
+      humans.add(value);
+    }
+  }
+  return Array.from(humans).sort();
 }
 
 async function executePlannedOperations(

--- a/src/apps/group-affiliates/main.ts
+++ b/src/apps/group-affiliates/main.ts
@@ -1,0 +1,438 @@
+import {Wallet} from "ethers";
+
+import {IGroupService} from "../../interfaces/IGroupService";
+import {SlackSeverity} from "../../interfaces/ISlackService";
+import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
+import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
+import {formatErrorWithCauses} from "../../formatError";
+import {getEffectiveDryRun, LeaderElection} from "../../services/leaderElection";
+import {LoggerService} from "../../services/loggerService";
+import {recordRunError, recordRunSuccess, setLeaderStatus, startMetricsServer} from "../../services/metricsService";
+import {resolveTransactionRpcUrl} from "../../services/transactionRpc";
+import {SafeGroupService} from "../../services/safeGroupService";
+import {SlackService} from "../../services/slackService";
+import {StateStore} from "../../services/stateStore";
+import {CirclesRpcService} from "../../services/circlesRpcService";
+import {
+  DEFAULT_GROUP_AFFILIATES_BATCH_SIZE,
+  DEFAULT_MANAGED_GROUP_ADDRESSES,
+  runForAffiliateEvents,
+  type RunConfig
+} from "./logic";
+import {
+  AffiliateGroupChangedListenerHandle,
+  AffiliateGroupChangedWithCursor,
+  EventCursor,
+  deriveGroupAffiliatesWsUrl,
+  fetchAffiliateGroupChangedEventsBetween,
+  fetchCurrentBlockNumber,
+  makeHeadCursor,
+  makeInclusiveBlockCursor,
+  maxCursor,
+  startAffiliateGroupChangedListener
+} from "./realtime";
+
+const APP_NAME = "group-affiliates";
+const DEFAULT_AFFILIATE_REGISTRY_ADDRESS = "0xca8222e780d046707083f51377b5fd85e2866014";
+const DEFAULT_START_BLOCK = 41_734_312;
+
+const rpcUrl = process.env.RPC_URL || "https://rpc.aboutcircles.com/";
+const txRpcUrl = resolveTransactionRpcUrl(rpcUrl);
+const affiliateRegistryAddress = (process.env.GROUP_AFFILIATES_REGISTRY_ADDRESS || DEFAULT_AFFILIATE_REGISTRY_ADDRESS).toLowerCase();
+const wsUrl = process.env.GROUP_AFFILIATES_WSS_URL || deriveGroupAffiliatesWsUrl(rpcUrl);
+const startBlock = parseEnvInt("GROUP_AFFILIATES_START_BLOCK", DEFAULT_START_BLOCK);
+const confirmationBlocks = parseEnvInt("CONFIRMATION_BLOCKS", 2);
+const batchSize = parseEnvInt("GROUP_AFFILIATES_BATCH_SIZE", DEFAULT_GROUP_AFFILIATES_BATCH_SIZE);
+const dryRun = process.env.DRY_RUN === "1";
+const verboseLogging = !!process.env.VERBOSE_LOGGING;
+const safeAddress = process.env.GROUP_AFFILIATES_SAFE_ADDRESS || "";
+const safeSignerPrivateKey = process.env.GROUP_AFFILIATES_SAFE_SIGNER_PRIVATE_KEY || "";
+const configuredSignerAddress = (process.env.GROUP_AFFILIATES_SIGNER_ADDRESS || "").toLowerCase();
+const canSimulateTransactions = safeAddress.trim().length > 0 && safeSignerPrivateKey.trim().length > 0;
+const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL || "";
+const slackWebhookUrlInfo = process.env.SLACK_WEBHOOK_URL_INFO || "";
+const slackInfoChannel = process.env.SLACK_INFO_CHANNEL || "";
+
+const rootLogger = new LoggerService(verboseLogging, APP_NAME);
+const runLogger = rootLogger.child("run");
+const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
+const slackConfigured = slackWebhookUrl.trim().length > 0;
+const errorsBeforeCrash = Math.max(1, parseEnvInt("ERRORS_BEFORE_CRASH", 5));
+const errorTracker = new ConsecutiveErrorTracker(errorsBeforeCrash);
+const circlesRpc = new CirclesRpcService(rpcUrl, (message) => {
+  console.warn(`[CirclesRpc] ${message}`);
+  void slackService.notifySlackStartOrCrash(
+    `⚠️ *group-affiliates* pagination cap: ${message}`,
+    SlackSeverity.WARNING
+  ).catch((error) => console.warn("[SlackAlert] failed:", (error as Error).message));
+});
+
+let leaderElection: LeaderElection | null = null;
+let listener: AffiliateGroupChangedListenerHandle | null = null;
+let groupService: IGroupService;
+let executionQueue: Promise<void> = Promise.resolve();
+
+const config: RunConfig = {
+  managedGroupAddresses: DEFAULT_MANAGED_GROUP_ADDRESSES,
+  batchSize,
+  dryRun
+};
+
+validateConfig();
+
+if (!dryRun || canSimulateTransactions) {
+  groupService = new SafeGroupService(rpcUrl, safeSignerPrivateKey, safeAddress, txRpcUrl);
+} else {
+  groupService = createDryRunGroupService();
+}
+
+process.on("SIGINT", () => { void gracefulShutdown("SIGINT"); });
+process.on("SIGTERM", () => { void gracefulShutdown("SIGTERM"); });
+
+process.on("uncaughtException", async (error) => {
+  rootLogger.error("Uncaught exception:", formatErrorWithCauses(error instanceof Error ? error : new Error(String(error))));
+  try {
+    await slackService.notifySlackStartOrCrash(`💥 *group-affiliates* Uncaught exception: ${error?.message || error}`, SlackSeverity.CRITICAL);
+  } catch (slackError) {
+    console.error("Failed to send Slack crash notification:", slackError);
+  }
+  process.exit(1);
+});
+
+process.on("unhandledRejection", async (reason) => {
+  const error = reason instanceof Error ? reason : new Error(String(reason));
+  rootLogger.error("Unhandled rejection:", formatErrorWithCauses(error));
+  try {
+    await slackService.notifySlackStartOrCrash(`💥 *group-affiliates* Unhandled rejection: ${error.message}`, SlackSeverity.CRITICAL);
+  } catch (slackError) {
+    console.error("Failed to send Slack crash notification:", slackError);
+  }
+  process.exit(1);
+});
+
+async function start(): Promise<void> {
+  startMetricsServer(APP_NAME);
+  leaderElection = await LeaderElection.create(
+    process.env.LEADER_DB_URL,
+    process.env.INSTANCE_ID,
+    rootLogger.child("leader-election"),
+    slackService,
+    (isLeader) => setLeaderStatus(APP_NAME, isLeader)
+  );
+
+  if (groupService.validateSafeOwnership) {
+    try {
+      await groupService.validateSafeOwnership();
+      rootLogger.info("Safe ownership validation passed — signer is a registered owner.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      rootLogger.error(`Safe ownership validation FAILED: ${message}`);
+      await slackService.notifySlackStartOrCrash(
+        `🚨 *Group Affiliates Safe ownership check failed*\n\n${message}`,
+        SlackSeverity.CRITICAL
+      ).catch((slackError) => rootLogger.warn("Failed to send Slack ownership failure notification:", slackError));
+      process.exit(1);
+    }
+  }
+
+  await notifySlackStartup();
+
+  const stateStore = process.env.LEADER_DB_URL ? new StateStore(process.env.LEADER_DB_URL) : null;
+  let cursor = await loadCursor(stateStore);
+
+  try {
+    cursor = await runStartupReplay(stateStore, cursor);
+    startRealtimeListener(stateStore, cursor);
+  } catch (cause) {
+    const error = cause instanceof Error ? cause : new Error(String(cause));
+    recordRunError(APP_NAME);
+    rootLogger.error("Startup replay failed:");
+    rootLogger.error(formatErrorWithCauses(error));
+    await notifySlackRunError(error, 1);
+    process.exit(1);
+  }
+
+  await new Promise(() => undefined);
+}
+
+async function runStartupReplay(
+  stateStore: StateStore | null,
+  cursor: EventCursor
+): Promise<EventCursor> {
+  const effectiveDryRun = getEffectiveDryRun(leaderElection, dryRun);
+  const isHealthy = await ensureRpcHealthyOrNotify({
+    appName: APP_NAME,
+    rpcUrl,
+    logger: rootLogger
+  });
+  if (!isHealthy) {
+    return cursor;
+  }
+
+  const head = await fetchCurrentBlockNumber(rpcUrl);
+  if (head === null) {
+    throw new Error("Failed to fetch current block number for startup replay.");
+  }
+
+  const safeHead = Math.max(0, head - confirmationBlocks);
+  if (safeHead < cursor.blockNumber) {
+    runLogger.info(`Startup replay skipped: cursor=${formatCursor(cursor)} safeHead=${safeHead}`);
+    return cursor;
+  }
+
+  runLogger.info(`Startup replay range: cursor=${formatCursor(cursor)} safeHead=${safeHead}`);
+  const events = await fetchAffiliateGroupChangedEventsBetween(
+    rpcUrl,
+    affiliateRegistryAddress,
+    cursor.blockNumber,
+    safeHead,
+    cursor,
+    runLogger
+  );
+
+  const shouldAdvance = await processEvents(events, effectiveDryRun);
+  const replayCursor = makeHeadCursor(safeHead);
+  if (shouldAdvance) {
+    await saveCursor(stateStore, replayCursor);
+    return replayCursor;
+  }
+  return cursor;
+}
+
+function startRealtimeListener(stateStore: StateStore | null, cursor: EventCursor): void {
+  if (listener) {
+    return;
+  }
+
+  rootLogger.info(`Starting AffiliateGroupChanged WSS listener from cursor=${formatCursor(cursor)}.`);
+  listener = startAffiliateGroupChangedListener({
+    httpRpcUrl: rpcUrl,
+    wsUrl,
+    registryAddress: affiliateRegistryAddress,
+    logger: rootLogger.child("wss"),
+    startCursor: cursor,
+    onEvents: async (events) => {
+      return enqueueExclusive(async () => {
+        const effectiveDryRun = getEffectiveDryRun(leaderElection, dryRun);
+        const shouldAdvance = await processEvents(events, effectiveDryRun);
+        if (shouldAdvance && events.length > 0) {
+          const latest = events[events.length - 1].cursor;
+          await saveCursor(stateStore, latest);
+        }
+        return shouldAdvance;
+      });
+    }
+  });
+}
+
+async function processEvents(
+  events: AffiliateGroupChangedWithCursor[],
+  effectiveDryRun: boolean
+): Promise<boolean> {
+  if (events.length === 0) {
+    runLogger.info("No group affiliate events to process.");
+    recordRunSuccess(APP_NAME, 0);
+    return !effectiveDryRun;
+  }
+
+  const startedAt = Date.now();
+  try {
+    const outcome = await runForAffiliateEvents(
+      {circlesRpc, groupService, logger: runLogger},
+      {...config, dryRun: effectiveDryRun},
+      events
+    );
+    recordRunSuccess(APP_NAME, Date.now() - startedAt);
+    errorTracker.recordSuccess();
+    if (errorTracker.wasAlertingAndRecovered()) {
+      slackService.notifySlackResolved("Group Affiliates").catch((error) => {
+        rootLogger.warn("Failed to send Slack resolved notification:", error);
+      });
+    }
+
+    runLogger.info(
+      `group-affiliates batch completed: events=${outcome.processedEvents} ` +
+      `ignored=${outcome.ignoredEvents} trustTxs=${outcome.trustTxHashes.length} ` +
+      `untrustTxs=${outcome.untrustTxHashes.length} dryRun=${effectiveDryRun}`
+    );
+    return !effectiveDryRun;
+  } catch (cause) {
+    const error = cause instanceof Error ? cause : new Error(String(cause));
+    const consecutiveErrors = errorTracker.recordError();
+    recordRunError(APP_NAME);
+    rootLogger.error(`Consecutive error ${consecutiveErrors} of ${errorsBeforeCrash}`);
+    rootLogger.error(formatErrorWithCauses(error));
+    if (errorTracker.shouldAlert()) {
+      await notifySlackRunError(error, consecutiveErrors);
+      setTimeout(() => process.exit(1), 3000).unref();
+    }
+    throw error;
+  }
+}
+
+async function loadCursor(stateStore: StateStore | null): Promise<EventCursor> {
+  if (!stateStore) {
+    return makeInclusiveBlockCursor(startBlock);
+  }
+
+  const persisted = await stateStore.load(APP_NAME);
+  const transactionIndex = Number(persisted?.data?.transactionIndex);
+  const logIndex = Number(persisted?.data?.logIndex);
+  if (persisted && Number.isFinite(transactionIndex) && Number.isFinite(logIndex)) {
+    const cursor = {
+      blockNumber: persisted.lastScannedBlock,
+      transactionIndex,
+      logIndex
+    };
+    rootLogger.info(`[state-store] Restored cursor: ${formatCursor(cursor)}`);
+    return cursor;
+  }
+
+  return makeInclusiveBlockCursor(startBlock);
+}
+
+async function saveCursor(stateStore: StateStore | null, cursor: EventCursor): Promise<void> {
+  if (!stateStore) {
+    return;
+  }
+
+  await stateStore.save(APP_NAME, cursor.blockNumber, {
+    transactionIndex: cursor.transactionIndex,
+    logIndex: cursor.logIndex
+  });
+  runLogger.info(`[state-store] Saved cursor: ${formatCursor(cursor)}`);
+}
+
+function createDryRunGroupService(simulationService?: IGroupService): IGroupService {
+  const notAvailable = async () => {
+    throw new Error("Group service is not available in dry-run mode");
+  };
+  return {
+    trustBatchWithConditions: notAvailable,
+    untrustBatch: notAvailable,
+    fetchGroupOwnerAndService: notAvailable,
+    simulateTrustBatchWithConditions: simulationService?.simulateTrustBatchWithConditions?.bind(simulationService),
+    simulateUntrustBatch: simulationService?.simulateUntrustBatch?.bind(simulationService)
+  };
+}
+
+async function gracefulShutdown(signal: string): Promise<void> {
+  if (listener) {
+    try {
+      listener.stop();
+    } catch (error) {
+      rootLogger.warn("Failed to stop AffiliateGroupChanged listener:", error);
+    } finally {
+      listener = null;
+    }
+  }
+
+  try {
+    await leaderElection?.stop();
+  } catch (error) {
+    rootLogger.warn("Failed to stop leader election:", error);
+  }
+
+  try {
+    await slackService.notifySlackStartOrCrash(
+      `🔄 *Group Affiliates service shutting down*\n\nService received ${signal} signal.`,
+      SlackSeverity.INFO
+    );
+  } catch (error) {
+    rootLogger.error("Failed to send shutdown notification:", error);
+  }
+  process.exit(0);
+}
+
+async function notifySlackStartup(): Promise<void> {
+  const message = `✅ *Group Affiliates service started*\n\n` +
+    `Monitoring AffiliateGroupChanged events and syncing group trust.\n` +
+    `- RPC: ${rpcUrl}\n` +
+    `- TX RPC: ${txRpcUrl}\n` +
+    `- WSS: ${wsUrl}\n` +
+    `- Affiliate Registry: ${affiliateRegistryAddress}\n` +
+    `- Start Block: ${startBlock}\n` +
+    `- Confirmations: ${confirmationBlocks}\n` +
+    `- Batch Size: ${batchSize}\n` +
+    `- Safe: ${safeAddress || "(not set)"}\n` +
+    `- Safe signer configured: ${safeSignerPrivateKey.trim().length > 0}\n` +
+    `- Dry Run: ${dryRun}\n` +
+    `- Managed Groups: ${DEFAULT_MANAGED_GROUP_ADDRESSES.join(", ")}`;
+
+  try {
+    await slackService.notifySlackStartOrCrash(message, SlackSeverity.INFO);
+    if (slackConfigured) {
+      rootLogger.info("Slack startup notification sent.");
+    } else {
+      rootLogger.info("Slack startup notification skipped (no webhook configured).");
+    }
+  } catch (error) {
+    rootLogger.warn("Failed to send Slack startup notification:", error);
+  }
+}
+
+async function notifySlackRunError(error: Error, consecutiveErrors: number): Promise<void> {
+  const message = `⚠️ *Group Affiliates run failed* (${consecutiveErrors} consecutive failures)\n\n${formatErrorWithCauses(error)}`;
+  try {
+    await slackService.notifySlackStartOrCrash(message, SlackSeverity.WARNING);
+  } catch (slackError) {
+    rootLogger.warn("Failed to send Slack run-error notification:", slackError);
+  }
+}
+
+function validateConfig(): void {
+  if (!affiliateRegistryAddress) {
+    throw new Error("GROUP_AFFILIATES_REGISTRY_ADDRESS is required");
+  }
+  if (!dryRun && safeAddress.trim().length === 0) {
+    throw new Error("GROUP_AFFILIATES_SAFE_ADDRESS is required when group-affiliates is not running in dry-run mode");
+  }
+  if (!dryRun && safeSignerPrivateKey.trim().length === 0) {
+    throw new Error("GROUP_AFFILIATES_SAFE_SIGNER_PRIVATE_KEY is required when group-affiliates is not running in dry-run mode");
+  }
+  if (configuredSignerAddress && safeSignerPrivateKey.trim().length > 0) {
+    const signerAddress = new Wallet(safeSignerPrivateKey).address.toLowerCase();
+    if (signerAddress !== configuredSignerAddress) {
+      throw new Error(
+        `Configured GROUP_AFFILIATES_SIGNER_ADDRESS (${configuredSignerAddress}) does not match signer address (${signerAddress}).`
+      );
+    }
+  }
+}
+
+function formatCursor(cursor: EventCursor): string {
+  return `${cursor.blockNumber}:${cursor.transactionIndex}:${cursor.logIndex}`;
+}
+
+function parseEnvInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw || raw.trim().length === 0) {
+    return fallback;
+  }
+
+  const value = Number.parseInt(raw, 10);
+  if (Number.isNaN(value)) {
+    rootLogger.warn(`Invalid integer for ${name}='${raw}', using fallback ${fallback}.`);
+    return fallback;
+  }
+  return value;
+}
+
+function enqueueExclusive<T>(task: () => Promise<T>): Promise<T> {
+  const next = executionQueue.then(task, task);
+  executionQueue = next.then(() => undefined, () => undefined);
+  return next;
+}
+
+start().catch((cause) => {
+  const error = cause instanceof Error ? cause : new Error(String(cause));
+  rootLogger.error("Group Affiliates service crashed:");
+  rootLogger.error(formatErrorWithCauses(error));
+  void slackService.notifySlackStartOrCrash(
+    `🚨 *Group Affiliates service crashed*\n\nLast error: ${error.message}`,
+    SlackSeverity.CRITICAL
+  ).catch((slackError: unknown) => {
+    rootLogger.warn("Failed to send crash notification to Slack:", slackError);
+  });
+  process.exit(1);
+});

--- a/src/apps/group-affiliates/main.ts
+++ b/src/apps/group-affiliates/main.ts
@@ -51,6 +51,7 @@ const reputationScoreThreshold = parseEnvNumber("GROUP_AFFILIATES_REPUTATION_SCO
 const reputationBaseUrl = process.env.GROUP_AFFILIATES_REPUTATION_BASE_URL || DEFAULT_REPUTATION_BASE_URL;
 const reputationTimeoutMs = parseEnvInt("GROUP_AFFILIATES_REPUTATION_TIMEOUT_MS", 30_000);
 const reputationRefreshMs = parseEnvInt("GROUP_AFFILIATES_REPUTATION_REFRESH_MS", 30 * 60 * 1000);
+const reputationConcurrency = parseEnvInt("GROUP_AFFILIATES_REPUTATION_CONCURRENCY", 8);
 const dryRun = process.env.DRY_RUN === "1";
 const verboseLogging = !!process.env.VERBOSE_LOGGING;
 const safeAddress = process.env.GROUP_AFFILIATES_SAFE_ADDRESS || "";
@@ -74,7 +75,7 @@ const circlesRpc = new CirclesRpcService(rpcUrl, (message) => {
     SlackSeverity.WARNING
   ).catch((error) => console.warn("[SlackAlert] failed:", (error as Error).message));
 });
-const reputationService = new ReputationService(reputationBaseUrl, reputationTimeoutMs);
+const reputationService = new ReputationService(reputationBaseUrl, reputationTimeoutMs, reputationConcurrency);
 
 let leaderElection: LeaderElection | null = null;
 let listener: AffiliateGroupChangedListenerHandle | null = null;

--- a/src/apps/group-affiliates/main.ts
+++ b/src/apps/group-affiliates/main.ts
@@ -16,9 +16,12 @@ import {CirclesRpcService} from "../../services/circlesRpcService";
 import {
   DEFAULT_GROUP_AFFILIATES_BATCH_SIZE,
   DEFAULT_MANAGED_GROUP_ADDRESSES,
+  DEFAULT_REPUTATION_SCORE_THRESHOLD,
+  runReputationReconciliation,
   runForAffiliateEvents,
   type RunConfig
 } from "./logic";
+import {ReputationService} from "./reputationService";
 import {
   AffiliateGroupChangedListenerHandle,
   AffiliateGroupChangedWithCursor,
@@ -34,6 +37,7 @@ import {
 
 const APP_NAME = "group-affiliates";
 const DEFAULT_AFFILIATE_REGISTRY_ADDRESS = "0xca8222e780d046707083f51377b5fd85e2866014";
+const DEFAULT_REPUTATION_BASE_URL = "https://walrus-app-2-iod58.ondigitalocean.app/aboutcircles-advanced-analytics2/rep_score/groups/gnosis/avatars";
 const DEFAULT_START_BLOCK = 41_734_312;
 
 const rpcUrl = process.env.RPC_URL || "https://rpc.aboutcircles.com/";
@@ -43,6 +47,10 @@ const wsUrl = process.env.GROUP_AFFILIATES_WSS_URL || deriveGroupAffiliatesWsUrl
 const startBlock = parseEnvInt("GROUP_AFFILIATES_START_BLOCK", DEFAULT_START_BLOCK);
 const confirmationBlocks = parseEnvInt("CONFIRMATION_BLOCKS", 2);
 const batchSize = parseEnvInt("GROUP_AFFILIATES_BATCH_SIZE", DEFAULT_GROUP_AFFILIATES_BATCH_SIZE);
+const reputationScoreThreshold = parseEnvNumber("GROUP_AFFILIATES_REPUTATION_SCORE_THRESHOLD", DEFAULT_REPUTATION_SCORE_THRESHOLD);
+const reputationBaseUrl = process.env.GROUP_AFFILIATES_REPUTATION_BASE_URL || DEFAULT_REPUTATION_BASE_URL;
+const reputationTimeoutMs = parseEnvInt("GROUP_AFFILIATES_REPUTATION_TIMEOUT_MS", 30_000);
+const reputationRefreshMs = parseEnvInt("GROUP_AFFILIATES_REPUTATION_REFRESH_MS", 30 * 60 * 1000);
 const dryRun = process.env.DRY_RUN === "1";
 const verboseLogging = !!process.env.VERBOSE_LOGGING;
 const safeAddress = process.env.GROUP_AFFILIATES_SAFE_ADDRESS || "";
@@ -66,15 +74,18 @@ const circlesRpc = new CirclesRpcService(rpcUrl, (message) => {
     SlackSeverity.WARNING
   ).catch((error) => console.warn("[SlackAlert] failed:", (error as Error).message));
 });
+const reputationService = new ReputationService(reputationBaseUrl, reputationTimeoutMs);
 
 let leaderElection: LeaderElection | null = null;
 let listener: AffiliateGroupChangedListenerHandle | null = null;
 let groupService: IGroupService;
 let executionQueue: Promise<void> = Promise.resolve();
+let reputationRefreshTimer: NodeJS.Timeout | null = null;
 
 const config: RunConfig = {
   managedGroupAddresses: DEFAULT_MANAGED_GROUP_ADDRESSES,
   batchSize,
+  reputationScoreThreshold,
   dryRun
 };
 
@@ -143,6 +154,7 @@ async function start(): Promise<void> {
   try {
     cursor = await runStartupReplay(stateStore, cursor);
     startRealtimeListener(stateStore, cursor);
+    startReputationReconciliationLoop();
   } catch (cause) {
     const error = cause instanceof Error ? cause : new Error(String(cause));
     recordRunError(APP_NAME);
@@ -238,7 +250,7 @@ async function processEvents(
   const startedAt = Date.now();
   try {
     const outcome = await runForAffiliateEvents(
-      {circlesRpc, groupService, logger: runLogger},
+      {circlesRpc, groupService, reputationService, logger: runLogger},
       {...config, dryRun: effectiveDryRun},
       events
     );
@@ -253,9 +265,55 @@ async function processEvents(
     runLogger.info(
       `group-affiliates batch completed: events=${outcome.processedEvents} ` +
       `ignored=${outcome.ignoredEvents} trustTxs=${outcome.trustTxHashes.length} ` +
-      `untrustTxs=${outcome.untrustTxHashes.length} dryRun=${effectiveDryRun}`
+      `untrustTxs=${outcome.untrustTxHashes.length} ` +
+      `reputationIneligible=${outcome.ineligibleByReputation.length} dryRun=${effectiveDryRun}`
     );
     return !effectiveDryRun;
+  } catch (cause) {
+    const error = cause instanceof Error ? cause : new Error(String(cause));
+    const consecutiveErrors = errorTracker.recordError();
+    recordRunError(APP_NAME);
+    rootLogger.error(`Consecutive error ${consecutiveErrors} of ${errorsBeforeCrash}`);
+    rootLogger.error(formatErrorWithCauses(error));
+    if (errorTracker.shouldAlert()) {
+      await notifySlackRunError(error, consecutiveErrors);
+      setTimeout(() => process.exit(1), 3000).unref();
+    }
+    throw error;
+  }
+}
+
+function startReputationReconciliationLoop(): void {
+  if (reputationRefreshMs <= 0 || reputationRefreshTimer) {
+    return;
+  }
+
+  rootLogger.info(`Starting reputation reconciliation loop every ${reputationRefreshMs}ms.`);
+  reputationRefreshTimer = setInterval(() => {
+    void enqueueExclusive(async () => {
+      const effectiveDryRun = getEffectiveDryRun(leaderElection, dryRun);
+      await processReputationReconciliation(effectiveDryRun);
+    }).catch((error) => {
+      rootLogger.error("Reputation reconciliation failed:");
+      rootLogger.error(formatErrorWithCauses(error instanceof Error ? error : new Error(String(error))));
+    });
+  }, reputationRefreshMs);
+}
+
+async function processReputationReconciliation(effectiveDryRun: boolean): Promise<void> {
+  const startedAt = Date.now();
+  try {
+    const outcome = await runReputationReconciliation(
+      {circlesRpc, groupService, reputationService, logger: runLogger.child("reputation")},
+      {...config, dryRun: effectiveDryRun}
+    );
+    recordRunSuccess(APP_NAME, Date.now() - startedAt);
+    errorTracker.recordSuccess();
+    runLogger.info(
+      `group-affiliates reputation reconciliation completed: ` +
+      `untrustTxs=${outcome.untrustTxHashes.length} ` +
+      `reputationIneligible=${outcome.ineligibleByReputation.length} dryRun=${effectiveDryRun}`
+    );
   } catch (cause) {
     const error = cause instanceof Error ? cause : new Error(String(cause));
     const consecutiveErrors = errorTracker.recordError();
@@ -326,6 +384,10 @@ async function gracefulShutdown(signal: string): Promise<void> {
       listener = null;
     }
   }
+  if (reputationRefreshTimer) {
+    clearInterval(reputationRefreshTimer);
+    reputationRefreshTimer = null;
+  }
 
   try {
     await leaderElection?.stop();
@@ -354,6 +416,9 @@ async function notifySlackStartup(): Promise<void> {
     `- Start Block: ${startBlock}\n` +
     `- Confirmations: ${confirmationBlocks}\n` +
     `- Batch Size: ${batchSize}\n` +
+    `- Reputation URL: ${reputationBaseUrl}\n` +
+    `- Reputation Threshold: > ${reputationScoreThreshold}\n` +
+    `- Reputation Refresh (ms): ${reputationRefreshMs}\n` +
     `- Safe: ${safeAddress || "(not set)"}\n` +
     `- Safe signer configured: ${safeSignerPrivateKey.trim().length > 0}\n` +
     `- Dry Run: ${dryRun}\n` +
@@ -413,6 +478,20 @@ function parseEnvInt(name: string, fallback: number): number {
   const value = Number.parseInt(raw, 10);
   if (Number.isNaN(value)) {
     rootLogger.warn(`Invalid integer for ${name}='${raw}', using fallback ${fallback}.`);
+    return fallback;
+  }
+  return value;
+}
+
+function parseEnvNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw || raw.trim().length === 0) {
+    return fallback;
+  }
+
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    rootLogger.warn(`Invalid number for ${name}='${raw}', using fallback ${fallback}.`);
     return fallback;
   }
   return value;

--- a/src/apps/group-affiliates/realtime.ts
+++ b/src/apps/group-affiliates/realtime.ts
@@ -1,0 +1,579 @@
+import {FallbackProvider, Interface, JsonRpcProvider, Log} from "ethers";
+
+import {ILoggerService} from "../../interfaces/ILoggerService";
+import {createProvider} from "../../services/rpcProvider";
+import {retryWithBackoff} from "../../services/retryWithBackoff";
+
+export type EventCursor = {
+  blockNumber: number;
+  transactionIndex: number;
+  logIndex: number;
+};
+
+export type AffiliateGroupChangedWithCursor = {
+  blockNumber: number;
+  txHash: string;
+  human: string;
+  oldGroup: string;
+  newGroup: string;
+  cursor: EventCursor;
+};
+
+type StartAffiliateGroupChangedListenerOptions = {
+  httpRpcUrl: string;
+  wsUrl: string;
+  registryAddress: string;
+  logger: ILoggerService;
+  startCursor: EventCursor | null;
+  onEvents: (events: AffiliateGroupChangedWithCursor[]) => Promise<boolean> | boolean;
+  debounceMs?: number;
+  reconnectBaseMs?: number;
+  reconnectMaxMs?: number;
+};
+
+type JsonRpcMessage = {
+  id?: number;
+  method?: string;
+  params?: {
+    subscription?: string;
+    result?: unknown;
+  };
+  result?: unknown;
+  error?: {
+    code?: number;
+    message?: string;
+  };
+};
+
+type EthLogSubscriptionEvent = {
+  address?: string;
+  topics?: unknown[];
+  data?: string;
+  blockNumber?: string | number;
+  transactionHash?: string;
+  transactionIndex?: string | number;
+  logIndex?: string | number;
+};
+
+type WebSocketMessageEventLike = {
+  data: unknown;
+};
+
+type WebSocketCloseEventLike = {
+  code: number;
+};
+
+type WebSocketLike = {
+  addEventListener: (type: string, listener: (event: any) => void) => void;
+  send: (data: string) => void;
+  close: () => void;
+};
+
+export type AffiliateGroupChangedListenerHandle = {
+  stop: () => void;
+};
+
+const DEFAULT_DEBOUNCE_MS = 1_000;
+const DEFAULT_RECONNECT_BASE_MS = 2_000;
+const DEFAULT_RECONNECT_MAX_MS = 60_000;
+const DEFAULT_LOG_CHUNK_SIZE = 100_000;
+const WebSocketImpl = (globalThis as any).WebSocket as { new(url: string): WebSocketLike };
+
+export const AFFILIATE_GROUP_CHANGED_ABI = [
+  "event AffiliateGroupChanged(address indexed human, address oldGroup, address newGroup)"
+] as const;
+
+const AFFILIATE_GROUP_CHANGED_IFACE = new Interface(AFFILIATE_GROUP_CHANGED_ABI);
+export const AFFILIATE_GROUP_CHANGED_TOPIC0 =
+  AFFILIATE_GROUP_CHANGED_IFACE.getEvent("AffiliateGroupChanged")!.topicHash.toLowerCase();
+
+export function startAffiliateGroupChangedListener(
+  options: StartAffiliateGroupChangedListenerOptions
+): AffiliateGroupChangedListenerHandle {
+  const {
+    httpRpcUrl,
+    wsUrl,
+    registryAddress,
+    logger,
+    onEvents,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    reconnectBaseMs = DEFAULT_RECONNECT_BASE_MS,
+    reconnectMaxMs = DEFAULT_RECONNECT_MAX_MS
+  } = options;
+
+  let stopped = false;
+  let ws: WebSocketLike | null = null;
+  let reconnectTimer: NodeJS.Timeout | null = null;
+  let flushTimer: NodeJS.Timeout | null = null;
+  let reconnectAttempt = 0;
+  let lastSeenCursor = options.startCursor;
+  let catchUpInFlight: Promise<void> | null = null;
+  const pendingEvents: AffiliateGroupChangedWithCursor[] = [];
+  const subscriptionRequest = buildAffiliateGroupChangedSubscriptionRequest(registryAddress);
+
+  const clearReconnectTimer = (): void => {
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+  };
+
+  const clearFlushTimer = (): void => {
+    if (flushTimer) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+  };
+
+  const deliverEvents = async (events: AffiliateGroupChangedWithCursor[]): Promise<void> => {
+    const filtered = filterEventsAfterCursor(events, lastSeenCursor);
+    if (filtered.length === 0) {
+      return;
+    }
+
+    try {
+      const shouldAdvance = await onEvents(filtered);
+      if (shouldAdvance) {
+        lastSeenCursor = maxCursor(lastSeenCursor, filtered[filtered.length - 1].cursor);
+      }
+    } catch (error) {
+      logger.error("AffiliateGroupChanged listener callback failed:", error);
+    }
+  };
+
+  const flushPendingEvents = async (): Promise<void> => {
+    clearFlushTimer();
+    if (pendingEvents.length === 0) {
+      return;
+    }
+
+    const events = pendingEvents.splice(0, pendingEvents.length);
+    await deliverEvents(events);
+  };
+
+  const scheduleFlush = (): void => {
+    if (flushTimer) {
+      return;
+    }
+    flushTimer = setTimeout(() => {
+      void flushPendingEvents();
+    }, debounceMs);
+  };
+
+  const closeSocket = (): void => {
+    if (!ws) {
+      return;
+    }
+    try {
+      ws.close();
+    } catch {
+      // Ignore close errors during shutdown/reconnect.
+    }
+    ws = null;
+  };
+
+  const scheduleReconnect = (reason: string): void => {
+    if (stopped || reconnectTimer) {
+      return;
+    }
+
+    const delay = Math.min(reconnectBaseMs * (2 ** reconnectAttempt), reconnectMaxMs);
+    reconnectAttempt += 1;
+    logger.warn(`AffiliateGroupChanged listener disconnected (${reason}); reconnecting in ${delay}ms.`);
+
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      connect();
+    }, delay);
+  };
+
+  const runCatchUp = async (connectStartedHead: number | null): Promise<void> => {
+    if (catchUpInFlight) {
+      return catchUpInFlight;
+    }
+
+    catchUpInFlight = (async () => {
+      try {
+        const currentHead = connectStartedHead ?? await fetchCurrentBlockNumber(httpRpcUrl);
+        if (!Number.isFinite(currentHead)) {
+          return;
+        }
+
+        if (!lastSeenCursor) {
+          lastSeenCursor = makeHeadCursor(currentHead as number);
+          return;
+        }
+
+        if ((currentHead as number) < lastSeenCursor.blockNumber) {
+          return;
+        }
+
+        const events = await fetchAffiliateGroupChangedEventsBetween(
+          httpRpcUrl,
+          registryAddress,
+          lastSeenCursor.blockNumber,
+          currentHead as number,
+          lastSeenCursor,
+          logger
+        );
+        await deliverEvents(events);
+      } catch (error) {
+        logger.warn("AffiliateGroupChanged listener catch-up failed:", error);
+      } finally {
+        catchUpInFlight = null;
+      }
+    })();
+
+    return catchUpInFlight;
+  };
+
+  const handleSubscriptionPayload = (payload: unknown): void => {
+    const events = extractAffiliateGroupChangedEventsFromSubscriptionPayload(payload, registryAddress);
+    if (events.length === 0) {
+      return;
+    }
+
+    pendingEvents.push(...events);
+    logger.info(`AffiliateGroupChanged listener detected ${events.length} event(s).`);
+    scheduleFlush();
+  };
+
+  const connect = (): void => {
+    if (stopped) {
+      return;
+    }
+
+    clearReconnectTimer();
+    closeSocket();
+
+    logger.info(`Connecting AffiliateGroupChanged listener to ${wsUrl}...`);
+    ws = new WebSocketImpl(wsUrl);
+    let connectStartedHead: number | null = null;
+
+    void fetchCurrentBlockNumber(httpRpcUrl)
+      .then((head) => {
+        connectStartedHead = head;
+      })
+      .catch((error) => {
+        logger.warn("AffiliateGroupChanged listener failed to fetch current block before subscribing:", error);
+      });
+
+    ws.addEventListener("open", () => {
+      reconnectAttempt = 0;
+      logger.info("AffiliateGroupChanged listener connected. Subscribing to chain logs...");
+      ws?.send(JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_subscribe",
+        params: subscriptionRequest.params
+      }));
+    });
+
+    ws.addEventListener("message", (event: WebSocketMessageEventLike) => {
+      let message: JsonRpcMessage;
+      try {
+        message = JSON.parse(String(event.data)) as JsonRpcMessage;
+      } catch (error) {
+        logger.warn("AffiliateGroupChanged listener received invalid JSON payload:", error);
+        return;
+      }
+
+      if (message.id === 1) {
+        if (message.error) {
+          logger.error(
+            `AffiliateGroupChanged listener subscription failed: ${message.error.message ?? "unknown error"}`
+          );
+          closeSocket();
+          scheduleReconnect("subscription failed");
+          return;
+        }
+
+        logger.info(`AffiliateGroupChanged listener subscribed successfully (id=${String(message.result ?? "")}).`);
+        void runCatchUp(connectStartedHead);
+        return;
+      }
+
+      if (message.method === "eth_subscription") {
+        handleSubscriptionPayload(message.params?.result);
+      }
+    });
+
+    ws.addEventListener("error", (event: unknown) => {
+      logger.warn("AffiliateGroupChanged listener websocket error:", event);
+    });
+
+    ws.addEventListener("close", (event: WebSocketCloseEventLike) => {
+      ws = null;
+      if (stopped) {
+        return;
+      }
+      scheduleReconnect(`close code ${event.code}`);
+    });
+  };
+
+  connect();
+
+  return {
+    stop: () => {
+      stopped = true;
+      clearReconnectTimer();
+      clearFlushTimer();
+      closeSocket();
+    }
+  };
+}
+
+export function deriveGroupAffiliatesWsUrl(rpcUrl: string): string {
+  const trimmed = rpcUrl.trim();
+  if (trimmed.startsWith("ws://") || trimmed.startsWith("wss://")) {
+    return trimmed;
+  }
+
+  const url = new URL(trimmed);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  if (!url.pathname || url.pathname === "/") {
+    url.pathname = "/ws/chain";
+  }
+  return url.toString();
+}
+
+export function buildAffiliateGroupChangedSubscriptionRequest(registryAddress: string): {
+  description: string;
+  params: ["logs", {address: string; topics: string[]}];
+} {
+  return {
+    description: "AffiliateGroupChanged chain logs",
+    params: ["logs", {
+      address: registryAddress,
+      topics: [AFFILIATE_GROUP_CHANGED_TOPIC0]
+    }]
+  };
+}
+
+export function extractAffiliateGroupChangedEventsFromSubscriptionPayload(
+  payload: unknown,
+  registryAddress?: string
+): AffiliateGroupChangedWithCursor[] {
+  const logs = Array.isArray(payload)
+    ? payload as EthLogSubscriptionEvent[]
+    : payload
+      ? [payload as EthLogSubscriptionEvent]
+      : [];
+
+  const events: AffiliateGroupChangedWithCursor[] = [];
+  for (const log of logs) {
+    const parsed = parseAffiliateGroupChangedLog(log, registryAddress);
+    if (parsed) {
+      events.push(parsed);
+    }
+  }
+  return dedupeAndSortEvents(events);
+}
+
+export async function fetchAffiliateGroupChangedEventsBetween(
+  rpcUrl: string,
+  registryAddress: string,
+  fromBlock: number,
+  toBlock: number,
+  afterCursor: EventCursor | null = null,
+  logger?: ILoggerService,
+  chunkSize = DEFAULT_LOG_CHUNK_SIZE
+): Promise<AffiliateGroupChangedWithCursor[]> {
+  if (fromBlock > toBlock) {
+    return [];
+  }
+
+  const provider = createProvider(rpcUrl) as JsonRpcProvider | FallbackProvider;
+  const events: AffiliateGroupChangedWithCursor[] = [];
+  let chunkStart = Math.max(0, fromBlock);
+  const totalChunks = Math.ceil((toBlock - chunkStart + 1) / chunkSize);
+  let chunkIndex = 0;
+
+  try {
+    while (chunkStart <= toBlock) {
+      const chunkEnd = Math.min(toBlock, chunkStart + chunkSize - 1);
+      chunkIndex += 1;
+      const logs = await retryWithBackoff(() =>
+        provider.getLogs({
+          address: registryAddress,
+          fromBlock: chunkStart,
+          toBlock: chunkEnd,
+          topics: [AFFILIATE_GROUP_CHANGED_TOPIC0]
+        })
+      );
+
+      logger?.info(
+        `[group-affiliates-fetch] chunk ${chunkIndex}/${totalChunks} range=${chunkStart}-${chunkEnd} logs=${logs.length}`
+      );
+
+      for (const log of logs) {
+        const parsed = parseAffiliateGroupChangedLog(fromEthersLog(log), registryAddress);
+        if (parsed && (!afterCursor || compareEventCursor(parsed.cursor, afterCursor) > 0)) {
+          events.push(parsed);
+        }
+      }
+
+      chunkStart = chunkEnd + 1;
+    }
+  } finally {
+    provider.destroy();
+  }
+
+  return dedupeAndSortEvents(events);
+}
+
+export async function fetchCurrentBlockNumber(httpRpcUrl: string): Promise<number | null> {
+  const response = await fetch(httpRpcUrl, {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "eth_blockNumber",
+      params: []
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`eth_blockNumber failed with HTTP ${response.status}.`);
+  }
+
+  const payload = await response.json() as {result?: string | number; error?: {message?: string}};
+  if (payload.error) {
+    throw new Error(payload.error.message ?? "eth_blockNumber returned an RPC error.");
+  }
+
+  return toFiniteNumber(payload.result);
+}
+
+export function makeHeadCursor(blockNumber: number): EventCursor {
+  return {
+    blockNumber,
+    transactionIndex: Number.MAX_SAFE_INTEGER,
+    logIndex: Number.MAX_SAFE_INTEGER
+  };
+}
+
+export function makeInclusiveBlockCursor(blockNumber: number): EventCursor {
+  return {
+    blockNumber,
+    transactionIndex: -1,
+    logIndex: -1
+  };
+}
+
+export function compareEventCursor(left: EventCursor, right: EventCursor): number {
+  if (left.blockNumber !== right.blockNumber) {
+    return left.blockNumber - right.blockNumber;
+  }
+  if (left.transactionIndex !== right.transactionIndex) {
+    return left.transactionIndex - right.transactionIndex;
+  }
+  return left.logIndex - right.logIndex;
+}
+
+export function maxCursor(left: EventCursor | null, right: EventCursor | null): EventCursor | null {
+  if (!left) {
+    return right;
+  }
+  if (!right) {
+    return left;
+  }
+  return compareEventCursor(left, right) >= 0 ? left : right;
+}
+
+export function filterEventsAfterCursor(
+  events: AffiliateGroupChangedWithCursor[],
+  cursor: EventCursor | null
+): AffiliateGroupChangedWithCursor[] {
+  return dedupeAndSortEvents(
+    cursor
+      ? events.filter((event) => compareEventCursor(event.cursor, cursor) > 0)
+      : events
+  );
+}
+
+function parseAffiliateGroupChangedLog(
+  log: EthLogSubscriptionEvent,
+  registryAddress?: string
+): AffiliateGroupChangedWithCursor | null {
+  if (registryAddress && typeof log.address === "string" && log.address.toLowerCase() !== registryAddress.toLowerCase()) {
+    return null;
+  }
+
+  const topics = Array.isArray(log.topics)
+    ? log.topics.filter((topic): topic is string => typeof topic === "string")
+    : [];
+  if (topics.length === 0 || topics[0].toLowerCase() !== AFFILIATE_GROUP_CHANGED_TOPIC0 || typeof log.data !== "string") {
+    return null;
+  }
+
+  let parsedLog;
+  try {
+    parsedLog = AFFILIATE_GROUP_CHANGED_IFACE.parseLog({
+      topics,
+      data: log.data
+    });
+  } catch {
+    return null;
+  }
+
+  const blockNumber = toFiniteNumber(log.blockNumber);
+  const transactionIndex = toFiniteNumber(log.transactionIndex);
+  const logIndex = toFiniteNumber(log.logIndex);
+  if (!parsedLog || blockNumber === null || transactionIndex === null || logIndex === null || !log.transactionHash) {
+    return null;
+  }
+
+  return {
+    blockNumber,
+    txHash: log.transactionHash,
+    human: String(parsedLog.args.human),
+    oldGroup: String(parsedLog.args.oldGroup),
+    newGroup: String(parsedLog.args.newGroup),
+    cursor: {blockNumber, transactionIndex, logIndex}
+  };
+}
+
+function fromEthersLog(log: Log): EthLogSubscriptionEvent {
+  return {
+    address: log.address,
+    topics: [...log.topics],
+    data: log.data,
+    blockNumber: log.blockNumber,
+    transactionHash: log.transactionHash,
+    transactionIndex: log.transactionIndex,
+    logIndex: log.index
+  };
+}
+
+function dedupeAndSortEvents(events: AffiliateGroupChangedWithCursor[]): AffiliateGroupChangedWithCursor[] {
+  const seen = new Set<string>();
+  const deduped: AffiliateGroupChangedWithCursor[] = [];
+
+  for (const event of events) {
+    const key = `${event.txHash}:${event.cursor.blockNumber}:${event.cursor.transactionIndex}:${event.cursor.logIndex}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(event);
+  }
+
+  return deduped.sort((left, right) => compareEventCursor(left.cursor, right.cursor));
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const parsed = value.startsWith("0x")
+      ? Number.parseInt(value, 16)
+      : Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}

--- a/src/apps/group-affiliates/reputationService.ts
+++ b/src/apps/group-affiliates/reputationService.ts
@@ -18,14 +18,32 @@ type ReputationResponse = {
 export class ReputationService implements IReputationService {
   constructor(
     private readonly baseUrl: string,
-    private readonly timeoutMs: number = 30_000
+    private readonly timeoutMs: number = 30_000,
+    private readonly concurrency: number = 8
   ) {
   }
 
   async check(addresses: string[], threshold: number): Promise<Map<string, ReputationVerdict>> {
     const unique = Array.from(new Set(addresses.map((address) => getAddress(address).toLowerCase())));
-    const entries = await Promise.all(unique.map((address) => this.fetchVerdict(address, threshold)));
-    return new Map(entries.map((entry) => [entry.address, entry]));
+    // Rolling-window concurrency: at most `concurrency` fetches in flight at
+    // any time. Prevents the startup-replay path from firing hundreds of
+    // simultaneous requests, which overwhelms both the local TCP stack
+    // (undici ConnectTimeoutError on the connect queue) and the upstream
+    // rep_score service (2-worker gunicorn → queue blow-up).
+    const results = new Array<ReputationVerdict>(unique.length);
+    let nextIndex = 0;
+    const worker = async (): Promise<void> => {
+      while (true) {
+        const i = nextIndex++;
+        if (i >= unique.length) {
+          return;
+        }
+        results[i] = await this.fetchVerdict(unique[i], threshold);
+      }
+    };
+    const workerCount = Math.max(1, Math.min(this.concurrency, unique.length));
+    await Promise.all(Array.from({length: workerCount}, worker));
+    return new Map(results.map((entry) => [entry.address, entry]));
   }
 
   private async fetchVerdict(address: string, threshold: number): Promise<ReputationVerdict> {

--- a/src/apps/group-affiliates/reputationService.ts
+++ b/src/apps/group-affiliates/reputationService.ts
@@ -1,0 +1,68 @@
+import {getAddress} from "ethers";
+
+export type ReputationVerdict = {
+  address: string;
+  reputationScore: number | null;
+  eligible: boolean;
+};
+
+export interface IReputationService {
+  check(addresses: string[], threshold: number): Promise<Map<string, ReputationVerdict>>;
+}
+
+type ReputationResponse = {
+  address?: unknown;
+  reputation_score?: unknown;
+};
+
+export class ReputationService implements IReputationService {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly timeoutMs: number = 30_000
+  ) {
+  }
+
+  async check(addresses: string[], threshold: number): Promise<Map<string, ReputationVerdict>> {
+    const unique = Array.from(new Set(addresses.map((address) => getAddress(address).toLowerCase())));
+    const entries = await Promise.all(unique.map((address) => this.fetchVerdict(address, threshold)));
+    return new Map(entries.map((entry) => [entry.address, entry]));
+  }
+
+  private async fetchVerdict(address: string, threshold: number): Promise<ReputationVerdict> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      const response = await fetch(`${this.baseUrl.replace(/\/+$/, "")}/${address}`, {
+        method: "GET",
+        headers: {"accept": "application/json"},
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        throw new Error(`reputation request failed for ${address}: HTTP ${response.status}`);
+      }
+
+      const payload = await response.json() as ReputationResponse;
+      const score = parseScore(payload.reputation_score);
+      return {
+        address,
+        reputationScore: score,
+        eligible: score !== null && score > threshold
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function parseScore(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}

--- a/tests/apps/group-affiliates/logic.spec.ts
+++ b/tests/apps/group-affiliates/logic.spec.ts
@@ -1,0 +1,154 @@
+import {FakeCirclesRpc, FakeGroupService, FakeLogger} from "../../../fakes/fakes";
+import {
+  DEFAULT_MANAGED_GROUP_ADDRESSES,
+  runForAffiliateEvents,
+  type Deps,
+  type RunConfig
+} from "../../../src/apps/group-affiliates/logic";
+import {AffiliateGroupChangedWithCursor} from "../../../src/apps/group-affiliates/realtime";
+
+const [GROUP_A, GROUP_B, GROUP_C] = DEFAULT_MANAGED_GROUP_ADDRESSES.map((address) => address.toLowerCase());
+const UNMANAGED = "0x9999999999999999999999999999999999999999";
+const HUMAN_A = "0x1000000000000000000000000000000000000001";
+const HUMAN_B = "0x1000000000000000000000000000000000000002";
+
+function makeDeps(): Deps {
+  return {
+    circlesRpc: new FakeCirclesRpc(),
+    groupService: new FakeGroupService(),
+    logger: new FakeLogger(true)
+  };
+}
+
+function makeCfg(overrides?: Partial<RunConfig>): RunConfig {
+  return {
+    managedGroupAddresses: DEFAULT_MANAGED_GROUP_ADDRESSES,
+    batchSize: 20,
+    dryRun: false,
+    ...overrides
+  };
+}
+
+function event(
+  human: string,
+  oldGroup: string,
+  newGroup: string,
+  blockNumber: number,
+  transactionIndex = 0,
+  logIndex = 0
+): AffiliateGroupChangedWithCursor {
+  return {
+    blockNumber,
+    txHash: `0xtx${blockNumber}${transactionIndex}${logIndex}`,
+    human,
+    oldGroup,
+    newGroup,
+    cursor: {blockNumber, transactionIndex, logIndex}
+  };
+}
+
+describe("group-affiliates logic", () => {
+  it("trusts a human when they set a managed group as affiliate", async () => {
+    const deps = makeDeps();
+
+    await runForAffiliateEvents(deps, makeCfg(), [
+      event(HUMAN_A, UNMANAGED, GROUP_A, 10)
+    ]);
+
+    const groupService = deps.groupService as FakeGroupService;
+    expect(groupService.calls).toEqual([
+      {type: "trust", groupAddress: GROUP_A, trusteeAddresses: [HUMAN_A]}
+    ]);
+  });
+
+  it("untrusts a human when they switch away from a managed group", async () => {
+    const deps = makeDeps();
+    (deps.circlesRpc as FakeCirclesRpc).trusteesByTruster[GROUP_A] = [HUMAN_A];
+
+    await runForAffiliateEvents(deps, makeCfg(), [
+      event(HUMAN_A, GROUP_A, UNMANAGED, 10)
+    ]);
+
+    const groupService = deps.groupService as FakeGroupService;
+    expect(groupService.calls).toEqual([
+      {type: "untrust", groupAddress: GROUP_A, trusteeAddresses: [HUMAN_A]}
+    ]);
+  });
+
+  it("untrusts the old managed group before trusting the new managed group", async () => {
+    const deps = makeDeps();
+    (deps.circlesRpc as FakeCirclesRpc).trusteesByTruster[GROUP_A] = [HUMAN_A];
+
+    await runForAffiliateEvents(deps, makeCfg(), [
+      event(HUMAN_A, GROUP_A, GROUP_B, 10)
+    ]);
+
+    const groupService = deps.groupService as FakeGroupService;
+    expect(groupService.calls).toEqual([
+      {type: "untrust", groupAddress: GROUP_A, trusteeAddresses: [HUMAN_A]},
+      {type: "trust", groupAddress: GROUP_B, trusteeAddresses: [HUMAN_A]}
+    ]);
+  });
+
+  it("collapses multiple replayed switches to the final managed group", async () => {
+    const deps = makeDeps();
+    (deps.circlesRpc as FakeCirclesRpc).trusteesByTruster[GROUP_A] = [HUMAN_A];
+    (deps.circlesRpc as FakeCirclesRpc).trusteesByTruster[GROUP_B] = [];
+    (deps.circlesRpc as FakeCirclesRpc).trusteesByTruster[GROUP_C] = [];
+
+    await runForAffiliateEvents(deps, makeCfg(), [
+      event(HUMAN_A, GROUP_A, GROUP_B, 11),
+      event(HUMAN_A, GROUP_B, GROUP_C, 12)
+    ]);
+
+    const groupService = deps.groupService as FakeGroupService;
+    expect(groupService.calls).toEqual([
+      {type: "untrust", groupAddress: GROUP_A, trusteeAddresses: [HUMAN_A]},
+      {type: "trust", groupAddress: GROUP_C, trusteeAddresses: [HUMAN_A]}
+    ]);
+  });
+
+  it("ignores unrelated and same-group events", async () => {
+    const deps = makeDeps();
+
+    const outcome = await runForAffiliateEvents(deps, makeCfg(), [
+      event(HUMAN_A, UNMANAGED, UNMANAGED, 10),
+      event(HUMAN_A, GROUP_A, GROUP_A, 11)
+    ]);
+
+    expect((deps.groupService as FakeGroupService).calls).toEqual([]);
+    expect(outcome.ignoredEvents).toBe(2);
+  });
+
+  it("batches changes and keeps untrust batches before trust batches", async () => {
+    const deps = makeDeps();
+    (deps.circlesRpc as FakeCirclesRpc).trusteesByTruster[GROUP_A] = [HUMAN_A, HUMAN_B];
+
+    await runForAffiliateEvents(deps, makeCfg({batchSize: 1}), [
+      event(HUMAN_B, GROUP_A, UNMANAGED, 10),
+      event(HUMAN_A, GROUP_A, GROUP_B, 11),
+      event(HUMAN_B, UNMANAGED, GROUP_B, 12)
+    ]);
+
+    const calls = (deps.groupService as FakeGroupService).calls;
+    expect(calls.map((call) => call.type)).toEqual(["untrust", "untrust", "trust", "trust"]);
+    expect(calls[0].groupAddress).toBe(GROUP_A);
+    expect(calls[1].groupAddress).toBe(GROUP_A);
+    expect(calls[2].groupAddress).toBe(GROUP_B);
+    expect(calls[3].groupAddress).toBe(GROUP_B);
+  });
+
+  it("supports dry-run mode with simulations and no write calls", async () => {
+    const deps = makeDeps();
+
+    await runForAffiliateEvents(deps, makeCfg({dryRun: true}), [
+      event(HUMAN_A, UNMANAGED, GROUP_A, 10)
+    ]);
+
+    const groupService = deps.groupService as FakeGroupService;
+    expect(groupService.calls).toEqual([]);
+    expect(groupService.simulations).toEqual([
+      {type: "trust", groupAddress: GROUP_A, trusteeAddresses: [HUMAN_A]}
+    ]);
+  });
+});

--- a/tests/apps/group-affiliates/logic.spec.ts
+++ b/tests/apps/group-affiliates/logic.spec.ts
@@ -1,11 +1,13 @@
 import {FakeCirclesRpc, FakeGroupService, FakeLogger} from "../../../fakes/fakes";
 import {
   DEFAULT_MANAGED_GROUP_ADDRESSES,
+  runReputationReconciliation,
   runForAffiliateEvents,
   type Deps,
   type RunConfig
 } from "../../../src/apps/group-affiliates/logic";
 import {AffiliateGroupChangedWithCursor} from "../../../src/apps/group-affiliates/realtime";
+import {IReputationService, ReputationVerdict} from "../../../src/apps/group-affiliates/reputationService";
 
 const [GROUP_A, GROUP_B, GROUP_C] = DEFAULT_MANAGED_GROUP_ADDRESSES.map((address) => address.toLowerCase());
 const UNMANAGED = "0x9999999999999999999999999999999999999999";
@@ -13,9 +15,11 @@ const HUMAN_A = "0x1000000000000000000000000000000000000001";
 const HUMAN_B = "0x1000000000000000000000000000000000000002";
 
 function makeDeps(): Deps {
+  const reputationService = new FakeReputationService();
   return {
     circlesRpc: new FakeCirclesRpc(),
     groupService: new FakeGroupService(),
+    reputationService,
     logger: new FakeLogger(true)
   };
 }
@@ -24,9 +28,28 @@ function makeCfg(overrides?: Partial<RunConfig>): RunConfig {
   return {
     managedGroupAddresses: DEFAULT_MANAGED_GROUP_ADDRESSES,
     batchSize: 20,
+    reputationScoreThreshold: 40,
     dryRun: false,
     ...overrides
   };
+}
+
+class FakeReputationService implements IReputationService {
+  scores = new Map<string, number | null>();
+
+  async check(addresses: string[], threshold: number): Promise<Map<string, ReputationVerdict>> {
+    const result = new Map<string, ReputationVerdict>();
+    for (const address of addresses) {
+      const normalized = address.toLowerCase();
+      const score = this.scores.has(normalized) ? this.scores.get(normalized)! : 100;
+      result.set(normalized, {
+        address: normalized,
+        reputationScore: score,
+        eligible: score !== null && score > threshold
+      });
+    }
+    return result;
+  }
 }
 
 function event(
@@ -149,6 +172,46 @@ describe("group-affiliates logic", () => {
     expect(groupService.calls).toEqual([]);
     expect(groupService.simulations).toEqual([
       {type: "trust", groupAddress: GROUP_A, trusteeAddresses: [HUMAN_A]}
+    ]);
+  });
+
+  it("does not trust a managed affiliate whose reputation score is at or below threshold", async () => {
+    const deps = makeDeps();
+    (deps.reputationService as FakeReputationService).scores.set(HUMAN_A, 40);
+
+    const outcome = await runForAffiliateEvents(deps, makeCfg(), [
+      event(HUMAN_A, UNMANAGED, GROUP_A, 10)
+    ]);
+
+    expect((deps.groupService as FakeGroupService).calls).toEqual([]);
+    expect(outcome.ineligibleByReputation).toEqual([HUMAN_A]);
+  });
+
+  it("untrusts a touched managed affiliate when their reputation score falls below threshold", async () => {
+    const deps = makeDeps();
+    (deps.circlesRpc as FakeCirclesRpc).trusteesByTruster[GROUP_A] = [HUMAN_A];
+    (deps.reputationService as FakeReputationService).scores.set(HUMAN_A, 39.99);
+
+    await runForAffiliateEvents(deps, makeCfg(), [
+      event(HUMAN_A, UNMANAGED, GROUP_A, 10)
+    ]);
+
+    expect((deps.groupService as FakeGroupService).calls).toEqual([
+      {type: "untrust", groupAddress: GROUP_A, trusteeAddresses: [HUMAN_A]}
+    ]);
+  });
+
+  it("reconciles current trustees whose reputation score falls below threshold", async () => {
+    const deps = makeDeps();
+    (deps.circlesRpc as FakeCirclesRpc).trusteesByTruster[GROUP_A] = [HUMAN_A, HUMAN_B];
+    (deps.reputationService as FakeReputationService).scores.set(HUMAN_A, 41);
+    (deps.reputationService as FakeReputationService).scores.set(HUMAN_B, 10);
+
+    const outcome = await runReputationReconciliation(deps, makeCfg());
+
+    expect(outcome.ineligibleByReputation).toEqual([HUMAN_B]);
+    expect((deps.groupService as FakeGroupService).calls).toEqual([
+      {type: "untrust", groupAddress: GROUP_A, trusteeAddresses: [HUMAN_B]}
     ]);
   });
 });

--- a/tests/apps/group-affiliates/realtime.spec.ts
+++ b/tests/apps/group-affiliates/realtime.spec.ts
@@ -1,0 +1,115 @@
+import {Interface} from "ethers";
+
+import {
+  AFFILIATE_GROUP_CHANGED_ABI,
+  AFFILIATE_GROUP_CHANGED_TOPIC0,
+  AffiliateGroupChangedWithCursor,
+  buildAffiliateGroupChangedSubscriptionRequest,
+  deriveGroupAffiliatesWsUrl,
+  extractAffiliateGroupChangedEventsFromSubscriptionPayload,
+  filterEventsAfterCursor
+} from "../../../src/apps/group-affiliates/realtime";
+
+const REGISTRY = "0xcA8222E780D046707083F51377B5Fd85E2866014";
+const HUMAN = "0x1000000000000000000000000000000000000001";
+const GROUP_A = "0x1ACA75e38263c79d9D4F10dF0635cc6FCfe6F026";
+const GROUP_B = "0xb629a1e86F3eFada0F87C83494Da8Cc34C3F84ef";
+const UNMANAGED = "0x9999999999999999999999999999999999999999";
+const iface = new Interface(AFFILIATE_GROUP_CHANGED_ABI);
+
+function makeLog(
+  human: string,
+  oldGroup: string,
+  newGroup: string,
+  blockNumber: number,
+  transactionIndex: number,
+  logIndex: number,
+  address = REGISTRY
+) {
+  const encoded = iface.encodeEventLog(
+    iface.getEvent("AffiliateGroupChanged")!,
+    [human, oldGroup, newGroup]
+  );
+
+  return {
+    address,
+    blockNumber: `0x${blockNumber.toString(16)}`,
+    transactionIndex: `0x${transactionIndex.toString(16)}`,
+    logIndex: `0x${logIndex.toString(16)}`,
+    transactionHash: `0xtx${blockNumber}${transactionIndex}${logIndex}`,
+    topics: encoded.topics,
+    data: encoded.data
+  };
+}
+
+describe("group-affiliates realtime helpers", () => {
+  it("derives the default chain websocket URL from the HTTP RPC URL", () => {
+    expect(deriveGroupAffiliatesWsUrl("https://rpc.aboutcircles.com/")).toBe("wss://rpc.aboutcircles.com/ws/chain");
+    expect(deriveGroupAffiliatesWsUrl("http://localhost:8080/")).toBe("ws://localhost:8080/ws/chain");
+    expect(deriveGroupAffiliatesWsUrl("wss://rpc.aboutcircles.com/ws/chain")).toBe("wss://rpc.aboutcircles.com/ws/chain");
+  });
+
+  it("builds a chain log subscription for the affiliate registry", () => {
+    expect(buildAffiliateGroupChangedSubscriptionRequest(REGISTRY)).toEqual({
+      description: "AffiliateGroupChanged chain logs",
+      params: ["logs", {
+        address: REGISTRY,
+        topics: [AFFILIATE_GROUP_CHANGED_TOPIC0]
+      }]
+    });
+  });
+
+  it("extracts and orders AffiliateGroupChanged events from WSS log payloads", () => {
+    const events = extractAffiliateGroupChangedEventsFromSubscriptionPayload([
+      makeLog(HUMAN, GROUP_A, GROUP_B, 20, 2, 7),
+      makeLog(HUMAN, UNMANAGED, GROUP_A, 20, 1, 8),
+      makeLog(HUMAN, GROUP_B, UNMANAGED, 19, 9, 1)
+    ], REGISTRY);
+
+    expect(events.map((event) => event.cursor)).toEqual([
+      {blockNumber: 19, transactionIndex: 9, logIndex: 1},
+      {blockNumber: 20, transactionIndex: 1, logIndex: 8},
+      {blockNumber: 20, transactionIndex: 2, logIndex: 7}
+    ]);
+    expect(events[0]).toMatchObject({
+      human: HUMAN,
+      oldGroup: GROUP_B,
+      newGroup: UNMANAGED
+    });
+  });
+
+  it("skips malformed logs and logs from a different registry", () => {
+    const events = extractAffiliateGroupChangedEventsFromSubscriptionPayload([
+      makeLog(HUMAN, UNMANAGED, GROUP_A, 10, 0, 0, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+      {topics: ["0xnot-a-topic"], data: "0x"},
+      {topics: [AFFILIATE_GROUP_CHANGED_TOPIC0], data: "0x"}
+    ], REGISTRY);
+
+    expect(events).toEqual([]);
+  });
+
+  it("filters catch-up results after the persisted cursor", () => {
+    const before = eventAt(10, 0, 0);
+    const same = eventAt(10, 1, 1);
+    const after = eventAt(10, 1, 2);
+    const later = eventAt(11, 0, 0);
+
+    const events = filterEventsAfterCursor(
+      [later, before, after, same],
+      {blockNumber: 10, transactionIndex: 1, logIndex: 1}
+    );
+
+    expect(events).toEqual([after, later]);
+  });
+});
+
+function eventAt(blockNumber: number, transactionIndex: number, logIndex: number): AffiliateGroupChangedWithCursor {
+  return {
+    blockNumber,
+    txHash: `0x${blockNumber}${transactionIndex}${logIndex}`,
+    human: HUMAN,
+    oldGroup: UNMANAGED,
+    newGroup: GROUP_A,
+    cursor: {blockNumber, transactionIndex, logIndex}
+  };
+}


### PR DESCRIPTION
## Summary

Ships the `group-affiliates` worker (`belonging-groups` branch) together with a client-side concurrency cap onto the `staging` branch in one merge.

Supersedes #80 (which targeted `belonging-groups`).

## What's in the diff

This branch is `belonging-groups` + 1 commit on top:

- All of `belonging-groups` — the affiliates feature: `src/apps/group-affiliates/*`, new env vars, test fixtures.
- 1 new commit — rolling-window concurrency cap inside `ReputationService.check()`. Defaults to 8 in-flight fetches, overridable via `GROUP_AFFILIATES_REPUTATION_CONCURRENCY`. Replaces the un-bounded `Promise.all(unique.map(...))` over ~800 affiliate events on startup-replay, which overwhelmed undici's connect queue (`ConnectTimeoutError`) and the upstream 2-worker FastAPI gunicorn regardless of where the reputation endpoint was hosted.

## Why target the staging branch

Production hosts pull from the `staging` branch (`group_tms_repo_version: staging` in `group_vars/production/main.yml`). Landing the feature on `staging` is what makes it build for production. The accompanying infrastructure PR aligns per-host repo-version overrides so the dry-run worker exercises the same image production builds.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm test` — 413/413 passing.
- [ ] Merge this PR + the accompanying infrastructure PR.
- [ ] Deploy the worker in dry-run mode against a co-located rep_score endpoint, watch the startup-replay complete the reputation phase with ≤ 8 concurrent fetches in flight and no `ConnectTimeoutError`.

## Followups (not in this PR)

- Tests for `ReputationService` — no existing coverage before this PR.
- The container's health probe only checks the metrics endpoint, which comes up well before the work loop has done anything. A synthetic ping to the reputation backend would prevent `(healthy)` from lying during the seconds before the first reputation call.