### PR TITLE
feat(router-tms): persist enablement state in Postgres

### DIFF
--- a/src/apps/router-tms/main.ts
+++ b/src/apps/router-tms/main.ts
@@ -21,6 +21,8 @@ import {formatErrorWithCauses} from "../../formatError";
 import {startMetricsServer, recordRunSuccess, recordRunError, setLeaderStatus} from "../../services/metricsService";
 import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
 import {InMemoryRouterEnablementStore} from "./enablementStore";
+import {PgRouterEnablementStore} from "./pgRouterEnablementStore";
+import {IRouterEnablementStore} from "../../interfaces/IRouterEnablementStore";
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {LeaderElection, getEffectiveDryRun} from "../../services/leaderElection";
 import {StateStore} from "../../services/stateStore";
@@ -60,7 +62,15 @@ const blacklistTimeoutMs = (() => {
 })();
 const blacklistingService = new BlacklistingService(blacklistingServiceUrl, blacklistTimeoutMs);
 const quarantineTtlHours = parseEnvInt("ROUTER_QUARANTINE_TTL_HOURS", 24);
-const enablementStore = new InMemoryRouterEnablementStore([], quarantineTtlHours * 60 * 60 * 1000);
+const quarantineTtlMs = quarantineTtlHours * 60 * 60 * 1000;
+// Persist enablement + quarantine state when LEADER_DB_URL is available.
+// Without persistence, every restart re-emits ~7k enableCRCForRouting txs
+// because the in-memory dedup cache can't tell "previously enabled but
+// reverted/revoked on-chain" from "never tried" — both fall through to
+// `!routerTrustSet.has(avatar)` which is true for both.
+const enablementStore: IRouterEnablementStore = process.env.LEADER_DB_URL
+  ? new PgRouterEnablementStore(process.env.LEADER_DB_URL, quarantineTtlMs)
+  : new InMemoryRouterEnablementStore([], quarantineTtlMs);
 const errorsBeforeCrash = Math.max(1, parseEnvInt("ERRORS_BEFORE_CRASH", 5));
 const errorTracker = new ConsecutiveErrorTracker(errorsBeforeCrash);
 let leaderElection: LeaderElection | null = null;

--- a/src/apps/router-tms/pgRouterEnablementStore.ts
+++ b/src/apps/router-tms/pgRouterEnablementStore.ts
@@ -1,0 +1,164 @@
+/**
+ * Persist router-tms enablement + quarantine state to PostgreSQL so a worker
+ * restart resumes its de-duplication state instead of re-emitting every
+ * `enableCRCForRouting` tx for avatars that were already processed but are
+ * not (yet) in the router's on-chain trust set.
+ *
+ * Graceful fallback: pg errors are logged and the method resolves quietly
+ * so a transient PG hiccup never crashes the run loop.
+ *
+ * Shares GROUP_TMS_DDL_LOCK_KEY with StateStore + LeaderElection so all
+ * group-tms DDL serializes against the system-catalog race
+ * (pg_type_typname_nsp_index) when multiple workers boot concurrently.
+ */
+import {getAddress} from "ethers";
+import pg from "pg";
+
+import {GROUP_TMS_DDL_LOCK_KEY} from "../../services/stateStore";
+import {
+  IRouterEnablementStore,
+  RouterEnablementSource,
+  RouterEnablementStatus
+} from "../../interfaces/IRouterEnablementStore";
+
+const DDL = `
+CREATE TABLE IF NOT EXISTS router_tms_enablement (
+  avatar              TEXT PRIMARY KEY,
+  fallback_enabled    BOOLEAN     NOT NULL DEFAULT FALSE,
+  base_group_enabled  BOOLEAN     NOT NULL DEFAULT FALSE,
+  quarantined_until   TIMESTAMPTZ,
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+`;
+
+function tryNormalize(address: string): string | null {
+  try {
+    return getAddress(address).toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeBatch(addresses: string[]): string[] {
+  const out: string[] = [];
+  for (const a of addresses) {
+    const n = tryNormalize(a);
+    if (n !== null) out.push(n);
+  }
+  return out;
+}
+
+export class PgRouterEnablementStore implements IRouterEnablementStore {
+  private pool: pg.Pool;
+  private ready: Promise<void>;
+
+  constructor(dbUrl: string, private quarantineTtlMs: number) {
+    this.pool = new pg.Pool({connectionString: dbUrl, max: 2});
+    this.ready = this.ensureTable();
+  }
+
+  private async ensureTable(): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query("SELECT pg_advisory_xact_lock($1)", [GROUP_TMS_DDL_LOCK_KEY]);
+      await client.query(DDL);
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK").catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async loadEnablementStatuses(): Promise<RouterEnablementStatus[]> {
+    try {
+      await this.ready;
+      const result = await this.pool.query(
+        `SELECT avatar, fallback_enabled, base_group_enabled
+           FROM router_tms_enablement
+          WHERE fallback_enabled OR base_group_enabled`
+      );
+      return result.rows.map((row) => ({
+        avatar: row.avatar,
+        fallbackEnabled: row.fallback_enabled,
+        baseGroupEnabled: row.base_group_enabled
+      }));
+    } catch (err) {
+      console.warn(
+        `[router-enablement-store] Failed to load enablement statuses:`,
+        (err as Error).message
+      );
+      return [];
+    }
+  }
+
+  async markEnabled(addresses: string[], source: RouterEnablementSource): Promise<void> {
+    const normalized = normalizeBatch(addresses);
+    if (normalized.length === 0) return;
+    // Column name is internal-only (one of two literals) — safe to interpolate.
+    const col = source === "fallback" ? "fallback_enabled" : "base_group_enabled";
+    try {
+      await this.ready;
+      await this.pool.query(
+        `INSERT INTO router_tms_enablement (avatar, ${col}, updated_at)
+           SELECT unnest($1::text[]), TRUE, now()
+         ON CONFLICT (avatar) DO UPDATE
+           SET ${col} = router_tms_enablement.${col} OR EXCLUDED.${col},
+               updated_at = now()`,
+        [normalized]
+      );
+    } catch (err) {
+      console.warn(
+        `[router-enablement-store] Failed to mark ${normalized.length} address(es) enabled (${source}):`,
+        (err as Error).message
+      );
+    }
+  }
+
+  async loadQuarantinedAddresses(): Promise<string[]> {
+    try {
+      await this.ready;
+      const result = await this.pool.query(
+        `SELECT avatar
+           FROM router_tms_enablement
+          WHERE quarantined_until IS NOT NULL
+            AND quarantined_until > now()`
+      );
+      return result.rows.map((row) => row.avatar);
+    } catch (err) {
+      console.warn(
+        `[router-enablement-store] Failed to load quarantined addresses:`,
+        (err as Error).message
+      );
+      return [];
+    }
+  }
+
+  async markQuarantined(addresses: string[]): Promise<void> {
+    const normalized = normalizeBatch(addresses);
+    if (normalized.length === 0) return;
+    const until = new Date(Date.now() + this.quarantineTtlMs).toISOString();
+    try {
+      await this.ready;
+      await this.pool.query(
+        `INSERT INTO router_tms_enablement (avatar, quarantined_until, updated_at)
+           SELECT unnest($1::text[]), $2::timestamptz, now()
+         ON CONFLICT (avatar) DO UPDATE
+           SET quarantined_until = EXCLUDED.quarantined_until,
+               updated_at = now()`,
+        [normalized, until]
+      );
+    } catch (err) {
+      console.warn(
+        `[router-enablement-store] Failed to mark ${normalized.length} address(es) quarantined:`,
+        (err as Error).message
+      );
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+}

--- a/tests/apps/router-tms/pgRouterEnablementStore.spec.ts
+++ b/tests/apps/router-tms/pgRouterEnablementStore.spec.ts
@@ -1,0 +1,182 @@
+import {PgRouterEnablementStore} from "../../../src/apps/router-tms/pgRouterEnablementStore";
+import {GROUP_TMS_DDL_LOCK_KEY} from "../../../src/services/stateStore";
+
+// Mock the pg module — mirrors tests/services/stateStore.spec.ts shape.
+jest.mock("pg", () => {
+  const mockClient = {
+    query: jest.fn(),
+    release: jest.fn()
+  };
+  const mockPool = {
+    connect: jest.fn().mockResolvedValue(mockClient),
+    query: jest.fn(),
+    end: jest.fn()
+  };
+  return {Pool: jest.fn(() => mockPool)};
+});
+
+import pg from "pg";
+
+function getMockPool(): any {
+  return (pg.Pool as any).mock.results[0]?.value;
+}
+
+const QUARANTINE_TTL_MS = 60 * 60 * 1000;
+
+// All-lowercase test addresses — getAddress accepts these and checksums
+// them; normalize then lowercases back. Mixed-case would have to satisfy
+// EIP-55 checksum or getAddress throws.
+const ADDR_A = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const ADDR_B = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const ADDR_A_LC = ADDR_A;
+const ADDR_B_LC = ADDR_B;
+
+describe("PgRouterEnablementStore", () => {
+  let store: PgRouterEnablementStore;
+  let mockPool: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = new PgRouterEnablementStore("postgres://localhost/test", QUARANTINE_TTL_MS);
+    mockPool = getMockPool();
+  });
+
+  afterEach(async () => {
+    await store.close();
+  });
+
+  describe("ensureTable", () => {
+    it("runs DDL inside BEGIN + pg_advisory_xact_lock + COMMIT", async () => {
+      // Trigger ready by issuing any query
+      mockPool.query.mockResolvedValueOnce({rows: []});
+      await store.loadEnablementStatuses();
+      const mockClient = await mockPool.connect.mock.results[0].value;
+      const calls = mockClient.query.mock.calls;
+      expect(calls[0]).toEqual(["BEGIN"]);
+      expect(calls[1]).toEqual([
+        "SELECT pg_advisory_xact_lock($1)",
+        [GROUP_TMS_DDL_LOCK_KEY]
+      ]);
+      expect(calls[2][0]).toMatch(/CREATE TABLE IF NOT EXISTS router_tms_enablement/);
+      expect(calls[3]).toEqual(["COMMIT"]);
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+  });
+
+  describe("markEnabled", () => {
+    it("UPSERTs fallback_enabled with sticky-OR semantics", async () => {
+      mockPool.query.mockResolvedValueOnce({});
+      await store.markEnabled([ADDR_A, ADDR_B], "fallback");
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining("fallback_enabled = router_tms_enablement.fallback_enabled OR EXCLUDED.fallback_enabled"),
+        [[ADDR_A_LC, ADDR_B_LC]]
+      );
+    });
+
+    it("UPSERTs base_group_enabled with sticky-OR semantics", async () => {
+      mockPool.query.mockResolvedValueOnce({});
+      await store.markEnabled([ADDR_A], "base-group");
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining("base_group_enabled = router_tms_enablement.base_group_enabled OR EXCLUDED.base_group_enabled"),
+        [[ADDR_A_LC]]
+      );
+    });
+
+    it("no-op for empty addresses (no query issued)", async () => {
+      await store.markEnabled([], "fallback");
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
+    it("filters invalid addresses; valid subset still upserts", async () => {
+      mockPool.query.mockResolvedValueOnce({});
+      await store.markEnabled([ADDR_A, "not-an-address"], "fallback");
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.any(String),
+        [[ADDR_A_LC]] // invalid filtered out
+      );
+    });
+
+    it("filters invalid addresses; all invalid → no query issued", async () => {
+      await store.markEnabled(["not-an-address", ""], "fallback");
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
+    it("logs warning on PG error (graceful fallback)", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      mockPool.query.mockRejectedValueOnce(new Error("connection refused"));
+      await store.markEnabled([ADDR_A], "fallback"); // must not throw
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[router-enablement-store]"),
+        expect.stringContaining("connection refused")
+      );
+    });
+  });
+
+  describe("loadEnablementStatuses", () => {
+    it("returns mapped rows for avatars with either flag set", async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [
+          {avatar: ADDR_A_LC, fallback_enabled: true, base_group_enabled: false},
+          {avatar: ADDR_B_LC, fallback_enabled: false, base_group_enabled: true}
+        ]
+      });
+      const result = await store.loadEnablementStatuses();
+      expect(result).toEqual([
+        {avatar: ADDR_A_LC, fallbackEnabled: true, baseGroupEnabled: false},
+        {avatar: ADDR_B_LC, fallbackEnabled: false, baseGroupEnabled: true}
+      ]);
+    });
+
+    it("returns empty array and logs warning on PG error", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      mockPool.query.mockRejectedValueOnce(new Error("connection refused"));
+      const result = await store.loadEnablementStatuses();
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[router-enablement-store]"),
+        expect.stringContaining("connection refused")
+      );
+    });
+  });
+
+  describe("markQuarantined", () => {
+    it("UPSERTs quarantined_until with TTL-derived timestamp", async () => {
+      mockPool.query.mockResolvedValueOnce({});
+      await store.markQuarantined([ADDR_A]);
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining("quarantined_until = EXCLUDED.quarantined_until"),
+        [
+          [ADDR_A_LC],
+          expect.stringMatching(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+        ]
+      );
+    });
+
+    it("no-op for empty addresses", async () => {
+      await store.markQuarantined([]);
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("loadQuarantinedAddresses", () => {
+    it("returns only un-expired quarantined avatars", async () => {
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{avatar: ADDR_A_LC}, {avatar: ADDR_B_LC}]
+      });
+      const result = await store.loadQuarantinedAddresses();
+      expect(result).toEqual([ADDR_A_LC, ADDR_B_LC]);
+      // The WHERE clause must exclude expired rows
+      expect(mockPool.query).toHaveBeenCalledWith(
+        expect.stringContaining("quarantined_until > now()")
+      );
+    });
+
+    it("returns empty array on PG error (graceful fallback)", async () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      mockPool.query.mockRejectedValueOnce(new Error("connection refused"));
+      const result = await store.loadQuarantinedAddresses();
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- New `PgRouterEnablementStore` implements `IRouterEnablementStore` against Postgres via the shared `LEADER_DB_URL`. New table `router_tms_enablement` (avatar PK, `fallback_enabled`, `base_group_enabled`, `quarantined_until`, `updated_at`).
- `main.ts` selects PG-backed store when `LEADER_DB_URL` is present; the in-memory store remains as the local-dev / no-DB fallback (mirrors `src/apps/group-affiliates/main.ts`).
- `InMemoryRouterEnablementStore` left untouched as the dormant fallback.

## Why

Without persistence the worker re-emits `enableCRCForRouting` on every restart for any avatar previously enabled but not currently in the on-chain router trust set (reverted tx, quarantined, in-flight). Cache is the only signal that distinguishes "already tried" from "never tried" — it must survive a restart.

## Implementation notes

- `ensureTable` uses the `pg_advisory_xact_lock(GROUP_TMS_DDL_LOCK_KEY)` pattern introduced in the parent commit so the new DDL serializes with `group_tms_state` / `group_tms_leader` across concurrent worker boots.
- `markEnabled` UPSERTs with sticky-OR semantics (`col = router_tms_enablement.col OR EXCLUDED.col`) so a later `base-group` write never silently un-sets `fallback_enabled`.
- `markQuarantined` writes an absolute expiry (`Date.now() + ttlMs` → `TIMESTAMPTZ`); `loadQuarantinedAddresses` filters `quarantined_until > now()`.
- Addresses normalized + EIP-55-validated via ethers `getAddress()`; invalid entries dropped before the parameterized `unnest($1::text[])` write.
- Graceful fallback matches StateStore: pg errors are logged with `[router-enablement-store]` prefix and swallowed so a transient hiccup never crashes the run loop.

## Test plan

- [x] `npm test -- pgRouterEnablementStore` — 13/13
- [x] `npm test` — 433/433 (jest, integration excluded)
- [x] `npm run typecheck` — clean
- [ ] Deploy staging1, verify table created, `loadEnablementStatuses` returns non-empty after a poll cycle
- [ ] Restart router-tms; verify next poll's `enableCRCForRouting` batch count matches natural deltas only (NOT the ~7,300 cold-start replay)