### PR TITLE
perf(group-affiliates): increase BulkReputationService page size 100→10 000

### DIFF
--- a/src/apps/group-affiliates/reputationService.ts
+++ b/src/apps/group-affiliates/reputationService.ts
@@ -90,9 +90,9 @@ type ScoresPage = {
  * address. The per-address ReputationService fans out N requests across
  * thousands of trustees on the full-reconcile path, which blows the
  * rep_score service's request rate limit and aborts the run. Paging
- * `/scores` (limit 100) is ~ceil(total/100) sequential requests total,
- * well under the limit, and serves repeated/incremental checks from a
- * short-lived snapshot so an event burst can't re-page on every event.
+ * `/scores` (limit 10 000) fetches the full member set in a single request
+ * and serves repeated/incremental checks from a short-lived snapshot so
+ * an event burst can't re-page on every event.
  */
 export class BulkReputationService implements IReputationService {
   private snapshot: Map<string, number | null> | null = null;
@@ -102,7 +102,7 @@ export class BulkReputationService implements IReputationService {
     private readonly scoresUrl: string,
     private readonly timeoutMs: number = 30_000,
     private readonly snapshotTtlMs: number = 5 * 60 * 1000,
-    private readonly pageSize: number = 100
+    private readonly pageSize: number = 10_000
   ) {
   }
 


### PR DESCRIPTION
## Summary

- `BulkReputationService` page size raised from 100 → 10 000 (AA `/scores` API max)
- Updated inline comment to reflect the new fetch pattern

## Why

Fetching 10K group members in pages of 100 issued ~100 sequential HTTP requests to the rep_score `/scores` endpoint. Each request triggered a separate batched live B/O lookup against postgres-gnosis. One request at the API max achieves the same result in a single round-trip, eliminating ~99% of the request volume on the AA side.

## Test plan

- [ ] Deploy to prod1 and confirm `group-affiliates` completes its reputation snapshot in 1 request (check logs for pagination loop count)
- [ ] Verify prod1 AA `/scores` p95 drops for the `172.18.0.51`-sourced calls
- [ ] No change in affiliate trust decisions (same scores, same data, fewer requests)