### PR TITLE
apps: swap new-gnosis + router2 default to redeployed group

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ RPC_URL=https://rpc.aboutcircles.com/
 TX_RPC_URL=https://your-write-rpc.example/   # optional; overrides only transaction execution
 ROUTER2_WSS_URL=wss://rpc.aboutcircles.com/ws/chain
 ROUTER2_ADDRESS=0xA60Cd6ddbB4eBa93246D6f80ff4504476c8117D1
-ROUTER2_TRUSTED_BY_ADDRESS=0x7CadB2E92295F3E4fA65D3d4E7265E2e05d7a783
+ROUTER2_TRUSTED_BY_ADDRESS=0x93eD5A96347927ff6fF6b790F8Cf5258240c321f
 
 # Safe execution (required unless dry run)
 ROUTER2_ADMIN_SAFE_ADDRESS=0xcC05dab6e530b5E846DDfdEd09874BF4ADDEE8eC

--- a/src/apps/new-gnosis/logic.ts
+++ b/src/apps/new-gnosis/logic.ts
@@ -56,7 +56,7 @@ export const DEFAULT_FETCH_TIMEOUT_MS = 60_000;
 export const DEFAULT_INDEXER_URL =
   "https://indexer.eu.hyperindex.xyz/3bc5dfd/v1/graphql";
 export const DEFAULT_CONTRACT_ADDRESS =
-  "0x7CadB2E92295F3E4fA65D3d4E7265E2e05d7a783";
+  "0x93eD5A96347927ff6fF6b790F8Cf5258240c321f";
 export const DEFAULT_START_BLOCK = 46271576;
 
 export async function runOnce(deps: RunDeps, cfg: RunConfig): Promise<RunOutcome> {

--- a/src/apps/router2/logic.ts
+++ b/src/apps/router2/logic.ts
@@ -4,7 +4,7 @@ import {ILoggerService} from "../../interfaces/ILoggerService";
 import {IRouter2Service} from "../../interfaces/IRouter2Service";
 
 export const DEFAULT_ROUTER2_ADDRESS = "0xA60Cd6ddbB4eBa93246D6f80ff4504476c8117D1";
-export const DEFAULT_ROUTER2_TRUSTED_BY_ADDRESS = "0x7CadB2E92295F3E4fA65D3d4E7265E2e05d7a783";
+export const DEFAULT_ROUTER2_TRUSTED_BY_ADDRESS = "0x93eD5A96347927ff6fF6b790F8Cf5258240c321f";
 export const DEFAULT_ROUTER2_ADMIN_SAFE_ADDRESS = "0xcC05dab6e530b5E846DDfdEd09874BF4ADDEE8eC";
 export const DEFAULT_ROUTER2_BATCH_SIZE = 20;
 export const DEFAULT_ROUTER2_FETCH_PAGE_SIZE = 2_000;


### PR DESCRIPTION
## Summary

Adopt the redeployed `ScoreGroup` contract `0x93eD5A96347927ff6fF6b790F8Cf5258240c321f` as the default target for the two workers that operate against the score group on-chain.

- `src/apps/new-gnosis/logic.ts` `DEFAULT_CONTRACT_ADDRESS` swapped.
- `src/apps/router2/logic.ts` `DEFAULT_ROUTER2_TRUSTED_BY_ADDRESS` swapped.
- `README.md` env-var example updated.

No ABI changes — both workers continue calling Hub-level trust functions; the redeployed group's `trust()` is permissionless (verified by on-chain simulation from the active worker EOA).

## Cutover SQL (run on group_tms DB before restarting workers)

The new-gnosis worker persists its cursor under `app_name = 'new-gnosis'` only (no contract namespacing). After the address swap, the persisted cursor from the OLD group would override the new `NEW_GNOSIS_START_BLOCK=46398128` env value, silently skipping any GnosisAppUser created between block 46398128 and the persisted cursor.

```sql
DELETE FROM group_tms_state WHERE app_name = 'new-gnosis';
```

Router2 is stateless (re-derives candidates each tick from `fetchAllTrustees`) — no cursor reset needed.

## Test plan

- [ ] `pnpm build` (tsc) clean.
- [ ] Cutover SQL executed on group_tms DB.
- [ ] After redeploy: new-gnosis worker logs show `startBlock=46398128`; resumes scanning from there.
- [ ] router2 worker resolves the new group's trust list.