### PR TITLE
added new tms for community 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Specialized services for Circles protocol trust management:
 * Replays historical logs from a persisted cursor on startup before listening live
 * Supports dry-run mode with optional Safe transaction simulation
 
+## Community New App
+* Reads multi-affiliate community intent from `circles_getAffiliateGroupMembersWishlist`
+* Loads each managed group's `minRepScore` and checks every intended member's reputation
+* Enforces the aggregate community membership-fee cap (`totalFeePercentage <= 100`)
+* Trusts eligible intended members and untrusts members that become ineligible
+* Untrusts every current trustee removed from the wishlist, treating removal as intent to leave
+* Supports dry-run Safe simulation
+
 ## Router2 App
 * Calls `setApprovalForCRC(address[])` for every address trusted by the configured truster and every Gnosis App user with `avatarType=RegisterHuman`
 * Executes transactions directly from the configured EOA signer
@@ -74,6 +82,7 @@ npm run start:dublin-tms
 npm run start:oic
 npm run start:all
 npm run start:group-affiliates
+npm run start:community-new
 npm run start:router2
 ```
 
@@ -315,6 +324,49 @@ INSTANCE_ID=                                 # Used by Slack messages to tag the
 VERBOSE_LOGGING=1
 ```
 
+### Community New App Configuration
+
+```dotenv
+# New multi-affiliate reads. Keep this separate from RPC_URL while the methods
+# are staging-only; RPC_URL is used for group contract reads and Safe writes.
+COMMUNITY_NEW_RPC_URL=https://rpc.staging.aboutcircles.com
+RPC_URL=https://rpc.aboutcircles.com/
+TX_RPC_URL=https://your-write-rpc.example/       # optional
+
+# Comma-separated groups managed by this worker. Defaults to the three
+# existing Group Affiliates managed groups when omitted.
+COMMUNITY_NEW_GROUP_ADDRESSES=0x4E2564e5df6C1Fb10C1A018538de36E4D5844DE5,0x2709757a543CF1BF4d92586b73d3891438b2589d,0xEEcAe593589a6eE4a12AE64F19420B47F3112Fa9
+
+# One Safe must be the service for every configured group.
+COMMUNITY_NEW_SAFE_ADDRESS=
+COMMUNITY_NEW_SAFE_SIGNER_PRIVATE_KEY=
+COMMUNITY_NEW_SIGNER_ADDRESS=                    # optional key/address validation
+
+# Reconciliation and RPC pagination
+COMMUNITY_NEW_POLL_INTERVAL_MS=600000
+COMMUNITY_NEW_PAGE_SIZE=500                      # 1..1000
+COMMUNITY_NEW_BATCH_SIZE=20
+COMMUNITY_NEW_FEE_FETCH_CONCURRENCY=8
+COMMUNITY_NEW_RPC_TIMEOUT_MS=30000
+COMMUNITY_NEW_RPC_MAX_PAGES=500
+COMMUNITY_NEW_ERRORS_BEFORE_CRASH=5
+
+# Group criteria and reputation lookups
+COMMUNITY_NEW_PROFILE_TIMEOUT_MS=30000
+COMMUNITY_NEW_REPUTATION_BASE_URL=https://walrus-app-2-iod58.ondigitalocean.app/aboutcircles-advanced-analytics2/rep_score/groups/gnosis/avatars
+COMMUNITY_NEW_REPUTATION_SCORES_URL=              # optional explicit bulk /scores URL
+COMMUNITY_NEW_REPUTATION_BULK=1
+COMMUNITY_NEW_REPUTATION_TIMEOUT_MS=30000
+COMMUNITY_NEW_REPUTATION_SNAPSHOT_TTL_MS=600000
+
+# Operation and notifications
+DRY_RUN=0
+COMMUNITY_NEW_SLACK_WEBHOOK_URL=                  # falls back to SLACK_WEBHOOK_URL
+SLACK_WEBHOOK_URL=
+SLACK_WEBHOOK_URL_INFO=
+VERBOSE_LOGGING=1
+```
+
 ### Gnosis Group App Configuration
 
 ```dotenv
@@ -429,6 +481,15 @@ VERBOSE_LOGGING=1
 * Cursor persistence uses `LEADER_DB_URL` and app name `group-affiliates`
 * `DRY_RUN=1` logs planned trust/untrust batches and simulates them when Safe credentials are configured
 * Service maintains incremental state to avoid re-processing old events
+
+### Community New App
+* The wishlist RPC is the source of membership intent; a normal group trust relation alone is not community intent
+* Eligibility requires `reputation_score > minRepScore` and an aggregate wishlist fee no greater than 100%
+* Missing or invalid group criteria and failed RPC/reputation reads fail the run before any transactions are submitted
+* A current trustee absent from the wishlist is treated as having left and is untrusted regardless of reputation or fee criteria
+* Current trustees still on the wishlist are untrusted when they fail reputation or fee eligibility
+* The RPC methods read chain head and do not support block pinning, so reconciliation is intentionally repeatable and eventually consistent
+* Use `DRY_RUN=1` to inspect and optionally simulate the exact trust/untrust plan before enabling writes
 
 ### Dublin TMS App
 * `DUBLIN_TMS_SERVICE_EOA` should be the group service EOA (defaults to `0x20a3C619De4C15E360d30F329DBCfe5bb618654f`)

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -16,6 +16,7 @@ module.exports = {
     "<rootDir>/src/apps/gp-crc/logic.ts",
     "<rootDir>/src/apps/router-tms/logic.ts",
     "<rootDir>/src/apps/group-affiliates/logic.ts",
+    "<rootDir>/src/apps/community-new/logic.ts",
     "!<rootDir>/src/main.ts",
     "!**/*.d.ts",
     "!**/__tests__/**",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start:router-tms": "node --env-file=.env dist/src/apps/router-tms/main.js",
     "start:router2": "node --env-file=.env dist/src/apps/router2/main.js",
     "start:group-affiliates": "node --env-file=.env dist/src/apps/group-affiliates/main.js",
+    "start:community-new": "node --env-file=.env dist/src/apps/community-new/main.js",
     "start:new-gnosis": "node --env-file=.env dist/src/apps/new-gnosis/main.js",
     "start:all": "node --env-file=.env dist/src/apps/manager.js",
     "test": "jest --config jest.config.ts",

--- a/src/apps/community-new/groupProfileService.ts
+++ b/src/apps/community-new/groupProfileService.ts
@@ -1,0 +1,100 @@
+import {getAddress} from "ethers";
+
+import {primaryRpcUrl} from "../../services/rpcProvider";
+import {IGroupProfileService} from "../group-affiliates/groupProfileService";
+
+type JsonRpcResponse = {
+  result?: unknown;
+  error?: {code?: unknown; message?: unknown};
+};
+
+/** Reads current membership criteria from Circles profiles over JSON-RPC. */
+export class CommunityGroupProfileService implements IGroupProfileService {
+  private requestId = 0;
+  private readonly rpcUrl: string;
+
+  constructor(rpcUrl: string, private readonly timeoutMs: number = 30_000) {
+    this.rpcUrl = primaryRpcUrl(rpcUrl);
+    if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+      throw new Error("Community profile RPC timeout must be a positive integer");
+    }
+  }
+
+  async fetchMinRepScores(groupAddresses: readonly string[]): Promise<Record<string, number>> {
+    const groups = Array.from(new Set(groupAddresses.map((group) => getAddress(group).toLowerCase())));
+    if (groups.length === 0) return {};
+
+    const result = await this.call("circles_getProfileByAddressBatch", [groups]);
+    if (!Array.isArray(result) || result.length !== groups.length) {
+      throw new Error(
+        `circles_getProfileByAddressBatch returned ${Array.isArray(result) ? result.length : "a non-array"} ` +
+        `for ${groups.length} managed group(s)`
+      );
+    }
+
+    const thresholds: Record<string, number> = {};
+    result.forEach((profile, index) => {
+      const group = groups[index];
+      if (!isRecord(profile)) {
+        throw new Error(`No group profile found for ${group}`);
+      }
+      const criteria = profile.membershipCriteria;
+      if (!isRecord(criteria)) {
+        throw new Error(`group profile ${group} has no membershipCriteria`);
+      }
+      const minRepScore = parseNumber(criteria.minRepScore);
+      if (minRepScore === null) {
+        throw new Error(`group profile ${group} does not include a valid membershipCriteria.minRepScore`);
+      }
+      thresholds[group] = minRepScore;
+    });
+    return thresholds;
+  }
+
+  private async call(method: string, params: unknown[]): Promise<unknown> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await fetch(this.rpcUrl, {
+        method: "POST",
+        headers: {"content-type": "application/json"},
+        body: JSON.stringify({jsonrpc: "2.0", id: ++this.requestId, method, params}),
+        signal: controller.signal
+      });
+      if (!response.ok) {
+        throw new Error(`${method} failed: HTTP ${response.status} ${response.statusText}`.trim());
+      }
+
+      const payload = await response.json() as JsonRpcResponse;
+      if (payload.error) {
+        const code = typeof payload.error.code === "number" ? ` ${payload.error.code}` : "";
+        const message = typeof payload.error.message === "string" ? payload.error.message : "unknown RPC error";
+        throw new Error(`${method} failed: RPC error${code}: ${message}`);
+      }
+      if (!("result" in payload)) {
+        throw new Error(`${method} failed: JSON-RPC response has no result`);
+      }
+      return payload.result;
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(`${method} timed out after ${this.timeoutMs}ms`, {cause: error});
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function parseNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/apps/community-new/logic.ts
+++ b/src/apps/community-new/logic.ts
@@ -1,0 +1,334 @@
+import {getAddress} from "ethers";
+
+import {IAffiliateGroupsRpc} from "../../interfaces/IAffiliateGroupsRpc";
+import {ICirclesRpc} from "../../interfaces/ICirclesRpc";
+import {IGroupService} from "../../interfaces/IGroupService";
+import {ILoggerService} from "../../interfaces/ILoggerService";
+import {IReputationService} from "../group-affiliates/reputationService";
+
+export const DEFAULT_COMMUNITY_BATCH_SIZE = 20;
+export const DEFAULT_COMMUNITY_PAGE_SIZE = 500;
+export const DEFAULT_FEE_FETCH_CONCURRENCY = 8;
+export const MAX_AFFILIATE_FEE_PERCENTAGE = 100;
+export const DEFAULT_COMMUNITY_GROUP_ADDRESSES = [
+  "0x4E2564e5df6C1Fb10C1A018538de36E4D5844DE5",
+  "0x2709757a543CF1BF4d92586b73d3891438b2589d",
+  "0xEEcAe593589a6eE4a12AE64F19420B47F3112Fa9"
+] as const;
+
+export type CommunityRunConfig = {
+  managedGroupAddresses: readonly string[];
+  minRepScoresByGroup: Record<string, number>;
+  pageSize: number;
+  batchSize: number;
+  feeFetchConcurrency: number;
+  maxTotalFeePercentage?: number;
+  dryRun?: boolean;
+};
+
+export type CommunityRunDeps = {
+  affiliateRpc: IAffiliateGroupsRpc;
+  circlesRpc: Pick<ICirclesRpc, "fetchAllTrustees">;
+  groupService: IGroupService;
+  reputationService: IReputationService;
+  logger: ILoggerService;
+};
+
+export type EligibilityFailure = {
+  groupAddress: string;
+  avatarAddress: string;
+  reasons: Array<"reputation" | "fee-cap">;
+  reputationScore: number | null;
+  requiredMinRepScore: number;
+  totalFeePercentage: number;
+};
+
+export type CommunityRunOutcome = {
+  wishlistMembersByGroup: Record<string, number>;
+  currentTrusteesByGroup: Record<string, number>;
+  leftByGroup: Record<string, string[]>;
+  trustedByGroup: Record<string, string[]>;
+  untrustedByGroup: Record<string, string[]>;
+  trustTxHashes: string[];
+  untrustTxHashes: string[];
+  ineligible: EligibilityFailure[];
+};
+
+type GroupSnapshot = {
+  groupAddress: string;
+  wishlist: Set<string>;
+  currentTrustees: Set<string>;
+};
+
+/**
+ * Reconciles the bilateral community handshake.
+ *
+ * The wishlist is the source of intent. An address is trusted only when its
+ * reputation is strictly greater than the group's minRepScore and its total
+ * committed community fee is at most 100%. Current trustees that become
+ * ineligible or disappear from the wishlist are untrusted. Absence from the
+ * wishlist is the registry's leave signal and takes precedence over criteria.
+ */
+export async function runCommunityReconciliation(
+  deps: CommunityRunDeps,
+  cfg: CommunityRunConfig
+): Promise<CommunityRunOutcome> {
+  const groups = normalizeGroups(cfg.managedGroupAddresses);
+  const thresholds = normalizeThresholds(groups, cfg.minRepScoresByGroup);
+  const pageSize = positiveIntegerInRange("pageSize", cfg.pageSize, 1, 1000);
+  const batchSize = positiveIntegerInRange("batchSize", cfg.batchSize, 1, Number.MAX_SAFE_INTEGER);
+  const feeFetchConcurrency = positiveIntegerInRange(
+    "feeFetchConcurrency",
+    cfg.feeFetchConcurrency,
+    1,
+    Number.MAX_SAFE_INTEGER
+  );
+  const maxTotalFeePercentage = cfg.maxTotalFeePercentage ?? MAX_AFFILIATE_FEE_PERCENTAGE;
+  if (!Number.isFinite(maxTotalFeePercentage) || maxTotalFeePercentage < 0) {
+    throw new Error(`maxTotalFeePercentage must be a finite non-negative number, received ${maxTotalFeePercentage}`);
+  }
+
+  const snapshots = await Promise.all(groups.map(async (groupAddress): Promise<GroupSnapshot> => {
+    const [wishlistMembers, currentTrustees] = await Promise.all([
+      deps.affiliateRpc.fetchAllGroupMembersWishlist(groupAddress, pageSize),
+      deps.circlesRpc.fetchAllTrustees(groupAddress)
+    ]);
+    return {
+      groupAddress,
+      wishlist: new Set(wishlistMembers.map((member) => normalizeAddress(member.avatarAddress))),
+      currentTrustees: new Set(currentTrustees.map(normalizeAddress))
+    };
+  }));
+
+  const allWishlistAddresses = Array.from(new Set(
+    snapshots.flatMap((snapshot) => Array.from(snapshot.wishlist))
+  )).sort();
+  const [reputationVerdicts, feePercentages] = await Promise.all([
+    allWishlistAddresses.length > 0
+      ? deps.reputationService.check(allWishlistAddresses, 0)
+      : new Map(),
+    fetchFeePercentages(deps.affiliateRpc, allWishlistAddresses, feeFetchConcurrency)
+  ]);
+
+  const wishlistMembersByGroup: Record<string, number> = {};
+  const currentTrusteesByGroup: Record<string, number> = {};
+  const leftByGroup: Record<string, string[]> = {};
+  const trustedByGroup: Record<string, string[]> = {};
+  const untrustedByGroup: Record<string, string[]> = {};
+  const ineligible: EligibilityFailure[] = [];
+
+  for (const snapshot of snapshots) {
+    const threshold = thresholds.get(snapshot.groupAddress)!;
+    const eligible = new Set<string>();
+    wishlistMembersByGroup[snapshot.groupAddress] = snapshot.wishlist.size;
+    currentTrusteesByGroup[snapshot.groupAddress] = snapshot.currentTrustees.size;
+
+    for (const avatarAddress of snapshot.wishlist) {
+      const verdict = reputationVerdicts.get(avatarAddress);
+      const reputationScore = verdict?.reputationScore ?? null;
+      const totalFeePercentage = feePercentages.get(avatarAddress);
+      if (totalFeePercentage === undefined) {
+        throw new Error(`Missing aggregate fee result for ${avatarAddress}`);
+      }
+
+      const reasons: EligibilityFailure["reasons"] = [];
+      if (reputationScore === null || reputationScore <= threshold) {
+        reasons.push("reputation");
+      }
+      if (totalFeePercentage > maxTotalFeePercentage) {
+        reasons.push("fee-cap");
+      }
+
+      if (reasons.length === 0) {
+        eligible.add(avatarAddress);
+      } else {
+        ineligible.push({
+          groupAddress: snapshot.groupAddress,
+          avatarAddress,
+          reasons,
+          reputationScore,
+          requiredMinRepScore: threshold,
+          totalFeePercentage
+        });
+      }
+    }
+
+    leftByGroup[snapshot.groupAddress] = Array.from(snapshot.currentTrustees)
+      .filter((address) => !snapshot.wishlist.has(address))
+      .sort();
+
+    trustedByGroup[snapshot.groupAddress] = Array.from(eligible)
+      .filter((address) => !snapshot.currentTrustees.has(address))
+      .sort();
+    untrustedByGroup[snapshot.groupAddress] = Array.from(snapshot.currentTrustees)
+      .filter((address) => !eligible.has(address))
+      .sort();
+  }
+
+  const totalTrust = countAddresses(trustedByGroup);
+  const totalUntrust = countAddresses(untrustedByGroup);
+  const totalLeft = countAddresses(leftByGroup);
+  deps.logger.info(
+    `Community reconciliation: groups=${groups.length} wishlist=${allWishlistAddresses.length} ` +
+    `ineligible=${ineligible.length} left=${totalLeft} toTrust=${totalTrust} toUntrust=${totalUntrust}`
+  );
+
+  if (cfg.dryRun) {
+    await simulatePlan(deps.groupService, batchSize, untrustedByGroup, trustedByGroup, deps.logger);
+    return {
+      wishlistMembersByGroup,
+      currentTrusteesByGroup,
+      leftByGroup,
+      trustedByGroup,
+      untrustedByGroup,
+      trustTxHashes: [],
+      untrustTxHashes: [],
+      ineligible
+    };
+  }
+
+  const {trustTxHashes, untrustTxHashes} = await executePlan(
+    deps.groupService,
+    batchSize,
+    untrustedByGroup,
+    trustedByGroup,
+    deps.logger
+  );
+  return {
+    wishlistMembersByGroup,
+    currentTrusteesByGroup,
+    leftByGroup,
+    trustedByGroup,
+    untrustedByGroup,
+    trustTxHashes,
+    untrustTxHashes,
+    ineligible
+  };
+}
+
+async function fetchFeePercentages(
+  affiliateRpc: IAffiliateGroupsRpc,
+  addresses: string[],
+  concurrency: number
+): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  let nextIndex = 0;
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= addresses.length) return;
+      const address = addresses[index];
+      const total = await affiliateRpc.fetchAffiliateGroupFeesPercentage(address);
+      result.set(address, total);
+    }
+  };
+
+  const workerCount = Math.min(concurrency, addresses.length);
+  await Promise.all(Array.from({length: workerCount}, worker));
+  return result;
+}
+
+async function executePlan(
+  groupService: IGroupService,
+  batchSize: number,
+  untrustedByGroup: Record<string, string[]>,
+  trustedByGroup: Record<string, string[]>,
+  logger: ILoggerService
+): Promise<{trustTxHashes: string[]; untrustTxHashes: string[]}> {
+  const trustTxHashes: string[] = [];
+  const untrustTxHashes: string[] = [];
+
+  for (const [group, addresses] of Object.entries(untrustedByGroup)) {
+    for (const batch of chunk(addresses, batchSize)) {
+      logger.info(`Untrusting ${batch.length} ineligible community member(s) from ${group}: ${batch.join(", ")}`);
+      untrustTxHashes.push(await groupService.untrustBatch(group, batch));
+    }
+  }
+  for (const [group, addresses] of Object.entries(trustedByGroup)) {
+    for (const batch of chunk(addresses, batchSize)) {
+      logger.info(`Trusting ${batch.length} eligible community member(s) in ${group}: ${batch.join(", ")}`);
+      trustTxHashes.push(await groupService.trustBatchWithConditions(group, batch));
+    }
+  }
+
+  return {trustTxHashes, untrustTxHashes};
+}
+
+async function simulatePlan(
+  groupService: IGroupService,
+  batchSize: number,
+  untrustedByGroup: Record<string, string[]>,
+  trustedByGroup: Record<string, string[]>,
+  logger: ILoggerService
+): Promise<void> {
+  for (const [group, addresses] of Object.entries(untrustedByGroup)) {
+    for (const batch of chunk(addresses, batchSize)) {
+      logger.info(`DRY RUN untrust group=${group} addresses=${batch.join(", ")}`);
+      if (groupService.simulateUntrustBatch) {
+        const result = await groupService.simulateUntrustBatch(group, batch);
+        logger.info(`DRY RUN untrust simulation group=${group}: ok, gasEstimate=${result.gasEstimate}`);
+      }
+    }
+  }
+  for (const [group, addresses] of Object.entries(trustedByGroup)) {
+    for (const batch of chunk(addresses, batchSize)) {
+      logger.info(`DRY RUN trust group=${group} addresses=${batch.join(", ")}`);
+      if (groupService.simulateTrustBatchWithConditions) {
+        const result = await groupService.simulateTrustBatchWithConditions(group, batch);
+        logger.info(`DRY RUN trust simulation group=${group}: ok, gasEstimate=${result.gasEstimate}`);
+      }
+    }
+  }
+}
+
+function normalizeGroups(groups: readonly string[]): string[] {
+  const normalized = Array.from(new Set(groups.map(normalizeAddress)));
+  if (normalized.length === 0) {
+    throw new Error("At least one community group address is required");
+  }
+  return normalized;
+}
+
+function normalizeThresholds(groups: string[], configured: Record<string, number>): Map<string, number> {
+  const normalizedConfigured = new Map<string, number>();
+  for (const [group, threshold] of Object.entries(configured)) {
+    if (!Number.isFinite(threshold)) {
+      throw new Error(`Invalid minRepScore for ${group}: ${threshold}`);
+    }
+    normalizedConfigured.set(normalizeAddress(group), threshold);
+  }
+
+  const result = new Map<string, number>();
+  for (const group of groups) {
+    const threshold = normalizedConfigured.get(group);
+    if (threshold === undefined) {
+      throw new Error(`No minRepScore was loaded for managed group ${group}`);
+    }
+    result.set(group, threshold);
+  }
+  return result;
+}
+
+function normalizeAddress(address: string): string {
+  return getAddress(address).toLowerCase();
+}
+
+function positiveIntegerInRange(name: string, value: number, min: number, max: number): number {
+  if (!Number.isInteger(value) || value < min || value > max) {
+    throw new Error(`${name} must be an integer in [${min}, ${max}], received ${value}`);
+  }
+  return value;
+}
+
+function countAddresses(byGroup: Record<string, string[]>): number {
+  return Object.values(byGroup).reduce((sum, addresses) => sum + addresses.length, 0);
+}
+
+function chunk<T>(values: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < values.length; index += size) {
+    result.push(values.slice(index, index + size));
+  }
+  return result;
+}

--- a/src/apps/community-new/main.ts
+++ b/src/apps/community-new/main.ts
@@ -1,0 +1,288 @@
+import {getAddress, Wallet} from "ethers";
+
+import {formatErrorWithCauses} from "../../formatError";
+import {IGroupService} from "../../interfaces/IGroupService";
+import {SlackSeverity} from "../../interfaces/ISlackService";
+import {AffiliateGroupsRpcService} from "../../services/affiliateGroupsRpcService";
+import {CirclesRpcService} from "../../services/circlesRpcService";
+import {ConsecutiveErrorTracker} from "../../services/consecutiveErrorTracker";
+import {LoggerService} from "../../services/loggerService";
+import {recordRunError, recordRunSuccess, startMetricsServer} from "../../services/metricsService";
+import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
+import {SafeGroupService} from "../../services/safeGroupService";
+import {SlackService} from "../../services/slackService";
+import {resolveTransactionRpcUrl} from "../../services/transactionRpc";
+import {
+  BulkReputationService,
+  IReputationService,
+  ReputationService
+} from "../group-affiliates/reputationService";
+import {CommunityGroupProfileService} from "./groupProfileService";
+import {
+  DEFAULT_COMMUNITY_BATCH_SIZE,
+  DEFAULT_COMMUNITY_GROUP_ADDRESSES,
+  DEFAULT_COMMUNITY_PAGE_SIZE,
+  DEFAULT_FEE_FETCH_CONCURRENCY,
+  runCommunityReconciliation
+} from "./logic";
+
+const APP_NAME = "community-new";
+const DEFAULT_COMMUNITY_RPC_URL = "https://rpc.staging.aboutcircles.com";
+const DEFAULT_REPUTATION_BASE_URL =
+  "https://walrus-app-2-iod58.ondigitalocean.app/aboutcircles-advanced-analytics2/rep_score/groups/gnosis/avatars";
+
+const verboseLogging = !!process.env.VERBOSE_LOGGING;
+const logger = new LoggerService(verboseLogging, APP_NAME);
+const runLogger = logger.child("run");
+const communityRpcUrl = process.env.COMMUNITY_NEW_RPC_URL || DEFAULT_COMMUNITY_RPC_URL;
+const chainRpcUrl = process.env.RPC_URL || communityRpcUrl;
+const txRpcUrl = resolveTransactionRpcUrl(chainRpcUrl);
+const managedGroups = parseGroupAddresses(
+  process.env.COMMUNITY_NEW_GROUP_ADDRESSES,
+  DEFAULT_COMMUNITY_GROUP_ADDRESSES
+);
+const pageSize = parsePositiveInt("COMMUNITY_NEW_PAGE_SIZE", DEFAULT_COMMUNITY_PAGE_SIZE, 1000);
+const batchSize = parsePositiveInt("COMMUNITY_NEW_BATCH_SIZE", DEFAULT_COMMUNITY_BATCH_SIZE);
+const feeFetchConcurrency = parsePositiveInt(
+  "COMMUNITY_NEW_FEE_FETCH_CONCURRENCY",
+  DEFAULT_FEE_FETCH_CONCURRENCY
+);
+const pollIntervalMs = Math.max(1_000, parsePositiveInt("COMMUNITY_NEW_POLL_INTERVAL_MS", 10 * 60 * 1000));
+const affiliateRpcTimeoutMs = parsePositiveInt("COMMUNITY_NEW_RPC_TIMEOUT_MS", 30_000);
+const affiliateRpcMaxPages = parsePositiveInt("COMMUNITY_NEW_RPC_MAX_PAGES", 500);
+const profileTimeoutMs = parsePositiveInt("COMMUNITY_NEW_PROFILE_TIMEOUT_MS", 30_000);
+const reputationBaseUrl = process.env.COMMUNITY_NEW_REPUTATION_BASE_URL || DEFAULT_REPUTATION_BASE_URL;
+const reputationTimeoutMs = parsePositiveInt("COMMUNITY_NEW_REPUTATION_TIMEOUT_MS", 30_000);
+const reputationConcurrency = parsePositiveInt("COMMUNITY_NEW_REPUTATION_CONCURRENCY", 8);
+const reputationSnapshotTtlMs = parsePositiveInt(
+  "COMMUNITY_NEW_REPUTATION_SNAPSHOT_TTL_MS",
+  Math.max(pollIntervalMs, 5 * 60 * 1000)
+);
+const dryRun = process.env.DRY_RUN === "1";
+const safeAddress = process.env.COMMUNITY_NEW_SAFE_ADDRESS || "";
+const safeSignerPrivateKey = process.env.COMMUNITY_NEW_SAFE_SIGNER_PRIVATE_KEY || "";
+const configuredSignerAddress = process.env.COMMUNITY_NEW_SIGNER_ADDRESS || "";
+const canSimulate = safeAddress.trim().length > 0 && safeSignerPrivateKey.trim().length > 0;
+const errorsBeforeCrash = parsePositiveInt("COMMUNITY_NEW_ERRORS_BEFORE_CRASH", 5);
+const slackWebhookUrl = process.env.COMMUNITY_NEW_SLACK_WEBHOOK_URL || process.env.SLACK_WEBHOOK_URL || "";
+const slackWebhookUrlInfo = process.env.SLACK_WEBHOOK_URL_INFO || "";
+const slackInfoChannel = process.env.SLACK_INFO_CHANNEL || "";
+
+validateConfig();
+
+const affiliateRpc = new AffiliateGroupsRpcService(
+  communityRpcUrl,
+  affiliateRpcTimeoutMs,
+  affiliateRpcMaxPages
+);
+const circlesRpc = new CirclesRpcService(communityRpcUrl);
+const profileService = new CommunityGroupProfileService(communityRpcUrl, profileTimeoutMs);
+const reputationScoresUrl = process.env.COMMUNITY_NEW_REPUTATION_SCORES_URL ||
+  (/\/avatars\/*$/.test(reputationBaseUrl)
+    ? reputationBaseUrl.replace(/\/avatars\/*$/, "/scores")
+    : "");
+const useBulkReputation = process.env.COMMUNITY_NEW_REPUTATION_BULK !== "0" && reputationScoresUrl.length > 0;
+const reputationService: IReputationService = useBulkReputation
+  ? new BulkReputationService(reputationScoresUrl, reputationTimeoutMs, reputationSnapshotTtlMs)
+  : new ReputationService(reputationBaseUrl, reputationTimeoutMs, reputationConcurrency);
+const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slackInfoChannel);
+const errorTracker = new ConsecutiveErrorTracker(errorsBeforeCrash);
+const groupService = createGroupService();
+
+let shuttingDown = false;
+
+process.on("SIGINT", () => { void shutdown("SIGINT"); });
+process.on("SIGTERM", () => { void shutdown("SIGTERM"); });
+process.on("uncaughtException", (cause) => { void crash("Uncaught exception", cause); });
+process.on("unhandledRejection", (cause) => { void crash("Unhandled rejection", cause); });
+
+async function start(): Promise<void> {
+  startMetricsServer(APP_NAME);
+  if (groupService.validateSafeOwnership) {
+    await groupService.validateSafeOwnership();
+    logger.info("Safe ownership validation passed.");
+  }
+  if (!dryRun || canSimulate) {
+    await validateManagedGroupServices();
+  }
+
+  logConfiguration();
+  await notify(
+    `✅ *community-new started*\n` +
+    `Groups: ${managedGroups.join(", ")}\n` +
+    `Community RPC: ${communityRpcUrl}\n` +
+    `Dry run: ${dryRun}`,
+    SlackSeverity.INFO
+  );
+
+  while (!shuttingDown) {
+    const startedAt = Date.now();
+    try {
+      const healthy = await ensureRpcHealthyOrNotify({
+        appName: APP_NAME,
+        rpcUrl: communityRpcUrl,
+        logger
+      });
+      if (healthy) {
+        const minRepScoresByGroup = await profileService.fetchMinRepScores(managedGroups);
+        const outcome = await runCommunityReconciliation(
+          {affiliateRpc, circlesRpc, groupService, reputationService, logger: runLogger},
+          {
+            managedGroupAddresses: managedGroups,
+            minRepScoresByGroup,
+            pageSize,
+            batchSize,
+            feeFetchConcurrency,
+            dryRun
+          }
+        );
+        recordRunSuccess(APP_NAME, Date.now() - startedAt);
+        errorTracker.recordSuccess();
+        if (errorTracker.wasAlertingAndRecovered()) {
+          void slackService.notifySlackResolved("community-new").catch((error) => {
+            logger.warn("Failed to send Slack recovery notification:", error);
+          });
+        }
+        runLogger.info(
+          `Run complete: trustTxs=${outcome.trustTxHashes.length} ` +
+          `untrustTxs=${outcome.untrustTxHashes.length} ineligible=${outcome.ineligible.length} ` +
+          `elapsedMs=${Date.now() - startedAt}`
+        );
+      }
+    } catch (cause) {
+      const error = asError(cause);
+      const consecutiveErrors = errorTracker.recordError();
+      recordRunError(APP_NAME);
+      logger.error(`Run failed (${consecutiveErrors}/${errorsBeforeCrash} consecutive errors):`);
+      logger.error(formatErrorWithCauses(error));
+      if (errorTracker.shouldAlert()) {
+        await notify(
+          `⚠️ *community-new run failed* (${consecutiveErrors} consecutive failures)\n\n` +
+          formatErrorWithCauses(error),
+          SlackSeverity.WARNING
+        );
+        setTimeout(() => process.exit(1), 3_000).unref();
+        return;
+      }
+    }
+
+    await delay(pollIntervalMs);
+  }
+}
+
+function createGroupService(): IGroupService {
+  if (!dryRun || canSimulate) {
+    return new SafeGroupService(chainRpcUrl, safeSignerPrivateKey, safeAddress, txRpcUrl);
+  }
+
+  const unavailable = async (): Promise<never> => {
+    throw new Error("Group writes are unavailable in dry-run mode without Safe credentials");
+  };
+  return {
+    trustBatchWithConditions: unavailable,
+    untrustBatch: unavailable,
+    fetchGroupOwnerAndService: unavailable
+  };
+}
+
+function validateConfig(): void {
+  if (!dryRun && safeAddress.trim().length === 0) {
+    throw new Error("COMMUNITY_NEW_SAFE_ADDRESS is required unless DRY_RUN=1");
+  }
+  if (!dryRun && safeSignerPrivateKey.trim().length === 0) {
+    throw new Error("COMMUNITY_NEW_SAFE_SIGNER_PRIVATE_KEY is required unless DRY_RUN=1");
+  }
+  if (safeAddress.trim().length > 0) {
+    getAddress(safeAddress);
+  }
+  if (configuredSignerAddress.trim().length > 0) {
+    if (safeSignerPrivateKey.trim().length === 0) {
+      throw new Error("COMMUNITY_NEW_SIGNER_ADDRESS requires COMMUNITY_NEW_SAFE_SIGNER_PRIVATE_KEY");
+    }
+    const expected = getAddress(configuredSignerAddress).toLowerCase();
+    const actual = new Wallet(safeSignerPrivateKey).address.toLowerCase();
+    if (expected !== actual) {
+      throw new Error(`Configured community signer ${expected} does not match private-key signer ${actual}`);
+    }
+  }
+}
+
+async function validateManagedGroupServices(): Promise<void> {
+  const expectedService = getAddress(safeAddress).toLowerCase();
+  for (const group of managedGroups) {
+    const configured = await groupService.fetchGroupOwnerAndService(group);
+    if (configured.service !== expectedService) {
+      throw new Error(
+        `Managed group ${group} has service ${configured.service}, but COMMUNITY_NEW_SAFE_ADDRESS is ${expectedService}`
+      );
+    }
+  }
+  logger.info(`Group service validation passed for ${managedGroups.length} managed group(s).`);
+}
+
+function logConfiguration(): void {
+  logger.info("Starting community-new with config:");
+  logger.info(`  - communityRpcUrl=${communityRpcUrl}`);
+  logger.info(`  - chainRpcUrl=${chainRpcUrl}`);
+  logger.info(`  - txRpcUrl=${txRpcUrl}`);
+  logger.info(`  - groups=${managedGroups.join(",")}`);
+  logger.info(`  - pageSize=${pageSize}`);
+  logger.info(`  - batchSize=${batchSize}`);
+  logger.info(`  - feeFetchConcurrency=${feeFetchConcurrency}`);
+  logger.info(`  - pollIntervalMs=${pollIntervalMs}`);
+  logger.info(`  - profileSource=${communityRpcUrl} (circles_getProfileByAddressBatch)`);
+  logger.info(`  - reputationMode=${useBulkReputation ? "bulk" : "per-address"}`);
+  logger.info(`  - safe=${safeAddress || "(not set)"}`);
+  logger.info(`  - dryRun=${dryRun}`);
+}
+
+async function shutdown(signal: string): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  await notify(`🔄 *community-new shutting down* (${signal})`, SlackSeverity.INFO);
+  process.exit(0);
+}
+
+async function crash(label: string, cause: unknown): Promise<void> {
+  const error = asError(cause);
+  logger.error(`${label}:`, formatErrorWithCauses(error));
+  await notify(`🚨 *community-new crashed*\n\n${formatErrorWithCauses(error)}`, SlackSeverity.CRITICAL);
+  process.exit(1);
+}
+
+async function notify(message: string, severity: SlackSeverity): Promise<void> {
+  try {
+    await slackService.notifySlackStartOrCrash(message, severity);
+  } catch (error) {
+    logger.warn("Failed to send Slack notification:", error);
+  }
+}
+
+function parseGroupAddresses(raw: string | undefined, fallback: readonly string[]): string[] {
+  const values = raw
+    ? raw.split(",").map((value) => value.trim()).filter(Boolean)
+    : [...fallback];
+  if (values.length === 0) {
+    throw new Error("COMMUNITY_NEW_GROUP_ADDRESSES must include at least one address");
+  }
+  return Array.from(new Set(values.map((value) => getAddress(value).toLowerCase())));
+}
+
+function parsePositiveInt(name: string, fallback: number, max: number = Number.MAX_SAFE_INTEGER): number {
+  const raw = process.env[name];
+  const value = raw && raw.trim().length > 0 ? Number(raw) : fallback;
+  if (!Number.isInteger(value) || value <= 0 || value > max) {
+    throw new Error(`${name} must be an integer in [1, ${max}], received ${raw ?? value}`);
+  }
+  return value;
+}
+
+function asError(cause: unknown): Error {
+  return cause instanceof Error ? cause : new Error(String(cause));
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+void start().catch((cause) => crash("Startup failure", cause));

--- a/src/interfaces/IAffiliateGroupsRpc.ts
+++ b/src/interfaces/IAffiliateGroupsRpc.ts
@@ -1,0 +1,14 @@
+export type AffiliateGroupMember = {
+  avatarName: string | null;
+  avatarAddress: string;
+  timestamp: number;
+};
+
+/**
+ * Reads intent and confirmed community membership from the multi-affiliate RPC.
+ */
+export interface IAffiliateGroupsRpc {
+  fetchAllGroupMembersWishlist(groupAddress: string, pageSize?: number): Promise<AffiliateGroupMember[]>;
+  fetchAllGroupMembers(groupAddress: string, pageSize?: number): Promise<AffiliateGroupMember[]>;
+  fetchAffiliateGroupFeesPercentage(avatarAddress: string): Promise<number>;
+}

--- a/src/services/affiliateGroupsRpcService.ts
+++ b/src/services/affiliateGroupsRpcService.ts
@@ -1,0 +1,211 @@
+import {getAddress} from "ethers";
+
+import {
+  AffiliateGroupMember,
+  IAffiliateGroupsRpc
+} from "../interfaces/IAffiliateGroupsRpc";
+import {primaryRpcUrl} from "./rpcProvider";
+
+const DEFAULT_PAGE_SIZE = 500;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_PAGES = 500;
+
+type JsonRpcError = {
+  code?: unknown;
+  message?: unknown;
+};
+
+type JsonRpcResponse = {
+  result?: unknown;
+  error?: JsonRpcError;
+};
+
+type MembersPage = {
+  results: AffiliateGroupMember[];
+  hasMore: boolean;
+  nextCursor: string | null;
+};
+
+/**
+ * Raw JSON-RPC implementation used until rpc.affiliate.* is available in the
+ * published SDK version consumed by this repository.
+ */
+export class AffiliateGroupsRpcService implements IAffiliateGroupsRpc {
+  private requestId = 0;
+
+  constructor(
+    rpcUrl: string,
+    private readonly timeoutMs: number = DEFAULT_TIMEOUT_MS,
+    private readonly maxPages: number = DEFAULT_MAX_PAGES
+  ) {
+    this.rpcUrl = primaryRpcUrl(rpcUrl);
+    if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) {
+      throw new Error("Affiliate RPC timeout must be a positive integer");
+    }
+    if (!Number.isInteger(maxPages) || maxPages <= 0) {
+      throw new Error("Affiliate RPC maxPages must be a positive integer");
+    }
+  }
+
+  private readonly rpcUrl: string;
+
+  fetchAllGroupMembersWishlist(
+    groupAddress: string,
+    pageSize: number = DEFAULT_PAGE_SIZE
+  ): Promise<AffiliateGroupMember[]> {
+    return this.fetchAllMembers("circles_getAffiliateGroupMembersWishlist", groupAddress, pageSize);
+  }
+
+  fetchAllGroupMembers(
+    groupAddress: string,
+    pageSize: number = DEFAULT_PAGE_SIZE
+  ): Promise<AffiliateGroupMember[]> {
+    return this.fetchAllMembers("circles_getAffiliateGroupMembers", groupAddress, pageSize);
+  }
+
+  async fetchAffiliateGroupFeesPercentage(avatarAddress: string): Promise<number> {
+    const avatar = normalizeAddress(avatarAddress, "avatar");
+    const result = await this.call("circles_getAffiliateGroupFeesPercentage", [avatar]);
+    if (!isRecord(result)) {
+      throw new Error("circles_getAffiliateGroupFeesPercentage returned a non-object result");
+    }
+
+    const total = result.totalFeePercentage;
+    if (typeof total !== "number" || !Number.isFinite(total) || total < 0) {
+      throw new Error("circles_getAffiliateGroupFeesPercentage returned an invalid totalFeePercentage");
+    }
+    return total;
+  }
+
+  private async fetchAllMembers(
+    method: "circles_getAffiliateGroupMembersWishlist" | "circles_getAffiliateGroupMembers",
+    groupAddress: string,
+    pageSize: number
+  ): Promise<AffiliateGroupMember[]> {
+    const group = normalizeAddress(groupAddress, "group");
+    const limit = normalizePageSize(pageSize);
+    const members = new Map<string, AffiliateGroupMember>();
+    const seenCursors = new Set<string>();
+    let cursor: string | null = null;
+
+    for (let pageNumber = 1; pageNumber <= this.maxPages; pageNumber++) {
+      const params: unknown[] = cursor ? [group, limit, cursor] : [group, limit];
+      const page = parseMembersPage(await this.call(method, params), method);
+      for (const member of page.results) {
+        members.set(member.avatarAddress, member);
+      }
+
+      if (!page.hasMore) {
+        return Array.from(members.values());
+      }
+      if (!page.nextCursor) {
+        throw new Error(`${method} returned hasMore=true without nextCursor`);
+      }
+      if (seenCursors.has(page.nextCursor)) {
+        throw new Error(`${method} returned a repeated pagination cursor`);
+      }
+      seenCursors.add(page.nextCursor);
+      cursor = page.nextCursor;
+    }
+
+    throw new Error(`${method} exceeded the ${this.maxPages}-page safety limit`);
+  }
+
+  private async call(method: string, params: unknown[]): Promise<unknown> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    const id = ++this.requestId;
+
+    try {
+      const response = await fetch(this.rpcUrl, {
+        method: "POST",
+        headers: {"content-type": "application/json"},
+        body: JSON.stringify({jsonrpc: "2.0", id, method, params}),
+        signal: controller.signal
+      });
+      if (!response.ok) {
+        throw new Error(`${method} failed: HTTP ${response.status} ${response.statusText}`.trim());
+      }
+
+      const payload = await response.json() as JsonRpcResponse;
+      if (payload.error) {
+        const code = typeof payload.error.code === "number" ? ` ${payload.error.code}` : "";
+        const message = typeof payload.error.message === "string"
+          ? payload.error.message
+          : "unknown RPC error";
+        throw new Error(`${method} failed: RPC error${code}: ${message}`);
+      }
+      if (!("result" in payload)) {
+        throw new Error(`${method} failed: JSON-RPC response has no result`);
+      }
+      return payload.result;
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(`${method} timed out after ${this.timeoutMs}ms`, {cause: error});
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function parseMembersPage(value: unknown, method: string): MembersPage {
+  if (!isRecord(value) || !Array.isArray(value.results) || typeof value.hasMore !== "boolean") {
+    throw new Error(`${method} returned an invalid members page`);
+  }
+
+  const nextCursor = value.nextCursor;
+  if (nextCursor !== null && nextCursor !== undefined && typeof nextCursor !== "string") {
+    throw new Error(`${method} returned an invalid nextCursor`);
+  }
+
+  return {
+    results: value.results.map((member, index) => parseMember(member, method, index)),
+    hasMore: value.hasMore,
+    nextCursor: typeof nextCursor === "string" ? nextCursor : null
+  };
+}
+
+function parseMember(value: unknown, method: string, index: number): AffiliateGroupMember {
+  if (!isRecord(value)) {
+    throw new Error(`${method} returned a non-object member at index ${index}`);
+  }
+
+  const avatarName = value.avatarName;
+  const timestamp = value.timestamp;
+  if (avatarName !== null && typeof avatarName !== "string") {
+    throw new Error(`${method} returned an invalid avatarName at index ${index}`);
+  }
+  if (typeof value.avatarAddress !== "string") {
+    throw new Error(`${method} returned an invalid avatarAddress at index ${index}`);
+  }
+  if (typeof timestamp !== "number" || !Number.isInteger(timestamp) || timestamp < 0) {
+    throw new Error(`${method} returned an invalid timestamp at index ${index}`);
+  }
+
+  return {
+    avatarName,
+    avatarAddress: normalizeAddress(value.avatarAddress, `member at index ${index}`),
+    timestamp
+  };
+}
+
+function normalizeAddress(value: string, label: string): string {
+  try {
+    return getAddress(value).toLowerCase();
+  } catch (cause) {
+    throw new Error(`Invalid ${label} address: ${value}`, {cause});
+  }
+}
+
+function normalizePageSize(value: number): number {
+  if (!Number.isInteger(value) || value < 1 || value > 1000) {
+    throw new Error(`Affiliate RPC page size must be an integer in [1, 1000], received ${value}`);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tests/apps/community-new/groupProfileService.spec.ts
+++ b/tests/apps/community-new/groupProfileService.spec.ts
@@ -1,0 +1,55 @@
+import {CommunityGroupProfileService} from "../../../src/apps/community-new/groupProfileService";
+
+const RPC_URL = "https://rpc.staging.aboutcircles.com";
+const GROUP_A = "0x4e2564e5df6c1fb10c1a018538de36e4d5844de5";
+const GROUP_B = "0x2709757a543cf1bf4d92586b73d3891438b2589d";
+
+function response(result: unknown): Partial<Response> {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({jsonrpc: "2.0", id: 1, result})
+  };
+}
+
+describe("CommunityGroupProfileService", () => {
+  it("loads nested membershipCriteria.minRepScore values from the Circles RPC", async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue(response([
+      {address: GROUP_A, membershipCriteria: {minRepScore: 30, membershipFee: 5}},
+      {address: GROUP_B, membershipCriteria: {minRepScore: "50", membershipFee: null}}
+    ]));
+    const service = new CommunityGroupProfileService(RPC_URL);
+
+    await expect(service.fetchMinRepScores([GROUP_A, GROUP_B])).resolves.toEqual({
+      [GROUP_A]: 30,
+      [GROUP_B]: 50
+    });
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      method: "circles_getProfileByAddressBatch",
+      params: [[GROUP_A, GROUP_B]]
+    });
+  });
+
+  it("fails closed when a managed profile has no valid reputation requirement", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(response([
+      {address: GROUP_A, membershipCriteria: {membershipFee: 5}}
+    ]));
+    const service = new CommunityGroupProfileService(RPC_URL);
+
+    await expect(service.fetchMinRepScores([GROUP_A]))
+      .rejects
+      .toThrow("does not include a valid membershipCriteria.minRepScore");
+  });
+
+  it("fails when the batch response does not cover every managed group", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(response([null]));
+    const service = new CommunityGroupProfileService(RPC_URL);
+
+    await expect(service.fetchMinRepScores([GROUP_A]))
+      .rejects
+      .toThrow(`No group profile found for ${GROUP_A}`);
+  });
+});

--- a/tests/apps/community-new/logic.spec.ts
+++ b/tests/apps/community-new/logic.spec.ts
@@ -1,0 +1,173 @@
+import {AffiliateGroupMember, IAffiliateGroupsRpc} from "../../../src/interfaces/IAffiliateGroupsRpc";
+import {
+  CommunityRunConfig,
+  runCommunityReconciliation
+} from "../../../src/apps/community-new/logic";
+import {IReputationService, ReputationVerdict} from "../../../src/apps/group-affiliates/reputationService";
+import {FakeGroupService, FakeLogger} from "../../../fakes/fakes";
+import {FakeCirclesRpc} from "../../../fakes/fakes";
+
+const GROUP_A = "0x4e2564e5df6c1fb10c1a018538de36e4d5844de5";
+const GROUP_B = "0x2709757a543cf1bf4d92586b73d3891438b2589d";
+const ELIGIBLE = "0x1000000000000000000000000000000000000001";
+const EXISTING = "0x2000000000000000000000000000000000000002";
+const LOW_SCORE = "0x3000000000000000000000000000000000000003";
+const OVER_FEE_CAP = "0x4000000000000000000000000000000000000004";
+const STALE_CONFIRMED = "0x5000000000000000000000000000000000000005";
+
+class FakeAffiliateRpc implements IAffiliateGroupsRpc {
+  wishlistByGroup: Record<string, string[]> = {};
+  feesByAvatar: Record<string, number> = {};
+  feeRequests: string[] = [];
+
+  async fetchAllGroupMembersWishlist(groupAddress: string): Promise<AffiliateGroupMember[]> {
+    return (this.wishlistByGroup[groupAddress] ?? []).map(member);
+  }
+
+  async fetchAllGroupMembers(groupAddress: string): Promise<AffiliateGroupMember[]> {
+    return [];
+  }
+
+  async fetchAffiliateGroupFeesPercentage(avatarAddress: string): Promise<number> {
+    this.feeRequests.push(avatarAddress);
+    const fee = this.feesByAvatar[avatarAddress];
+    if (fee === undefined) throw new Error(`No fake fee for ${avatarAddress}`);
+    return fee;
+  }
+}
+
+class FakeReputation implements IReputationService {
+  scores = new Map<string, number | null>();
+
+  async check(addresses: string[], threshold: number): Promise<Map<string, ReputationVerdict>> {
+    return new Map(addresses.map((address) => {
+      const score = this.scores.get(address) ?? null;
+      return [address, {
+        address,
+        reputationScore: score,
+        eligible: score !== null && score > threshold
+      }];
+    }));
+  }
+}
+
+function member(avatarAddress: string): AffiliateGroupMember {
+  return {avatarName: null, avatarAddress, timestamp: 123};
+}
+
+function config(overrides: Partial<CommunityRunConfig> = {}): CommunityRunConfig {
+  return {
+    managedGroupAddresses: [GROUP_A],
+    minRepScoresByGroup: {[GROUP_A]: 40},
+    pageSize: 500,
+    batchSize: 20,
+    feeFetchConcurrency: 2,
+    ...overrides
+  };
+}
+
+function setup() {
+  return {
+    affiliateRpc: new FakeAffiliateRpc(),
+    circlesRpc: new FakeCirclesRpc(),
+    reputationService: new FakeReputation(),
+    groupService: new FakeGroupService(),
+    logger: new FakeLogger()
+  };
+}
+
+describe("runCommunityReconciliation", () => {
+  it("trusts only wishlist members that pass the group threshold and aggregate fee cap", async () => {
+    const deps = setup();
+    deps.affiliateRpc.wishlistByGroup[GROUP_A] = [ELIGIBLE, EXISTING, LOW_SCORE, OVER_FEE_CAP];
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [EXISTING, LOW_SCORE, OVER_FEE_CAP];
+    deps.affiliateRpc.feesByAvatar = {
+      [ELIGIBLE]: 100,
+      [EXISTING]: 20,
+      [LOW_SCORE]: 10,
+      [OVER_FEE_CAP]: 101
+    };
+    deps.reputationService.scores = new Map([
+      [ELIGIBLE, 41],
+      [EXISTING, 90],
+      [LOW_SCORE, 40],
+      [OVER_FEE_CAP, 90]
+    ]);
+
+    const outcome = await runCommunityReconciliation(deps, config());
+
+    expect(outcome.trustedByGroup[GROUP_A]).toEqual([ELIGIBLE]);
+    expect(outcome.untrustedByGroup[GROUP_A]).toEqual([LOW_SCORE, OVER_FEE_CAP]);
+    expect(outcome.ineligible).toEqual([
+      expect.objectContaining({avatarAddress: LOW_SCORE, reasons: ["reputation"]}),
+      expect.objectContaining({avatarAddress: OVER_FEE_CAP, reasons: ["fee-cap"]})
+    ]);
+    expect(deps.groupService.calls).toEqual([
+      {type: "untrust", groupAddress: GROUP_A, trusteeAddresses: [LOW_SCORE, OVER_FEE_CAP]},
+      {type: "trust", groupAddress: GROUP_A, trusteeAddresses: [ELIGIBLE]}
+    ]);
+  });
+
+  it("uses each group's minRepScore and fetches aggregate fees once per avatar", async () => {
+    const deps = setup();
+    deps.affiliateRpc.wishlistByGroup = {
+      [GROUP_A]: [ELIGIBLE],
+      [GROUP_B]: [ELIGIBLE]
+    };
+    deps.affiliateRpc.feesByAvatar[ELIGIBLE] = 99;
+    deps.reputationService.scores.set(ELIGIBLE, 50);
+
+    const outcome = await runCommunityReconciliation(deps, config({
+      managedGroupAddresses: [GROUP_A, GROUP_B],
+      minRepScoresByGroup: {[GROUP_A]: 40, [GROUP_B]: 50}
+    }));
+
+    expect(outcome.trustedByGroup[GROUP_A]).toEqual([ELIGIBLE]);
+    expect(outcome.trustedByGroup[GROUP_B]).toEqual([]);
+    expect(outcome.ineligible).toEqual([
+      expect.objectContaining({groupAddress: GROUP_B, avatarAddress: ELIGIBLE, reasons: ["reputation"]})
+    ]);
+    expect(deps.affiliateRpc.feeRequests).toEqual([ELIGIBLE]);
+  });
+
+  it("untrusts a current trustee removed from the wishlist regardless of criteria", async () => {
+    const deps = setup();
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [STALE_CONFIRMED];
+
+    const outcome = await runCommunityReconciliation(deps, config());
+
+    expect(outcome.leftByGroup[GROUP_A]).toEqual([STALE_CONFIRMED]);
+    expect(outcome.untrustedByGroup[GROUP_A]).toEqual([STALE_CONFIRMED]);
+    expect(outcome.ineligible).toEqual([]);
+    expect(deps.groupService.calls).toEqual([
+      {type: "untrust", groupAddress: GROUP_A, trusteeAddresses: [STALE_CONFIRMED]}
+    ]);
+  });
+
+  it("simulates dry-run batches without submitting writes", async () => {
+    const deps = setup();
+    deps.affiliateRpc.wishlistByGroup[GROUP_A] = [ELIGIBLE, EXISTING];
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [LOW_SCORE];
+    deps.affiliateRpc.feesByAvatar = {[ELIGIBLE]: 0, [EXISTING]: 0};
+    deps.reputationService.scores = new Map([[ELIGIBLE, 90], [EXISTING, 90]]);
+
+    const outcome = await runCommunityReconciliation(deps, config({batchSize: 1, dryRun: true}));
+
+    expect(outcome.trustedByGroup[GROUP_A]).toEqual([ELIGIBLE, EXISTING]);
+    expect(deps.groupService.calls).toEqual([]);
+    expect(deps.groupService.simulations).toEqual([
+      {type: "untrust", groupAddress: GROUP_A, trusteeAddresses: [LOW_SCORE]},
+      {type: "trust", groupAddress: GROUP_A, trusteeAddresses: [ELIGIBLE]},
+      {type: "trust", groupAddress: GROUP_A, trusteeAddresses: [EXISTING]}
+    ]);
+  });
+
+  it("fails closed before writes when a managed group has no loaded requirement", async () => {
+    const deps = setup();
+
+    await expect(runCommunityReconciliation(deps, config({minRepScoresByGroup: {}})))
+      .rejects
+      .toThrow(`No minRepScore was loaded for managed group ${GROUP_A}`);
+    expect(deps.groupService.calls).toEqual([]);
+  });
+});

--- a/tests/services/affiliateGroupsRpcService.spec.ts
+++ b/tests/services/affiliateGroupsRpcService.spec.ts
@@ -1,0 +1,97 @@
+import {AffiliateGroupsRpcService} from "../../src/services/affiliateGroupsRpcService";
+
+const RPC_URL = "https://rpc.staging.aboutcircles.com";
+const GROUP = "0x4e2564e5df6c1fb10c1a018538de36e4d5844de5";
+const AVATAR_A = "0x1000000000000000000000000000000000000001";
+const AVATAR_B = "0x2000000000000000000000000000000000000002";
+
+function rpcResponse(result: unknown): Partial<Response> {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: async () => ({jsonrpc: "2.0", id: 1, result})
+  };
+}
+
+describe("AffiliateGroupsRpcService", () => {
+  it("paginates the group wishlist using opaque cursors", async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockResolvedValueOnce(rpcResponse({
+        results: [{avatarName: "A", avatarAddress: AVATAR_A, timestamp: 10}],
+        hasMore: true,
+        nextCursor: "opaque-page-2"
+      }))
+      .mockResolvedValueOnce(rpcResponse({
+        results: [{avatarName: null, avatarAddress: AVATAR_B, timestamp: 9}],
+        hasMore: false,
+        nextCursor: null
+      }));
+    const service = new AffiliateGroupsRpcService(RPC_URL);
+
+    await expect(service.fetchAllGroupMembersWishlist(GROUP, 50)).resolves.toEqual([
+      {avatarName: "A", avatarAddress: AVATAR_A, timestamp: 10},
+      {avatarName: null, avatarAddress: AVATAR_B, timestamp: 9}
+    ]);
+    const firstBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const secondBody = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(firstBody).toMatchObject({
+      method: "circles_getAffiliateGroupMembersWishlist",
+      params: [GROUP, 50]
+    });
+    expect(secondBody.params).toEqual([GROUP, 50, "opaque-page-2"]);
+  });
+
+  it("reads and validates an avatar's aggregate wishlist fee", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(rpcResponse({totalFeePercentage: 100}));
+    const service = new AffiliateGroupsRpcService(RPC_URL);
+
+    await expect(service.fetchAffiliateGroupFeesPercentage(AVATAR_A)).resolves.toBe(100);
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      method: "circles_getAffiliateGroupFeesPercentage",
+      params: [AVATAR_A]
+    });
+  });
+
+  it("surfaces JSON-RPC errors instead of treating them as empty results", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        jsonrpc: "2.0",
+        id: 1,
+        error: {code: -32601, message: "Method not found"}
+      })
+    });
+    const service = new AffiliateGroupsRpcService(RPC_URL);
+
+    await expect(service.fetchAllGroupMembers(GROUP))
+      .rejects
+      .toThrow("RPC error -32601: Method not found");
+  });
+
+  it("rejects a broken pagination response that could otherwise loop forever", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(rpcResponse({
+      results: [],
+      hasMore: true,
+      nextCursor: null
+    }));
+    const service = new AffiliateGroupsRpcService(RPC_URL);
+
+    await expect(service.fetchAllGroupMembersWishlist(GROUP))
+      .rejects
+      .toThrow("hasMore=true without nextCursor");
+  });
+
+  it("rejects invalid local addresses before issuing a request", async () => {
+    const service = new AffiliateGroupsRpcService(RPC_URL);
+
+    await expect(service.fetchAffiliateGroupFeesPercentage("not-an-address"))
+      .rejects
+      .toThrow("Invalid avatar address");
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `community-new`, a TMS for Circles Community 2.0 multi-affiliate membership reconciliation.

The service reads community intent from the affiliate wishlist RPC, evaluates membership requirements, and reconciles each managed group’s on-chain trust list.

## Behavior

For every configured community group, the service:

- Fetches the complete paginated membership wishlist.
- Fetches current on-chain trustees.
- Loads `membershipCriteria.minRepScore` from the group profile.
- Fetches each applicant’s aggregate community fee.
- Trusts members when:
  - `reputation_score > minRepScore`
  - `totalFeePercentage <= 100`
- Untrusts current trustees who:
  - removed the group from their wishlist, or
  - no longer satisfy reputation or fee requirements.

Untrust batches are executed before trust batches.