### PR TITLE
refactor(community-new): rename affiliate-group RPC calls to community methods

### DIFF
--- a/src/services/affiliateGroupsRpcService.ts
+++ b/src/services/affiliateGroupsRpcService.ts
@@ -69,32 +69,32 @@ export class AffiliateGroupsRpcService implements IAffiliateGroupsRpc {
     groupAddress: string,
     pageSize: number = DEFAULT_PAGE_SIZE
   ): Promise<AffiliateGroupMember[]> {
-    return this.fetchAllMembers("circles_getAffiliateGroupMembersWishlist", groupAddress, pageSize);
+    return this.fetchAllMembers("circles_getCommunityMembersWishlist", groupAddress, pageSize);
   }
 
   fetchAllGroupMembers(
     groupAddress: string,
     pageSize: number = DEFAULT_PAGE_SIZE
   ): Promise<AffiliateGroupMember[]> {
-    return this.fetchAllMembers("circles_getAffiliateGroupMembers", groupAddress, pageSize);
+    return this.fetchAllMembers("circles_getCommunityMembers", groupAddress, pageSize);
   }
 
   async fetchAffiliateGroupFeesPercentage(avatarAddress: string): Promise<number> {
     const avatar = normalizeAddress(avatarAddress, "avatar");
-    const result = await this.call("circles_getAffiliateGroupFeesPercentage", [avatar]);
+    const result = await this.call("circles_getAvatarCommunityFeesPercentage", [avatar]);
     if (!isRecord(result)) {
-      throw new Error("circles_getAffiliateGroupFeesPercentage returned a non-object result");
+      throw new Error("circles_getAvatarCommunityFeesPercentage returned a non-object result");
     }
 
     const total = result.totalFeePercentage;
     if (typeof total !== "number" || !Number.isFinite(total) || total < 0) {
-      throw new Error("circles_getAffiliateGroupFeesPercentage returned an invalid totalFeePercentage");
+      throw new Error("circles_getAvatarCommunityFeesPercentage returned an invalid totalFeePercentage");
     }
     return total;
   }
 
   private async fetchAllMembers(
-    method: "circles_getAffiliateGroupMembersWishlist" | "circles_getAffiliateGroupMembers",
+    method: "circles_getCommunityMembersWishlist" | "circles_getCommunityMembers",
     groupAddress: string,
     pageSize: number
   ): Promise<AffiliateGroupMember[]> {

--- a/tests/services/affiliateGroupsRpcService.spec.ts
+++ b/tests/services/affiliateGroupsRpcService.spec.ts
@@ -37,7 +37,7 @@ describe("AffiliateGroupsRpcService", () => {
     const firstBody = JSON.parse(fetchMock.mock.calls[0][1].body);
     const secondBody = JSON.parse(fetchMock.mock.calls[1][1].body);
     expect(firstBody).toMatchObject({
-      method: "circles_getAffiliateGroupMembersWishlist",
+      method: "circles_getCommunityMembersWishlist",
       params: [GROUP, 50]
     });
     expect(secondBody.params).toEqual([GROUP, 50, "opaque-page-2"]);
@@ -50,7 +50,7 @@ describe("AffiliateGroupsRpcService", () => {
     await expect(service.fetchAffiliateGroupFeesPercentage(AVATAR_A)).resolves.toBe(100);
     const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
     expect(body).toMatchObject({
-      method: "circles_getAffiliateGroupFeesPercentage",
+      method: "circles_getAvatarCommunityFeesPercentage",
       params: [AVATAR_A]
     });
   });


### PR DESCRIPTION
Renames the 3 multi-affiliate-group RPC methods `community-new` calls to the community vocabulary, matching the plugin rename.

- `circles_getAffiliateGroupMembersWishlist` → `circles_getCommunityMembersWishlist`
- `circles_getAffiliateGroupMembers` → `circles_getCommunityMembers`
- `circles_getAffiliateGroupFeesPercentage` → `circles_getAvatarCommunityFeesPercentage`

Response fields read (`avatarAddress`/`avatarName`, `totalFeePercentage`) are unchanged, so no field-access changes. Internal identifiers and the on-chain `AffiliateGroupChanged` listener are left as-is.

## Test plan
- [x] `tsc` build: 0 errors
- [x] full suite: 479/479 pass