### PR TITLE
fix(group-affiliates): file-backed scan-cursor persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN npm run build
 
 ENV NODE_ENV=production
 
+# Node-owned state dir so a named volume mounted here initialises
+# writable by uid 1000 (file-backed scan-cursor persistence).
+RUN mkdir -p /app/.state && chown -R node:node /app/.state
+
 USER node
 
 CMD ["sh","-c","[ -z \"$APP_NAME\" ] && { echo 'APP_NAME is required' >&2; exit 1; }; node dist/src/apps/$APP_NAME/main.js"]

--- a/src/apps/group-affiliates/main.ts
+++ b/src/apps/group-affiliates/main.ts
@@ -11,7 +11,8 @@ import {recordRunError, recordRunSuccess, setLeaderStatus, startMetricsServer} f
 import {resolveTransactionRpcUrl} from "../../services/transactionRpc";
 import {SafeGroupService} from "../../services/safeGroupService";
 import {SlackService} from "../../services/slackService";
-import {StateStore} from "../../services/stateStore";
+import {CursorStateStore, StateStore} from "../../services/stateStore";
+import {FileStateStore} from "../../services/fileStateStore";
 import {CirclesRpcService} from "../../services/circlesRpcService";
 import {
   DEFAULT_GROUP_AFFILIATES_BATCH_SIZE,
@@ -168,7 +169,19 @@ async function start(): Promise<void> {
 
   await notifySlackStartup();
 
-  const stateStore = process.env.LEADER_DB_URL ? new StateStore(process.env.LEADER_DB_URL) : null;
+  // Cursor persistence: prefer the leader DB when present; otherwise
+  // fall back to a file (group-affiliates has no LEADER_DB_URL — without
+  // either, every restart full-replays from the start block).
+  const stateFilePath = process.env.GROUP_AFFILIATES_STATE_FILE;
+  let stateStore: CursorStateStore | null = null;
+  if (process.env.LEADER_DB_URL) {
+    stateStore = new StateStore(process.env.LEADER_DB_URL);
+  } else if (stateFilePath && stateFilePath.trim().length > 0) {
+    stateStore = new FileStateStore(stateFilePath);
+    rootLogger.info(`[state-store] Using file-backed cursor at ${stateFilePath}`);
+  } else {
+    rootLogger.warn("[state-store] No LEADER_DB_URL or GROUP_AFFILIATES_STATE_FILE — cursor will NOT persist; every restart full-replays.");
+  }
   let cursor = await loadCursor(stateStore);
 
   try {
@@ -188,7 +201,7 @@ async function start(): Promise<void> {
 }
 
 async function runStartupReplay(
-  stateStore: StateStore | null,
+  stateStore: CursorStateStore | null,
   cursor: EventCursor
 ): Promise<EventCursor> {
   const effectiveDryRun = getEffectiveDryRun(leaderElection, dryRun);
@@ -231,7 +244,7 @@ async function runStartupReplay(
   return cursor;
 }
 
-function startRealtimeListener(stateStore: StateStore | null, cursor: EventCursor): void {
+function startRealtimeListener(stateStore: CursorStateStore | null, cursor: EventCursor): void {
   if (listener) {
     return;
   }
@@ -348,7 +361,7 @@ async function processReputationReconciliation(effectiveDryRun: boolean): Promis
   }
 }
 
-async function loadCursor(stateStore: StateStore | null): Promise<EventCursor> {
+async function loadCursor(stateStore: CursorStateStore | null): Promise<EventCursor> {
   if (!stateStore) {
     return makeInclusiveBlockCursor(startBlock);
   }
@@ -369,7 +382,7 @@ async function loadCursor(stateStore: StateStore | null): Promise<EventCursor> {
   return makeInclusiveBlockCursor(startBlock);
 }
 
-async function saveCursor(stateStore: StateStore | null, cursor: EventCursor): Promise<void> {
+async function saveCursor(stateStore: CursorStateStore | null, cursor: EventCursor): Promise<void> {
   if (!stateStore) {
     return;
   }

--- a/src/services/fileStateStore.ts
+++ b/src/services/fileStateStore.ts
@@ -1,0 +1,88 @@
+/**
+ * File-backed scan-cursor persistence for workers that have no leader DB
+ * (group-affiliates runs without LEADER_DB_URL). Without this, every
+ * restart re-scans from the configured start block — a full multi-million
+ * block eth_getLogs replay that hammers the indexer and RPC.
+ *
+ * Mirrors the StateStore contract. Reads are graceful: a missing or
+ * corrupt file yields null so the caller falls back to the start block
+ * (same behaviour as having no store) rather than crashing. Writes are
+ * atomic (write a temp file then rename) so a crash mid-write can never
+ * leave a torn JSON file that would force a full replay.
+ */
+import {promises as fs} from "fs";
+import * as path from "path";
+
+import {CursorStateStore, PersistedState} from "./stateStore";
+
+type StateFile = Record<string, PersistedState>;
+
+export class FileStateStore implements CursorStateStore {
+  private readonly filePath: string;
+  private writeChain: Promise<void> = Promise.resolve();
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  private async readAll(): Promise<StateFile> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.filePath, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return {};
+      }
+      console.warn(`[file-state-store] Failed to read ${this.filePath}:`, (err as Error).message);
+      return {};
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as StateFile;
+      }
+      console.warn(`[file-state-store] Ignoring non-object state in ${this.filePath}`);
+      return {};
+    } catch (err) {
+      // Corrupt file (e.g. torn write from an older non-atomic version,
+      // or manual edit) — fall back to a full replay rather than crash.
+      console.warn(`[file-state-store] Failed to parse ${this.filePath}:`, (err as Error).message);
+      return {};
+    }
+  }
+
+  async load(appName: string): Promise<PersistedState | null> {
+    const all = await this.readAll();
+    const entry = all[appName];
+    if (!entry || typeof entry.lastScannedBlock !== "number" || !Number.isFinite(entry.lastScannedBlock)) {
+      return null;
+    }
+    return {lastScannedBlock: entry.lastScannedBlock, data: entry.data};
+  }
+
+  async save(appName: string, lastScannedBlock: number, data?: Record<string, unknown>): Promise<void> {
+    // Serialise writes so concurrent saves can't interleave
+    // read-modify-write and lose an update.
+    const next = this.writeChain.then(async () => {
+      const all = await this.readAll();
+      all[appName] = {lastScannedBlock, data};
+      const tmpPath = `${this.filePath}.tmp`;
+      try {
+        await fs.mkdir(path.dirname(this.filePath), {recursive: true});
+        await fs.writeFile(tmpPath, JSON.stringify(all), "utf8");
+        await fs.rename(tmpPath, this.filePath);
+      } catch (err) {
+        console.warn(`[file-state-store] Failed to save ${this.filePath}:`, (err as Error).message);
+        await fs.rm(tmpPath, {force: true}).catch(() => undefined);
+      }
+    });
+    this.writeChain = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  async close(): Promise<void> {
+    // Flush any in-flight write before returning.
+    await this.writeChain;
+  }
+}

--- a/src/services/stateStore.ts
+++ b/src/services/stateStore.ts
@@ -21,7 +21,19 @@ export interface PersistedState {
   data?: Record<string, unknown>;
 }
 
-export class StateStore {
+/**
+ * Common contract for scan-cursor persistence. Implemented by the
+ * PostgreSQL-backed StateStore (used when LEADER_DB_URL is set) and the
+ * file-backed FileStateStore (used by workers with no leader DB, e.g.
+ * group-affiliates) so a restart resumes instead of full-replaying.
+ */
+export interface CursorStateStore {
+  load(appName: string): Promise<PersistedState | null>;
+  save(appName: string, lastScannedBlock: number, data?: Record<string, unknown>): Promise<void>;
+  close(): Promise<void>;
+}
+
+export class StateStore implements CursorStateStore {
   private pool: pg.Pool;
   private ready: Promise<void>;
 

--- a/tests/services/fileStateStore.spec.ts
+++ b/tests/services/fileStateStore.spec.ts
@@ -1,0 +1,92 @@
+import {promises as fs} from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {FileStateStore} from "../../src/services/fileStateStore";
+
+const APP = "group-affiliates";
+
+async function tmpFile(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fss-"));
+  return path.join(dir, "nested", "cursor.json");
+}
+
+describe("FileStateStore", () => {
+  it("round-trips a cursor (block + transactionIndex + logIndex) through save/load", async () => {
+    const file = await tmpFile();
+    const store = new FileStateStore(file);
+
+    await store.save(APP, 42_000_000, {transactionIndex: 7, logIndex: 3});
+    const loaded = await store.load(APP);
+
+    expect(loaded).toEqual({
+      lastScannedBlock: 42_000_000,
+      data: {transactionIndex: 7, logIndex: 3}
+    });
+  });
+
+  it("returns null when the state file does not exist (→ caller full-replays from start block)", async () => {
+    const store = new FileStateStore(await tmpFile());
+    expect(await store.load(APP)).toBeNull();
+  });
+
+  it("returns null (no throw) when the state file is corrupt", async () => {
+    const file = await tmpFile();
+    await fs.mkdir(path.dirname(file), {recursive: true});
+    await fs.writeFile(file, "{ this is not json", "utf8");
+
+    const store = new FileStateStore(file);
+    await expect(store.load(APP)).resolves.toBeNull();
+  });
+
+  it("writes atomically — no leftover .tmp file and the result is valid JSON", async () => {
+    const file = await tmpFile();
+    const store = new FileStateStore(file);
+
+    await store.save(APP, 1, {transactionIndex: 0, logIndex: 0});
+    await store.close();
+
+    await expect(fs.stat(`${file}.tmp`)).rejects.toMatchObject({code: "ENOENT"});
+    const parsed = JSON.parse(await fs.readFile(file, "utf8"));
+    expect(parsed[APP].lastScannedBlock).toBe(1);
+  });
+
+  it("keeps separate apps independent in one state file", async () => {
+    const file = await tmpFile();
+    const store = new FileStateStore(file);
+
+    await store.save("group-affiliates", 100, {transactionIndex: 1, logIndex: 1});
+    await store.save("other-app", 200, {transactionIndex: 2, logIndex: 2});
+
+    expect(await store.load("group-affiliates")).toEqual({
+      lastScannedBlock: 100,
+      data: {transactionIndex: 1, logIndex: 1}
+    });
+    expect(await store.load("other-app")).toEqual({
+      lastScannedBlock: 200,
+      data: {transactionIndex: 2, logIndex: 2}
+    });
+  });
+
+  it("serialises concurrent saves without losing an update", async () => {
+    const file = await tmpFile();
+    const store = new FileStateStore(file);
+
+    await Promise.all([
+      store.save(APP, 10, {transactionIndex: 0, logIndex: 0}),
+      store.save("app-b", 20, {transactionIndex: 0, logIndex: 0}),
+      store.save(APP, 30, {transactionIndex: 9, logIndex: 9})
+    ]);
+    await store.close();
+
+    expect(await store.load("app-b")).toEqual({
+      lastScannedBlock: 20,
+      data: {transactionIndex: 0, logIndex: 0}
+    });
+    // last write for APP wins; app-b not clobbered by interleaved RMW
+    expect(await store.load(APP)).toEqual({
+      lastScannedBlock: 30,
+      data: {transactionIndex: 9, logIndex: 9}
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Workers without `LEADER_DB_URL` (group-affiliates) discarded the event
scan cursor on every restart, forcing a full multi-million-block
`eth_getLogs` replay against the indexer/RPC each boot. This adds a
file-backed cursor store so a restart resumes from the last scanned
block.

## Changes

- **`FileStateStore`**: atomic (temp-file + `rename`) JSON cursor
  persistence. Reads are graceful — a missing or corrupt file yields
  `null`, so the caller falls back to the start block (unchanged
  no-store behaviour) instead of crashing. Writes are serialised so
  concurrent saves can't lose an update via interleaved
  read-modify-write.
- **`CursorStateStore`** shared interface; the existing PostgreSQL
  `StateStore` and the new `FileStateStore` both implement it.
- **`main.ts`** selects: `LEADER_DB_URL` → `StateStore`, else
  `GROUP_AFFILIATES_STATE_FILE` → `FileStateStore`, else `null`
  (full-replay, now logged as a warning).
- **Dockerfile**: a node-owned `/app/.state` directory so a named
  volume mounted there initialises writable by the unprivileged
  runtime user (uid 1000).

## Test plan

- [x] `npm run build` (tsc) clean
- [x] New `tests/services/fileStateStore.spec.ts`: round-trip,
      missing-file → null, corrupt-file → null (no throw), atomic
      write (no leftover `.tmp`), multi-app isolation, concurrent-save
      serialisation
- [x] Full suite: 424/424 pass, 28 suites
- [ ] On staging1: first boot logs file-backed store + one bounded
      replay; after container recreation logs restored cursor and
      skips the full replay