### PR TITLE
fix(group-tms): schema-qualify StateStore probe + log probe failures

### DIFF
--- a/src/apps/router-tms/pgRouterEnablementStore.ts
+++ b/src/apps/router-tms/pgRouterEnablementStore.ts
@@ -22,7 +22,7 @@ import {
 } from "../../interfaces/IRouterEnablementStore";
 
 const DDL = `
-CREATE TABLE IF NOT EXISTS router_tms_enablement (
+CREATE TABLE IF NOT EXISTS public.router_tms_enablement (
   avatar              TEXT PRIMARY KEY,
   fallback_enabled    BOOLEAN     NOT NULL DEFAULT FALSE,
   base_group_enabled  BOOLEAN     NOT NULL DEFAULT FALSE,
@@ -64,11 +64,17 @@ export class PgRouterEnablementStore implements IRouterEnablementStore {
     // pgbouncer; probing existence first avoids the lock in the common case.
     // The locked DDL path still runs on a fresh DB to serialize the concurrent
     // CREATE TABLE (the pg_type race the lock guards against).
+    // Schema-qualify the probe (and DDL) so existence detection is independent
+    // of the connection's search_path — the probe must look in exactly the
+    // schema the DDL targets, otherwise a non-default search_path could mask a
+    // present table and re-take the lock every boot.
     try {
-      const probe = await this.pool.query("SELECT to_regclass('router_tms_enablement') AS reg");
+      const probe = await this.pool.query("SELECT to_regclass('public.router_tms_enablement') AS reg");
       if (probe.rows[0]?.reg != null) return;
-    } catch {
-      // fall through to the locked create path on any probe error
+    } catch (err) {
+      // Probe failed (connectivity/permission/unexpected) — log a breadcrumb and
+      // fall through to the locked create path, which re-surfaces any real error.
+      console.warn("[router-enablement-store] table-existence probe failed; using locked create path:", (err as Error).message);
     }
     const client = await this.pool.connect();
     try {

--- a/src/services/stateStore.ts
+++ b/src/services/stateStore.ts
@@ -18,7 +18,7 @@ import pg from "pg";
 export const GROUP_TMS_DDL_LOCK_KEY = 7281992451;
 
 const DDL = `
-CREATE TABLE IF NOT EXISTS group_tms_state (
+CREATE TABLE IF NOT EXISTS public.group_tms_state (
   app_name         TEXT PRIMARY KEY,
   last_scanned_block BIGINT NOT NULL,
   state_data       JSONB,
@@ -47,11 +47,17 @@ export class StateStore {
     // pgbouncer; probing existence first avoids the lock in the common case.
     // The locked DDL path still runs on a fresh DB to serialize the concurrent
     // CREATE TABLE (the pg_type race the lock guards against).
+    // Schema-qualify the probe (and DDL) so existence detection is independent
+    // of the connection's search_path — the probe must look in exactly the
+    // schema the DDL targets, otherwise a non-default search_path could mask a
+    // present table and re-take the lock every boot.
     try {
-      const probe = await this.pool.query("SELECT to_regclass('group_tms_state') AS reg");
+      const probe = await this.pool.query("SELECT to_regclass('public.group_tms_state') AS reg");
       if (probe.rows[0]?.reg != null) return;
-    } catch {
-      // fall through to the locked create path on any probe error
+    } catch (err) {
+      // Probe failed (connectivity/permission/unexpected) — log a breadcrumb and
+      // fall through to the locked create path, which re-surfaces any real error.
+      console.warn("[state-store] table-existence probe failed; using locked create path:", (err as Error).message);
     }
     const client = await this.pool.connect();
     try {

--- a/tests/apps/router-tms/pgRouterEnablementStore.spec.ts
+++ b/tests/apps/router-tms/pgRouterEnablementStore.spec.ts
@@ -17,9 +17,11 @@ jest.mock("pg", () => {
 
 import pg from "pg";
 
-function getMockPool(): any {
-  return (pg.Pool as any).mock.results[0]?.value;
-}
+// The pg mock returns one shared pool instance for every `new Pool()`, so
+// calling the mocked constructor hands back that same singleton — letting us
+// stage the constructor's first query (the existence probe) before building
+// the store.
+const getMockPool = (): any => (pg.Pool as any)();
 
 const QUARANTINE_TTL_MS = 60 * 60 * 1000;
 
@@ -37,11 +39,15 @@ describe("PgRouterEnablementStore", () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    store = new PgRouterEnablementStore("postgres://localhost/test", QUARANTINE_TTL_MS);
     mockPool = getMockPool();
-    // ensureTable() issues a to_regclass existence probe (and DDL on a fresh
-    // DB) from the constructor; let it settle, then drop those pool.query calls
-    // so each test asserts only the queries it triggers.
+    // Stage the constructor's to_regclass probe as "table absent" so ensureTable
+    // takes the locked create path these tests assert against — and crucially
+    // without the probe throwing, which would route through its catch +
+    // console.warn and pollute routine test setup.
+    mockPool.query.mockResolvedValueOnce({rows: [{reg: null}]});
+    store = new PgRouterEnablementStore("postgres://localhost/test", QUARANTINE_TTL_MS);
+    // Let ensureTable settle, then drop its pool.query calls so each test
+    // asserts only the queries it triggers.
     await (store as any).ready;
     mockPool.query.mockClear();
   });
@@ -62,7 +68,7 @@ describe("PgRouterEnablementStore", () => {
         "SELECT pg_advisory_xact_lock($1)",
         [GROUP_TMS_DDL_LOCK_KEY]
       ]);
-      expect(calls[2][0]).toMatch(/CREATE TABLE IF NOT EXISTS router_tms_enablement/);
+      expect(calls[2][0]).toMatch(/CREATE TABLE IF NOT EXISTS public\.router_tms_enablement/);
       expect(calls[3]).toEqual(["COMMIT"]);
       expect(mockClient.release).toHaveBeenCalled();
     });
@@ -72,11 +78,11 @@ describe("PgRouterEnablementStore", () => {
       // transaction or take pg_advisory_xact_lock — the hot path that keeps a
       // near-idle shared state DB off the slow-query radar.
       jest.clearAllMocks();
-      mockPool.query.mockResolvedValueOnce({rows: [{reg: "router_tms_enablement"}]});
+      mockPool.query.mockResolvedValueOnce({rows: [{reg: "public.router_tms_enablement"}]});
       const warm = new PgRouterEnablementStore("postgres://localhost/test", QUARANTINE_TTL_MS);
       await (warm as any).ready;
       expect(mockPool.query).toHaveBeenCalledWith(
-        "SELECT to_regclass('router_tms_enablement') AS reg"
+        "SELECT to_regclass('public.router_tms_enablement') AS reg"
       );
       expect(mockPool.connect).not.toHaveBeenCalled();
       await warm.close();

--- a/tests/services/stateStore.spec.ts
+++ b/tests/services/stateStore.spec.ts
@@ -16,9 +16,11 @@ jest.mock("pg", () => {
 
 import pg from "pg";
 
-function getMockPool(): any {
-  return (pg.Pool as any).mock.results[0]?.value;
-}
+// The pg mock returns one shared pool instance for every `new Pool()`, so
+// calling the mocked constructor hands back that same singleton — letting us
+// stage the constructor's first query (the existence probe) before building
+// the store.
+const getMockPool = (): any => (pg.Pool as any)();
 
 describe("StateStore", () => {
   let store: StateStore;
@@ -26,11 +28,15 @@ describe("StateStore", () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    store = new StateStore("postgres://localhost/test");
     mockPool = getMockPool();
-    // ensureTable() issues a to_regclass existence probe (and DDL on a fresh
-    // DB) from the constructor; let it settle, then drop those pool.query calls
-    // so each test asserts only the queries it triggers.
+    // Stage the constructor's to_regclass probe as "table absent" so ensureTable
+    // takes the locked create path these tests assert against — and crucially
+    // without the probe throwing, which would route through its catch +
+    // console.warn and pollute routine test setup.
+    mockPool.query.mockResolvedValueOnce({ rows: [{ reg: null }] });
+    store = new StateStore("postgres://localhost/test");
+    // Let ensureTable settle, then drop its pool.query calls so each test
+    // asserts only the queries it triggers.
     await (store as any).ready;
     mockPool.query.mockClear();
   });
@@ -51,7 +57,7 @@ describe("StateStore", () => {
         "SELECT pg_advisory_xact_lock($1)",
         [GROUP_TMS_DDL_LOCK_KEY],
       ]);
-      expect(calls[2][0]).toMatch(/CREATE TABLE IF NOT EXISTS group_tms_state/);
+      expect(calls[2][0]).toMatch(/CREATE TABLE IF NOT EXISTS public\.group_tms_state/);
       expect(calls[3]).toEqual(["COMMIT"]);
       expect(mockClient.release).toHaveBeenCalled();
     });
@@ -61,11 +67,11 @@ describe("StateStore", () => {
       // transaction or take pg_advisory_xact_lock — the hot path that keeps a
       // near-idle shared state DB off the slow-query radar.
       jest.clearAllMocks();
-      mockPool.query.mockResolvedValueOnce({ rows: [{ reg: "group_tms_state" }] });
+      mockPool.query.mockResolvedValueOnce({ rows: [{ reg: "public.group_tms_state" }] });
       const warm = new StateStore("postgres://localhost/test");
       await (warm as any).ready;
       expect(mockPool.query).toHaveBeenCalledWith(
-        "SELECT to_regclass('group_tms_state') AS reg"
+        "SELECT to_regclass('public.group_tms_state') AS reg"
       );
       expect(mockPool.connect).not.toHaveBeenCalled();
       await warm.close();


### PR DESCRIPTION
Follow-up polish on the boot-DDL fast-path (#91), addressing deferred review nits.

## What changed
- **Schema-qualify** the `to_regclass` existence probe **and** the `CREATE TABLE` DDL with `public.` in both `StateStore` and `PgRouterEnablementStore`. The fast-path's existence check now looks in exactly the schema the DDL targets, so it no longer depends on the connection's `search_path` — a non-default `search_path` can't mask a present table and cause the advisory lock to be re-taken on every boot.
- **Log probe failures**: the previously-empty `catch {}` on the probe now emits a `console.warn` breadcrumb. Behaviour is unchanged — the locked create path still runs and re-surfaces any real connectivity/permission error — but a swallowed probe error is now observable.
- **Tests**: stage the constructor's probe deterministically in both specs (so the catch path stays out of routine setup) and update the probe-string + DDL assertions for the `public.` qualification.

## Test plan
- [x] `pnpm test` — 458 passed / 32 suites
- [x] `npx tsc --noEmit` — clean