### PR TITLE
fix(services): serialize ensureTable DDL with pg_advisory_xact_lock

### DIFF
--- a/src/services/leaderElection.ts
+++ b/src/services/leaderElection.ts
@@ -1,6 +1,7 @@
 import { Pool } from "pg";
 import { SlackSeverity } from "../interfaces/ISlackService";
 import { ILoggerService } from "../interfaces/ILoggerService";
+import { GROUP_TMS_DDL_LOCK_KEY } from "./stateStore";
 
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const STALENESS_THRESHOLD_SEC = 45;
@@ -60,13 +61,24 @@ export class LeaderElection {
   }
 
   private async ensureTable(): Promise<void> {
-    await this.pool.query(`
-      CREATE TABLE IF NOT EXISTS group_tms_leader (
-        id          INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
-        instance_id TEXT    NOT NULL,
-        last_heartbeat TIMESTAMPTZ NOT NULL DEFAULT now()
-      )
-    `);
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query("SELECT pg_advisory_xact_lock($1)", [GROUP_TMS_DDL_LOCK_KEY]);
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS group_tms_leader (
+          id          INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+          instance_id TEXT    NOT NULL,
+          last_heartbeat TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+      `);
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
   }
 
   private async tryAcquire(): Promise<void> {

--- a/src/services/stateStore.ts
+++ b/src/services/stateStore.ts
@@ -7,6 +7,14 @@
  */
 import pg from "pg";
 
+// Shared advisory-lock key across StateStore + LeaderElection. Serializes
+// all group-tms DDL against itself so 5 workers booting concurrently
+// against the same Postgres can't race on pg_type_typname_nsp_index
+// during the implicit CREATE TYPE under each CREATE TABLE. xact-scoped
+// so the lock auto-releases on COMMIT — required for pgbouncer
+// transaction-pool mode (session-scoped locks would orphan).
+export const GROUP_TMS_DDL_LOCK_KEY = 7281992451;
+
 const DDL = `
 CREATE TABLE IF NOT EXISTS group_tms_state (
   app_name         TEXT PRIMARY KEY,
@@ -33,7 +41,13 @@ export class StateStore {
   private async ensureTable(): Promise<void> {
     const client = await this.pool.connect();
     try {
+      await client.query("BEGIN");
+      await client.query("SELECT pg_advisory_xact_lock($1)", [GROUP_TMS_DDL_LOCK_KEY]);
       await client.query(DDL);
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw err;
     } finally {
       client.release();
     }

--- a/tests/services/leaderElection.spec.ts
+++ b/tests/services/leaderElection.spec.ts
@@ -1,13 +1,18 @@
 import {getEffectiveDryRun, LeaderElection} from "../../src/services/leaderElection";
+import {GROUP_TMS_DDL_LOCK_KEY} from "../../src/services/stateStore";
 import {FakeLogger} from "../../fakes/fakes";
 
 // --- Mock pg ---
 const mockQuery = jest.fn();
 const mockEnd = jest.fn();
+const mockClientQuery = jest.fn();
+const mockClientRelease = jest.fn();
+const mockConnect = jest.fn();
 
 jest.mock("pg", () => ({
   Pool: jest.fn().mockImplementation(() => ({
     query: mockQuery,
+    connect: mockConnect,
     end: mockEnd,
   })),
 }));
@@ -42,8 +47,15 @@ describe("LeaderElection", () => {
     statusUpdates = [];
     slackMessages = [];
     logger = new FakeLogger(true);
-    // Default: ensureTable succeeds
+    // Default: pool.query (tryAcquire/stop) and client.query (ensureTable
+    // BEGIN + lock + DDL + COMMIT) both succeed quietly.
     mockQuery.mockResolvedValue({rows: [], rowCount: 0});
+    mockClientQuery.mockResolvedValue(undefined);
+    mockClientRelease.mockReturnValue(undefined);
+    mockConnect.mockResolvedValue({
+      query: mockClientQuery,
+      release: mockClientRelease,
+    });
     mockEnd.mockResolvedValue(undefined);
   });
 
@@ -63,10 +75,7 @@ describe("LeaderElection", () => {
 
   describe("tryAcquire", () => {
     it("acquires leadership when UPSERT returns a row", async () => {
-      // First call = ensureTable, second = tryAcquire
-      mockQuery
-        .mockResolvedValueOnce({rows: [], rowCount: 0})  // CREATE TABLE
-        .mockResolvedValueOnce({rows: [{instance_id: "host-1"}], rowCount: 1}); // UPSERT
+      mockQuery.mockResolvedValueOnce({rows: [{instance_id: "host-1"}], rowCount: 1}); // UPSERT
 
       const le = createLE();
       await le.start();
@@ -79,9 +88,7 @@ describe("LeaderElection", () => {
     });
 
     it("does NOT acquire when UPSERT returns 0 rows (another leader holds it)", async () => {
-      mockQuery
-        .mockResolvedValueOnce({rows: [], rowCount: 0})  // CREATE TABLE
-        .mockResolvedValueOnce({rows: [], rowCount: 0});  // UPSERT — no match
+      mockQuery.mockResolvedValueOnce({rows: [], rowCount: 0});  // UPSERT — no match
 
       const le = createLE();
       await le.start();
@@ -94,9 +101,7 @@ describe("LeaderElection", () => {
 
     it("rowCount: null treated as non-leader (edge case from pg driver)", async () => {
       // pg can return rowCount: null for certain statements
-      mockQuery
-        .mockResolvedValueOnce({rows: [], rowCount: 0})
-        .mockResolvedValueOnce({rows: [], rowCount: null});
+      mockQuery.mockResolvedValueOnce({rows: [], rowCount: null});
 
       const le = createLE();
       await le.start();
@@ -106,9 +111,7 @@ describe("LeaderElection", () => {
     });
 
     it("PG error during tryAcquire → falls back to non-leader (safe)", async () => {
-      mockQuery
-        .mockResolvedValueOnce({rows: [], rowCount: 0})  // CREATE TABLE
-        .mockRejectedValueOnce(new Error("connection refused")); // tryAcquire fails
+      mockQuery.mockRejectedValueOnce(new Error("connection refused")); // tryAcquire fails
 
       const le = createLE();
       await le.start();
@@ -125,9 +128,7 @@ describe("LeaderElection", () => {
     });
 
     it("detects leadership loss on subsequent heartbeat", async () => {
-      mockQuery
-        .mockResolvedValueOnce({rows: [], rowCount: 0})  // CREATE TABLE
-        .mockResolvedValueOnce({rows: [{instance_id: "host-1"}], rowCount: 1}); // acquire
+      mockQuery.mockResolvedValueOnce({rows: [{instance_id: "host-1"}], rowCount: 1}); // acquire
 
       const le = createLE();
       await le.start();
@@ -147,7 +148,6 @@ describe("LeaderElection", () => {
 
     it("re-acquires on heartbeat (same instance, stays leader)", async () => {
       mockQuery
-        .mockResolvedValueOnce({rows: [], rowCount: 0})  // CREATE TABLE
         .mockResolvedValueOnce({rows: [{instance_id: "host-1"}], rowCount: 1}) // acquire
         .mockResolvedValueOnce({rows: [{instance_id: "host-1"}], rowCount: 1}); // heartbeat
 
@@ -170,9 +170,7 @@ describe("LeaderElection", () => {
 
   describe("stop", () => {
     it("releases leadership by backdating heartbeat", async () => {
-      mockQuery
-        .mockResolvedValueOnce({rows: [], rowCount: 0})
-        .mockResolvedValueOnce({rows: [{instance_id: "host-1"}], rowCount: 1});
+      mockQuery.mockResolvedValueOnce({rows: [{instance_id: "host-1"}], rowCount: 1});
 
       const le = createLE();
       await le.start();
@@ -193,9 +191,7 @@ describe("LeaderElection", () => {
     });
 
     it("stop when not leader → skips UPDATE, just cleans up", async () => {
-      mockQuery
-        .mockResolvedValueOnce({rows: [], rowCount: 0})
-        .mockResolvedValueOnce({rows: [], rowCount: 0}); // not leader
+      mockQuery.mockResolvedValueOnce({rows: [], rowCount: 0}); // not leader
 
       const le = createLE();
       await le.start();
@@ -212,9 +208,7 @@ describe("LeaderElection", () => {
     });
 
     it("PG error during stop release → warns but doesn't throw", async () => {
-      mockQuery
-        .mockResolvedValueOnce({rows: [], rowCount: 0})
-        .mockResolvedValueOnce({rows: [{instance_id: "host-1"}], rowCount: 1});
+      mockQuery.mockResolvedValueOnce({rows: [{instance_id: "host-1"}], rowCount: 1});
 
       const le = createLE();
       await le.start();
@@ -254,10 +248,29 @@ describe("LeaderElection", () => {
     });
   });
 
+  describe("ensureTable", () => {
+    it("runs DDL inside BEGIN + pg_advisory_xact_lock + COMMIT", async () => {
+      const le = createLE();
+      await le.start();
+
+      // mockClientQuery captures the ensureTable transaction sequence
+      const calls = mockClientQuery.mock.calls.map((c: any[]) => c);
+      expect(calls[0]).toEqual(["BEGIN"]);
+      expect(calls[1]).toEqual([
+        "SELECT pg_advisory_xact_lock($1)",
+        [GROUP_TMS_DDL_LOCK_KEY],
+      ]);
+      expect(calls[2][0]).toMatch(/CREATE TABLE IF NOT EXISTS group_tms_leader/);
+      expect(calls[3]).toEqual(["COMMIT"]);
+      expect(mockClientRelease).toHaveBeenCalled();
+
+      await le.stop();
+    });
+  });
+
   describe("onStatusUpdate callback", () => {
     it("fires on every tryAcquire, not just state changes", async () => {
       mockQuery
-        .mockResolvedValueOnce({rows: [], rowCount: 0})  // CREATE TABLE
         .mockResolvedValueOnce({rows: [], rowCount: 0})  // tryAcquire: not leader
         .mockResolvedValueOnce({rows: [], rowCount: 0}); // heartbeat: still not leader
 

--- a/tests/services/stateStore.spec.ts
+++ b/tests/services/stateStore.spec.ts
@@ -1,4 +1,4 @@
-import { StateStore } from "../../src/services/stateStore";
+import { StateStore, GROUP_TMS_DDL_LOCK_KEY } from "../../src/services/stateStore";
 
 // Mock the pg module
 jest.mock("pg", () => {
@@ -32,6 +32,24 @@ describe("StateStore", () => {
 
   afterEach(async () => {
     await store.close();
+  });
+
+  describe("ensureTable", () => {
+    it("runs DDL inside BEGIN + pg_advisory_xact_lock + COMMIT", async () => {
+      mockPool.query.mockResolvedValueOnce({ rows: [] });
+      // Trigger ready via any query
+      await store.load("anything");
+      const mockClient = await mockPool.connect.mock.results[0].value;
+      const calls = mockClient.query.mock.calls;
+      expect(calls[0]).toEqual(["BEGIN"]);
+      expect(calls[1]).toEqual([
+        "SELECT pg_advisory_xact_lock($1)",
+        [GROUP_TMS_DDL_LOCK_KEY],
+      ]);
+      expect(calls[2][0]).toMatch(/CREATE TABLE IF NOT EXISTS group_tms_state/);
+      expect(calls[3]).toEqual(["COMMIT"]);
+      expect(mockClient.release).toHaveBeenCalled();
+    });
   });
 
   describe("load", () => {


### PR DESCRIPTION
## Summary

When multiple worker apps that share the same Postgres database boot
concurrently, their independent `StateStore` + `LeaderElection`
`ensureTable()` calls race on the implicit `CREATE TYPE` that backs each
`CREATE TABLE IF NOT EXISTS`, surfacing as:

```
duplicate key value violates unique constraint "pg_type_typname_nsp_index"
```

Wrap each `ensureTable` in a short transaction holding an xact-scoped
advisory lock keyed on a shared constant (`GROUP_TMS_DDL_LOCK_KEY`), so
all `group-tms` DDL serializes against itself.

`xact`-scoped lock auto-releases on COMMIT — safe under pgbouncer
transaction-pool mode where session-scoped advisory locks would orphan.

## Changes

- `src/services/stateStore.ts` — export `GROUP_TMS_DDL_LOCK_KEY`, wrap
  DDL in BEGIN + advisory_xact_lock + COMMIT
- `src/services/leaderElection.ts` — switch `ensureTable` to
  `pool.connect()` and apply the same transactional + advisory-lock pattern
- Tests: extend the `LeaderElection` `pg` mock with `pool.connect()` to
  cover the transactional path; new assertion in each spec for the
  `BEGIN` / lock / DDL / `COMMIT` ordering

## Test plan

- [x] `npx jest tests/services/stateStore.spec.ts tests/services/leaderElection.spec.ts` — 25/25 pass
- [x] `npx jest --testPathIgnorePatterns="integration"` — 433/433 pass (no regressions)
- [x] `npx tsc --noEmit` — clean
- [ ] Deploy to staging1 (full-stack bounce), tail logs of all 5 workers for ~5 min — no `duplicate key value violates` / `pg_type_typname` lines
- [ ] Restart-cycle 3x: `docker restart group-tms-{crc-backers,oic,gnosis-group,gp-crc,router-tms}` — still no DDL race
- [ ] `\d group_tms_state` and `\d group_tms_leader` both present in `group_tms` db