### PR TITLE
perf(state-store): skip boot advisory lock when table already exists

### DIFF
--- a/src/apps/router-tms/pgRouterEnablementStore.ts
+++ b/src/apps/router-tms/pgRouterEnablementStore.ts
@@ -58,6 +58,18 @@ export class PgRouterEnablementStore implements IRouterEnablementStore {
   }
 
   private async ensureTable(): Promise<void> {
+    // Fast path: once the table exists (every boot after the first), skip the
+    // advisory lock + DDL. On a near-idle shared state DB the boot-time
+    // pg_advisory_xact_lock wait gets counted as multi-second query time by
+    // pgbouncer; probing existence first avoids the lock in the common case.
+    // The locked DDL path still runs on a fresh DB to serialize the concurrent
+    // CREATE TABLE (the pg_type race the lock guards against).
+    try {
+      const probe = await this.pool.query("SELECT to_regclass('router_tms_enablement') AS reg");
+      if (probe.rows[0]?.reg != null) return;
+    } catch {
+      // fall through to the locked create path on any probe error
+    }
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");

--- a/src/services/stateStore.ts
+++ b/src/services/stateStore.ts
@@ -41,6 +41,18 @@ export class StateStore {
   }
 
   private async ensureTable(): Promise<void> {
+    // Fast path: once the table exists (every boot after the first), skip the
+    // advisory lock + DDL. On a near-idle shared state DB the boot-time
+    // pg_advisory_xact_lock wait gets counted as multi-second query time by
+    // pgbouncer; probing existence first avoids the lock in the common case.
+    // The locked DDL path still runs on a fresh DB to serialize the concurrent
+    // CREATE TABLE (the pg_type race the lock guards against).
+    try {
+      const probe = await this.pool.query("SELECT to_regclass('group_tms_state') AS reg");
+      if (probe.rows[0]?.reg != null) return;
+    } catch {
+      // fall through to the locked create path on any probe error
+    }
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");

--- a/tests/apps/router-tms/pgRouterEnablementStore.spec.ts
+++ b/tests/apps/router-tms/pgRouterEnablementStore.spec.ts
@@ -35,10 +35,15 @@ describe("PgRouterEnablementStore", () => {
   let store: PgRouterEnablementStore;
   let mockPool: any;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
     store = new PgRouterEnablementStore("postgres://localhost/test", QUARANTINE_TTL_MS);
     mockPool = getMockPool();
+    // ensureTable() issues a to_regclass existence probe (and DDL on a fresh
+    // DB) from the constructor; let it settle, then drop those pool.query calls
+    // so each test asserts only the queries it triggers.
+    await (store as any).ready;
+    mockPool.query.mockClear();
   });
 
   afterEach(async () => {
@@ -60,6 +65,21 @@ describe("PgRouterEnablementStore", () => {
       expect(calls[2][0]).toMatch(/CREATE TABLE IF NOT EXISTS router_tms_enablement/);
       expect(calls[3]).toEqual(["COMMIT"]);
       expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it("skips the advisory lock + DDL when the table already exists", async () => {
+      // A boot whose existence probe finds the table present must NOT open a
+      // transaction or take pg_advisory_xact_lock — the hot path that keeps a
+      // near-idle shared state DB off the slow-query radar.
+      jest.clearAllMocks();
+      mockPool.query.mockResolvedValueOnce({rows: [{reg: "router_tms_enablement"}]});
+      const warm = new PgRouterEnablementStore("postgres://localhost/test", QUARANTINE_TTL_MS);
+      await (warm as any).ready;
+      expect(mockPool.query).toHaveBeenCalledWith(
+        "SELECT to_regclass('router_tms_enablement') AS reg"
+      );
+      expect(mockPool.connect).not.toHaveBeenCalled();
+      await warm.close();
     });
   });
 

--- a/tests/services/stateStore.spec.ts
+++ b/tests/services/stateStore.spec.ts
@@ -24,10 +24,15 @@ describe("StateStore", () => {
   let store: StateStore;
   let mockPool: any;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
     store = new StateStore("postgres://localhost/test");
     mockPool = getMockPool();
+    // ensureTable() issues a to_regclass existence probe (and DDL on a fresh
+    // DB) from the constructor; let it settle, then drop those pool.query calls
+    // so each test asserts only the queries it triggers.
+    await (store as any).ready;
+    mockPool.query.mockClear();
   });
 
   afterEach(async () => {
@@ -49,6 +54,21 @@ describe("StateStore", () => {
       expect(calls[2][0]).toMatch(/CREATE TABLE IF NOT EXISTS group_tms_state/);
       expect(calls[3]).toEqual(["COMMIT"]);
       expect(mockClient.release).toHaveBeenCalled();
+    });
+
+    it("skips the advisory lock + DDL when the table already exists", async () => {
+      // A boot whose existence probe finds the table present must NOT open a
+      // transaction or take pg_advisory_xact_lock — the hot path that keeps a
+      // near-idle shared state DB off the slow-query radar.
+      jest.clearAllMocks();
+      mockPool.query.mockResolvedValueOnce({ rows: [{ reg: "group_tms_state" }] });
+      const warm = new StateStore("postgres://localhost/test");
+      await (warm as any).ready;
+      expect(mockPool.query).toHaveBeenCalledWith(
+        "SELECT to_regclass('group_tms_state') AS reg"
+      );
+      expect(mockPool.connect).not.toHaveBeenCalled();
+      await warm.close();
     });
   });
 


### PR DESCRIPTION
## Summary
`StateStore` and `PgRouterEnablementStore` call `ensureTable()` from their constructors, taking `pg_advisory_xact_lock(GROUP_TMS_DDL_LOCK_KEY)` to serialize the concurrent `CREATE TABLE IF NOT EXISTS` (guards the `pg_type_typname_nsp_index` race). The lock is acquired on every restart even when the table already exists, so co-booting workers queue on it. Behind pgbouncer the lock-wait is counted as query duration; on a near-idle shared state DB a single blocked acquire dominates the average query time and trips `PgBouncerQueryTimeSlow`.

## Changes
- `ensureTable()` probes `to_regclass()` first and returns early when the table exists; the advisory lock + DDL run only on a fresh database.
- Applied to both `StateStore` (`group_tms_state`) and `PgRouterEnablementStore` (`router_tms_enablement`).
- Added a test asserting the warm path skips `connect()`/lock; `beforeEach` now drops the constructor's probe call so other assertions are unaffected.

## Test plan
- [x] `tsc --noEmit` + `pnpm build` pass
- [x] `pnpm test` — 457 passed, 32 suites
- [ ] After deploy, confirm worker restarts no longer spike `group_tms` avg query time / `PgBouncerQueryTimeSlow`