### PR TITLE
community-new: old/hybrid/new membership modes for the group-affiliates cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,15 +331,60 @@ VERBOSE_LOGGING=1
 ### Community New App Configuration
 
 ```dotenv
-# New multi-affiliate reads. Keep this separate from RPC_URL while the methods
-# are staging-only; RPC_URL is used for group contract reads and Safe writes.
-COMMUNITY_NEW_RPC_URL=https://rpc.staging.aboutcircles.com
+# Chain reads (getLogs, eth_blockNumber) and Safe writes.
 RPC_URL=https://rpc.aboutcircles.com/
 TX_RPC_URL=https://your-write-rpc.example/       # optional
+# Only used by MEMBERSHIP_SOURCE=rpc (staging-only wishlist methods).
+COMMUNITY_NEW_RPC_URL=https://rpc.staging.aboutcircles.com
 
-# Comma-separated groups managed by this worker. Defaults to the three
-# existing Group Affiliates managed groups when omitted.
+# Comma-separated groups managed by this worker (BaseGroups). Defaults to the
+# three featured community groups when omitted. Do NOT list a ScoreGroup here —
+# ScoreGroups are append-only and untrust would revert.
 COMMUNITY_NEW_GROUP_ADDRESSES=0x4E2564e5df6C1Fb10C1A018538de36E4D5844DE5,0x2709757a543CF1BF4d92586b73d3891438b2589d,0xEEcAe593589a6eE4a12AE64F19420B47F3112Fa9
+
+# --- Membership source: where the worker reads group intent from ---
+#   rpc     — staging-only wishlist RPC (dev/staging only).
+#   old     — OLD single-slot registry (0xca8222) via AffiliateGroupChanged;
+#             byte-identical to group-affiliates (prod parity baseline).
+#   hybrid  — OLD registry for everyone EXCEPT COMMUNITY_NEW_TEST_ADDRESSES,
+#             who are governed by the NEW multi registry (multi-group testing).
+#   new     — NEW multi registry (0x4a25a7cf) for everyone (final GA state).
+COMMUNITY_NEW_MEMBERSHIP_SOURCE=old
+
+# Test-dev allowlist (hybrid only): these avatars read from the NEW registry.
+COMMUNITY_NEW_TEST_ADDRESSES=
+# Cold-start dev addresses have reputation 0; opt-in to bypass the rep gate for
+# the allowlist so they can be trusted during testing. NEVER set for real users.
+COMMUNITY_NEW_TEST_BYPASS_REPUTATION=0
+
+# OLD registry (old/hybrid). Reconciliation is poll-gated (each poll refreshes the
+# map before reading it), so WSS only keeps the map warm between polls — for lower
+# trust latency, lower COMMUNITY_NEW_POLL_INTERVAL_MS rather than relying on WSS.
+COMMUNITY_NEW_OLD_REGISTRY_ADDRESS=0xca8222e780d046707083f51377b5fd85e2866014
+COMMUNITY_NEW_OLD_REGISTRY_START_BLOCK=46282003
+COMMUNITY_NEW_OLD_ENABLE_WSS=0
+COMMUNITY_NEW_OLD_WSS_URL=                        # optional; else derived from RPC_URL
+
+# NEW registry (new/hybrid).
+COMMUNITY_NEW_REGISTRY_ADDRESS=0x4a25a7cf216351963f1637ad965d77b3ae277ef3
+COMMUNITY_NEW_REGISTRY_DEPLOY_BLOCK=46891940
+COMMUNITY_NEW_ENABLE_WSS=0
+COMMUNITY_NEW_WSS_URL=                            # optional; else derived from RPC_URL
+
+# Persistence for the on-chain maps (block cursor + membership). Historical name;
+# it is just the shared state-DB DSN. Required for old/hybrid/new persistence.
+LEADER_DB_URL=
+
+# Untrust policy + safety. Default is `wishlist` (authoritative) in old/hybrid to
+# match group-affiliates, else `add-only`. The circuit breaker aborts a wet run
+# whose untrust set is implausibly large (guards a bad rescan).
+COMMUNITY_NEW_UNTRUST_MODE=                       # add-only|union|wishlist (per-mode default)
+COMMUNITY_NEW_MAX_UNTRUST_TOTAL=20
+COMMUNITY_NEW_MAX_UNTRUST_RATIO=0.5               # (0,1]
+
+# Cutover gate: community-new shares the Safe/signer with group-affiliates. Must
+# retire group-affiliates for these groups first, then set this to run wet.
+COMMUNITY_NEW_ACK_GROUP_AFFILIATES_RETIRED=0
 
 # One Safe must be the service for every configured group.
 COMMUNITY_NEW_SAFE_ADDRESS=
@@ -347,7 +392,7 @@ COMMUNITY_NEW_SAFE_SIGNER_PRIVATE_KEY=
 COMMUNITY_NEW_SIGNER_ADDRESS=                    # optional key/address validation
 
 # Reconciliation and RPC pagination
-COMMUNITY_NEW_POLL_INTERVAL_MS=600000
+COMMUNITY_NEW_POLL_INTERVAL_MS=600000            # lower (~60000) on prod for near-realtime
 COMMUNITY_NEW_PAGE_SIZE=500                      # 1..1000
 COMMUNITY_NEW_BATCH_SIZE=20
 COMMUNITY_NEW_FEE_FETCH_CONCURRENCY=2
@@ -355,10 +400,14 @@ COMMUNITY_NEW_RPC_TIMEOUT_MS=30000
 COMMUNITY_NEW_RPC_MAX_PAGES=500
 COMMUNITY_NEW_ERRORS_BEFORE_CRASH=5
 
-# Group criteria and reputation lookups
+# Group criteria and reputation lookups. The fee cap uses a staging-only RPC and
+# is only enforced in `rpc` mode; old/hybrid/new run with no fee cap (parity with
+# group-affiliates). In prod the reputation base URL is set to the in-network,
+# address-indexed endpoint (…/groups/0x93ed5a96…/avatars) so a slug rename cannot
+# 404 it; the public `score_group_v2` slug below is the code default fallback.
 COMMUNITY_NEW_PROFILE_TIMEOUT_MS=30000
 COMMUNITY_NEW_REPUTATION_BASE_URL=                 # required only when bulk mode is disabled
-COMMUNITY_NEW_REPUTATION_SCORES_URL=https://rpc.aboutcircles.com/analytics/rep_score/groups/score_group/scores
+COMMUNITY_NEW_REPUTATION_SCORES_URL=https://rpc.aboutcircles.com/analytics/rep_score/groups/score_group_v2/scores
 COMMUNITY_NEW_REPUTATION_BULK=1
 COMMUNITY_NEW_REPUTATION_TIMEOUT_MS=30000
 COMMUNITY_NEW_REPUTATION_SNAPSHOT_TTL_MS=600000
@@ -370,6 +419,12 @@ SLACK_WEBHOOK_URL=
 SLACK_WEBHOOK_URL_INFO=
 VERBOSE_LOGGING=1
 ```
+
+**prod1 cutover (replaces group-affiliates — same Safe, so only one runs wet):**
+1. Deploy `MEMBERSHIP_SOURCE=old`, `DRY_RUN=1`; run `npm run diff:community-new` and confirm the untrust set is empty/expected.
+2. Stop group-affiliates → set `COMMUNITY_NEW_ACK_GROUP_AFFILIATES_RETIRED=1`, `DRY_RUN=0` (still `old`). Verify trust/untrust matches the prior worker.
+3. Switch to `hybrid` with `COMMUNITY_NEW_TEST_ADDRESSES=…` (+ `COMMUNITY_NEW_TEST_BYPASS_REPUTATION=1` for cold-start dev addresses) to exercise multi-group.
+4. GA: switch to `new` for full multi-membership.
 
 ### Gnosis Group App Configuration
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start:community-new": "node --env-file=.env dist/src/apps/community-new/main.js",
     "start:new-gnosis": "node --env-file=.env dist/src/apps/new-gnosis/main.js",
     "start:all": "node --env-file=.env dist/src/apps/manager.js",
+    "diff:community-new": "node --env-file=.env dist/src/apps/community-new/tools/evictionDiff.js",
     "test": "jest --config jest.config.ts",
     "test:coverage": "jest --config jest.config.ts --coverage",
     "test:integration": "jest --config jest.integration.config.ts --verbose"

--- a/src/apps/community-new/affiliateMultiMap.ts
+++ b/src/apps/community-new/affiliateMultiMap.ts
@@ -1,0 +1,162 @@
+import {getAddress} from "ethers";
+
+import {StateStore} from "../../services/stateStore";
+
+/**
+ * Persistent MULTI-membership index built from the NEW MultiAffiliateGroupRegistry
+ * (`0x4a25a7cf…`) `AffiliateGroupAdded` / `AffiliateGroupRemoved` events.
+ *
+ * Unlike group-affiliates' single-slot {@link AffiliateMap} (one group per human),
+ * an avatar here belongs to MANY groups at once — mirroring the on-chain
+ * per-avatar linked list. Maintained by history backfill on boot and kept current
+ * by the realtime WSS listener; consumed by the reconciler as the membership
+ * source so community-new no longer depends on the staging-only wishlist RPC.
+ *
+ * Not a security boundary: a stale/incomplete map can only under-report members
+ * (fail to trust), never over-untrust — untrust decisions remain gated by the
+ * reconciler's mode + circuit breaker.
+ */
+export type AffiliateMultiMapSnapshot = {
+  /** Highest block whose registry events have been reduced into the map. */
+  lastScannedBlock: number;
+  /** Lowercased avatar → sorted list of lowercased affiliate group addresses. */
+  entries: Record<string, string[]>;
+};
+
+export class AffiliateMultiMap {
+  private readonly avatarToGroups = new Map<string, Set<string>>();
+  private readonly groupToAvatars = new Map<string, Set<string>>();
+  private _lastScannedBlock: number;
+  private _dirty = false;
+
+  constructor(lastScannedBlock = 0) {
+    this._lastScannedBlock = lastScannedBlock;
+  }
+
+  static fromSnapshot(snapshot: AffiliateMultiMapSnapshot): AffiliateMultiMap {
+    const map = new AffiliateMultiMap(snapshot.lastScannedBlock);
+    for (const [avatar, groups] of Object.entries(snapshot.entries ?? {})) {
+      for (const group of groups ?? []) {
+        map.link(avatar, group);
+      }
+    }
+    map._dirty = false;
+    return map;
+  }
+
+  /** Apply an `AffiliateGroupAdded(group, avatar)` event. */
+  add(avatar: string, group: string, observedAtBlock?: number): void {
+    if (this.link(avatar, group)) this._dirty = true;
+    this.maybeAdvanceCursor(observedAtBlock);
+  }
+
+  /** Apply an `AffiliateGroupRemoved(group, avatar)` event. */
+  remove(avatar: string, group: string, observedAtBlock?: number): void {
+    if (this.unlink(avatar, group)) this._dirty = true;
+    this.maybeAdvanceCursor(observedAtBlock);
+  }
+
+  /** Groups the avatar currently belongs to. */
+  getGroups(avatar: string): string[] {
+    const normalized = normalize(avatar);
+    if (!normalized) return [];
+    const set = this.avatarToGroups.get(normalized);
+    return set ? Array.from(set).sort() : [];
+  }
+
+  /** Avatars that currently belong to the group (the on-chain wishlist equivalent). */
+  getMembersOf(group: string): Set<string> {
+    const normalized = normalize(group);
+    if (!normalized) return new Set<string>();
+    return new Set(this.groupToAvatars.get(normalized) ?? []);
+  }
+
+  get lastScannedBlock(): number {
+    return this._lastScannedBlock;
+  }
+
+  get dirty(): boolean {
+    return this._dirty;
+  }
+
+  advanceCursor(blockNumber: number): void {
+    if (blockNumber > this._lastScannedBlock) {
+      this._lastScannedBlock = blockNumber;
+      this._dirty = true;
+    }
+  }
+
+  snapshot(): AffiliateMultiMapSnapshot {
+    const entries: Record<string, string[]> = {};
+    for (const [avatar, groups] of this.avatarToGroups) {
+      entries[avatar] = Array.from(groups).sort();
+    }
+    return {lastScannedBlock: this._lastScannedBlock, entries};
+  }
+
+  async save(stateStore: StateStore, appName: string): Promise<void> {
+    if (!this._dirty) return;
+    await stateStore.save(appName, this._lastScannedBlock, this.snapshot() as unknown as Record<string, unknown>);
+    this._dirty = false;
+  }
+
+  static async load(stateStore: StateStore, appName: string): Promise<AffiliateMultiMap | null> {
+    const persisted = await stateStore.load(appName);
+    if (!persisted) return null;
+    const data = persisted.data as Partial<AffiliateMultiMapSnapshot> | undefined;
+    const entries = data && typeof data.entries === "object" && data.entries !== null
+      ? data.entries as Record<string, string[]>
+      : {};
+    return AffiliateMultiMap.fromSnapshot({lastScannedBlock: persisted.lastScannedBlock, entries});
+  }
+
+  private link(avatar: string, group: string): boolean {
+    const a = normalize(avatar);
+    const g = normalize(group);
+    if (!a || !g) return false;
+    let groups = this.avatarToGroups.get(a);
+    if (!groups) {
+      groups = new Set<string>();
+      this.avatarToGroups.set(a, groups);
+    }
+    if (groups.has(g)) return false;
+    groups.add(g);
+    let avatars = this.groupToAvatars.get(g);
+    if (!avatars) {
+      avatars = new Set<string>();
+      this.groupToAvatars.set(g, avatars);
+    }
+    avatars.add(a);
+    return true;
+  }
+
+  private unlink(avatar: string, group: string): boolean {
+    const a = normalize(avatar);
+    const g = normalize(group);
+    if (!a || !g) return false;
+    const groups = this.avatarToGroups.get(a);
+    if (!groups || !groups.has(g)) return false;
+    groups.delete(g);
+    if (groups.size === 0) this.avatarToGroups.delete(a);
+    const avatars = this.groupToAvatars.get(g);
+    if (avatars) {
+      avatars.delete(a);
+      if (avatars.size === 0) this.groupToAvatars.delete(g);
+    }
+    return true;
+  }
+
+  private maybeAdvanceCursor(blockNumber?: number): void {
+    if (typeof blockNumber === "number" && blockNumber > this._lastScannedBlock) {
+      this._lastScannedBlock = blockNumber;
+    }
+  }
+}
+
+function normalize(address: string): string | null {
+  try {
+    return getAddress(address).toLowerCase();
+  } catch {
+    return null;
+  }
+}

--- a/src/apps/community-new/logic.ts
+++ b/src/apps/community-new/logic.ts
@@ -48,6 +48,15 @@ export type CommunityRunConfig = {
   batchSize: number;
   feeFetchConcurrency: number;
   maxTotalFeePercentage?: number;
+  /**
+   * Whether to fetch + enforce the per-member affiliate fee cap. Default true.
+   * The fee data comes from `circles_getAffiliateGroupFeesPercentage`, which is
+   * only served on the staging RPC. On prod (old/hybrid/new membership sources)
+   * this must be false — group-affiliates has no fee cap, and calling the missing
+   * method would throw. When false, fees are treated as unbounded (never a reason
+   * for ineligibility) and the fee RPC is never called.
+   */
+  feeCapEnabled?: boolean;
   dryRun?: boolean;
   /** How wishlist-absent trustees are handled. Default {@link DEFAULT_UNTRUST_MODE} (add-only). */
   untrustMode?: UntrustMode;
@@ -64,6 +73,13 @@ export type CommunityRunConfig = {
    * staging-only `circles_getAffiliateGroupMembersWishlist` method.
    */
   wishlistOverrideByGroup?: Record<string, ReadonlySet<string>>;
+  /**
+   * Avatars exempt from the reputation gate (test-dev allowlist). Used during the
+   * hybrid test period so fresh dev addresses (reputation 0, cold-start) can
+   * exercise the new multi-group flow without a qualifying score. The fee cap is
+   * already off in the modes this is used in. NEVER set this for real users.
+   */
+  reputationBypassAddresses?: ReadonlySet<string>;
 };
 
 export type CommunityRunDeps = {
@@ -127,11 +143,15 @@ export async function runCommunityReconciliation(
   if (!Number.isFinite(maxTotalFeePercentage) || maxTotalFeePercentage < 0) {
     throw new Error(`maxTotalFeePercentage must be a finite non-negative number, received ${maxTotalFeePercentage}`);
   }
+  const feeCapEnabled = cfg.feeCapEnabled ?? true;
   const untrustMode = cfg.untrustMode ?? DEFAULT_UNTRUST_MODE;
   const maxUntrustTotal = cfg.maxUntrustTotal ?? DEFAULT_MAX_UNTRUST_TOTAL;
   const maxUntrustRatioPerGroup = cfg.maxUntrustRatioPerGroup ?? DEFAULT_MAX_UNTRUST_RATIO_PER_GROUP;
   const protectedTrusteesByGroup = normalizeProtectedTrustees(cfg.protectedTrusteesByGroup);
   const wishlistOverrideByGroup = normalizeProtectedTrustees(cfg.wishlistOverrideByGroup);
+  const reputationBypass = new Set(
+    Array.from(cfg.reputationBypassAddresses ?? []).map(normalizeAddress)
+  );
 
   const snapshots = await Promise.all(groups.map(async (groupAddress): Promise<GroupSnapshot> => {
     const wishlistOverride = wishlistOverrideByGroup.get(groupAddress);
@@ -156,7 +176,9 @@ export async function runCommunityReconciliation(
     allWishlistAddresses.length > 0
       ? deps.reputationService.check(allWishlistAddresses, 0)
       : new Map(),
-    fetchFeePercentages(deps.affiliateRpc, allWishlistAddresses, feeFetchConcurrency)
+    feeCapEnabled
+      ? fetchFeePercentages(deps.affiliateRpc, allWishlistAddresses, feeFetchConcurrency)
+      : Promise.resolve(new Map<string, number>())
   ]);
 
   const wishlistMembersByGroup: Record<string, number> = {};
@@ -175,16 +197,17 @@ export async function runCommunityReconciliation(
     for (const avatarAddress of snapshot.wishlist) {
       const verdict = reputationVerdicts.get(avatarAddress);
       const reputationScore = verdict?.reputationScore ?? null;
-      const totalFeePercentage = feePercentages.get(avatarAddress);
-      if (totalFeePercentage === undefined) {
+      const feeResult = feePercentages.get(avatarAddress);
+      if (feeCapEnabled && feeResult === undefined) {
         throw new Error(`Missing aggregate fee result for ${avatarAddress}`);
       }
+      const totalFeePercentage = feeResult ?? 0;
 
       const reasons: EligibilityFailure["reasons"] = [];
-      if (reputationScore === null || reputationScore <= threshold) {
+      if (!reputationBypass.has(avatarAddress) && (reputationScore === null || reputationScore <= threshold)) {
         reasons.push("reputation");
       }
-      if (totalFeePercentage > maxTotalFeePercentage) {
+      if (feeCapEnabled && totalFeePercentage > maxTotalFeePercentage) {
         reasons.push("fee-cap");
       }
 

--- a/src/apps/community-new/logic.ts
+++ b/src/apps/community-new/logic.ts
@@ -16,6 +16,31 @@ export const DEFAULT_COMMUNITY_GROUP_ADDRESSES = [
   "0xEEcAe593589a6eE4a12AE64F19420B47F3112Fa9"
 ] as const;
 
+/**
+ * How the reconciler treats current on-chain trustees that are absent from the
+ * (eligible) wishlist. The featured groups are being migrated off the OLD
+ * single-slot affiliate registry onto the NEW multi-affiliate registry that
+ * feeds the wishlist; during migration the wishlist is NOT yet a complete
+ * membership set, so treating wishlist-absence as "leave" would evict members
+ * who joined via the old path.
+ *
+ * - `add-only`  — never untrust (default, migration-safe). Removal is handled
+ *   by the incumbent group-affiliates worker until it is retired.
+ * - `union`     — untrust only avatars absent from BOTH the wishlist and the
+ *   supplied protected set (old-registry members / current path). Bridges the
+ *   two registries so no current member is evicted.
+ * - `wishlist`  — the wishlist is authoritative; untrust anyone not eligible.
+ *   Only correct once every member has migrated to the new registry. Gated by
+ *   the untrust circuit breaker below.
+ */
+export type UntrustMode = "add-only" | "union" | "wishlist";
+
+export const DEFAULT_UNTRUST_MODE: UntrustMode = "add-only";
+/** Circuit breaker: abort the whole run if total untrusts across groups exceed this. */
+export const DEFAULT_MAX_UNTRUST_TOTAL = 20;
+/** Circuit breaker: abort if a single group would untrust more than this fraction of its trustees. */
+export const DEFAULT_MAX_UNTRUST_RATIO_PER_GROUP = 0.5;
+
 export type CommunityRunConfig = {
   managedGroupAddresses: readonly string[];
   minRepScoresByGroup: Record<string, number>;
@@ -24,6 +49,21 @@ export type CommunityRunConfig = {
   feeFetchConcurrency: number;
   maxTotalFeePercentage?: number;
   dryRun?: boolean;
+  /** How wishlist-absent trustees are handled. Default {@link DEFAULT_UNTRUST_MODE} (add-only). */
+  untrustMode?: UntrustMode;
+  /** `union` mode: per-group set of addresses that must never be untrusted (old-registry members / current path). */
+  protectedTrusteesByGroup?: Record<string, ReadonlySet<string>>;
+  /** Circuit breaker cap on total untrusts per run. Default {@link DEFAULT_MAX_UNTRUST_TOTAL}. */
+  maxUntrustTotal?: number;
+  /** Circuit breaker cap on per-group untrust fraction. Default {@link DEFAULT_MAX_UNTRUST_RATIO_PER_GROUP}. */
+  maxUntrustRatioPerGroup?: number;
+  /**
+   * Membership source override. When provided for a group, this set (e.g. the
+   * on-chain-derived {@link AffiliateMultiMap} members) is used as the wishlist
+   * instead of calling the wishlist RPC — removing the dependency on the
+   * staging-only `circles_getAffiliateGroupMembersWishlist` method.
+   */
+  wishlistOverrideByGroup?: Record<string, ReadonlySet<string>>;
 };
 
 export type CommunityRunDeps = {
@@ -87,15 +127,24 @@ export async function runCommunityReconciliation(
   if (!Number.isFinite(maxTotalFeePercentage) || maxTotalFeePercentage < 0) {
     throw new Error(`maxTotalFeePercentage must be a finite non-negative number, received ${maxTotalFeePercentage}`);
   }
+  const untrustMode = cfg.untrustMode ?? DEFAULT_UNTRUST_MODE;
+  const maxUntrustTotal = cfg.maxUntrustTotal ?? DEFAULT_MAX_UNTRUST_TOTAL;
+  const maxUntrustRatioPerGroup = cfg.maxUntrustRatioPerGroup ?? DEFAULT_MAX_UNTRUST_RATIO_PER_GROUP;
+  const protectedTrusteesByGroup = normalizeProtectedTrustees(cfg.protectedTrusteesByGroup);
+  const wishlistOverrideByGroup = normalizeProtectedTrustees(cfg.wishlistOverrideByGroup);
 
   const snapshots = await Promise.all(groups.map(async (groupAddress): Promise<GroupSnapshot> => {
+    const wishlistOverride = wishlistOverrideByGroup.get(groupAddress);
     const [wishlistMembers, currentTrustees] = await Promise.all([
-      deps.affiliateRpc.fetchAllGroupMembersWishlist(groupAddress, pageSize),
+      wishlistOverride ? Promise.resolve(null) : deps.affiliateRpc.fetchAllGroupMembersWishlist(groupAddress, pageSize),
       deps.circlesRpc.fetchAllTrustees(groupAddress)
     ]);
+    const wishlist = wishlistOverride ?? new Set(
+      (wishlistMembers ?? []).map((member) => normalizeAddress(member.avatarAddress))
+    );
     return {
       groupAddress,
-      wishlist: new Set(wishlistMembers.map((member) => normalizeAddress(member.avatarAddress))),
+      wishlist,
       currentTrustees: new Set(currentTrustees.map(normalizeAddress))
     };
   }));
@@ -160,17 +209,34 @@ export async function runCommunityReconciliation(
     trustedByGroup[snapshot.groupAddress] = Array.from(eligible)
       .filter((address) => !snapshot.currentTrustees.has(address))
       .sort();
-    untrustedByGroup[snapshot.groupAddress] = Array.from(snapshot.currentTrustees)
-      .filter((address) => !eligible.has(address))
-      .sort();
+
+    const rawUntrust = Array.from(snapshot.currentTrustees)
+      .filter((address) => !eligible.has(address));
+    untrustedByGroup[snapshot.groupAddress] = applyUntrustPolicy(
+      snapshot,
+      rawUntrust,
+      untrustMode,
+      protectedTrusteesByGroup.get(snapshot.groupAddress),
+      deps.logger
+    ).sort();
   }
+
+  assertUntrustWithinCaps(
+    untrustedByGroup,
+    currentTrusteesByGroup,
+    maxUntrustTotal,
+    maxUntrustRatioPerGroup,
+    !!cfg.dryRun,
+    deps.logger
+  );
 
   const totalTrust = countAddresses(trustedByGroup);
   const totalUntrust = countAddresses(untrustedByGroup);
   const totalLeft = countAddresses(leftByGroup);
   deps.logger.info(
     `Community reconciliation: groups=${groups.length} wishlist=${allWishlistAddresses.length} ` +
-    `ineligible=${ineligible.length} left=${totalLeft} toTrust=${totalTrust} toUntrust=${totalUntrust}`
+    `ineligible=${ineligible.length} left=${totalLeft} toTrust=${totalTrust} toUntrust=${totalUntrust} ` +
+    `untrustMode=${untrustMode}`
   );
 
   if (cfg.dryRun) {
@@ -323,6 +389,96 @@ function positiveIntegerInRange(name: string, value: number, min: number, max: n
 
 function countAddresses(byGroup: Record<string, string[]>): number {
   return Object.values(byGroup).reduce((sum, addresses) => sum + addresses.length, 0);
+}
+
+function normalizeProtectedTrustees(
+  protectedByGroup: Record<string, ReadonlySet<string>> | undefined
+): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>();
+  for (const [group, addresses] of Object.entries(protectedByGroup ?? {})) {
+    result.set(
+      normalizeAddress(group),
+      new Set(Array.from(addresses).map(normalizeAddress))
+    );
+  }
+  return result;
+}
+
+/**
+ * Decides which of `rawUntrust` (current trustees no longer eligible) are
+ * actually queued for untrust, honoring the empty-wishlist guard and the
+ * untrust mode. The empty-wishlist guard is unconditional: a well-formed empty
+ * wishlist must never be interpreted as "everyone left" — that is the primary
+ * mass-untrust failure mode this worker must not have.
+ */
+function applyUntrustPolicy(
+  snapshot: GroupSnapshot,
+  rawUntrust: string[],
+  mode: UntrustMode,
+  protectedTrustees: Set<string> | undefined,
+  logger: ILoggerService
+): string[] {
+  if (snapshot.wishlist.size === 0 && snapshot.currentTrustees.size > 0) {
+    logger.warn(
+      `Empty wishlist for ${snapshot.groupAddress} with ${snapshot.currentTrustees.size} ` +
+      `current trustee(s) — untrusting nobody this cycle (empty-wishlist guard).`
+    );
+    return [];
+  }
+
+  switch (mode) {
+    case "add-only":
+      return [];
+    case "union": {
+      const protectedSet = protectedTrustees ?? new Set<string>();
+      return rawUntrust.filter((address) => !protectedSet.has(address));
+    }
+    case "wishlist":
+      return rawUntrust;
+  }
+}
+
+/**
+ * Circuit breaker: refuses to submit an anomalously large untrust set. Trips on
+ * either an absolute total across all groups or a per-group fraction of current
+ * trustees. In dry-run it only warns (so the plan is still observable); in wet
+ * mode it throws before any write, so a sparse/misconfigured wishlist or an
+ * unintended `wishlist`-mode cutover cannot mass-evict members.
+ */
+function assertUntrustWithinCaps(
+  untrustedByGroup: Record<string, string[]>,
+  currentTrusteesByGroup: Record<string, number>,
+  maxTotal: number,
+  maxRatioPerGroup: number,
+  dryRun: boolean,
+  logger: ILoggerService
+): void {
+  const breaches: string[] = [];
+
+  const total = countAddresses(untrustedByGroup);
+  if (total > maxTotal) {
+    breaches.push(`total untrust ${total} exceeds cap ${maxTotal}`);
+  }
+  for (const [group, addresses] of Object.entries(untrustedByGroup)) {
+    const trustees = currentTrusteesByGroup[group] ?? 0;
+    if (addresses.length > 0 && trustees > 0 && addresses.length / trustees > maxRatioPerGroup) {
+      breaches.push(
+        `group ${group} would untrust ${addresses.length}/${trustees} ` +
+        `(${((addresses.length / trustees) * 100).toFixed(0)}% > ${(maxRatioPerGroup * 100).toFixed(0)}%)`
+      );
+    }
+  }
+  if (breaches.length === 0) return;
+
+  const message =
+    `Untrust circuit breaker tripped: ${breaches.join("; ")}. ` +
+    `Refusing to mass-untrust. If this is an intentional migration cutover, raise ` +
+    `COMMUNITY_NEW_MAX_UNTRUST_TOTAL / COMMUNITY_NEW_MAX_UNTRUST_RATIO deliberately.`;
+  if (dryRun) {
+    logger.warn(`[dry-run] ${message}`);
+    return;
+  }
+  throw new Error(message);
 }
 
 function chunk<T>(values: T[], size: number): T[][] {

--- a/src/apps/community-new/main.ts
+++ b/src/apps/community-new/main.ts
@@ -45,7 +45,10 @@ import {
   DEFAULT_OLD_AFFILIATE_REGISTRY_START_BLOCK,
   fetchOldRegistryMembersByGroup
 } from "./oldRegistryMembers";
+import {OldRegistrySource, mergeHybridMembers} from "./oldRegistrySource";
 import {resolveCommunityReputationConfig} from "./reputationConfig";
+
+type MembershipSource = "rpc" | "registry" | "old" | "hybrid";
 
 const APP_NAME = "community-new";
 const DEFAULT_COMMUNITY_RPC_URL = "https://rpc.staging.aboutcircles.com";
@@ -53,8 +56,15 @@ const DEFAULT_COMMUNITY_RPC_URL = "https://rpc.staging.aboutcircles.com";
 const verboseLogging = !!process.env.VERBOSE_LOGGING;
 const logger = new LoggerService(verboseLogging, APP_NAME);
 const runLogger = logger.child("run");
-const communityRpcUrl = process.env.COMMUNITY_NEW_RPC_URL || DEFAULT_COMMUNITY_RPC_URL;
-const chainRpcUrl = process.env.RPC_URL || communityRpcUrl;
+const membershipSource = parseMembershipSource(process.env.COMMUNITY_NEW_MEMBERSHIP_SOURCE);
+const chainRpcUrl = process.env.RPC_URL || DEFAULT_COMMUNITY_RPC_URL;
+// The community RPC serves trustees + profile (minRepScore) reads and, in `rpc`
+// mode, the staging-only wishlist methods. In old/hybrid/new there is NO
+// staging-only dependency, so it must be the same prod chain as RPC_URL — fall
+// back to it (never the staging default) so the worker can't read staging trust
+// state on prod and untrust against it.
+const communityRpcUrl = process.env.COMMUNITY_NEW_RPC_URL
+  || (membershipSource === "rpc" ? DEFAULT_COMMUNITY_RPC_URL : chainRpcUrl);
 const txRpcUrl = resolveTransactionRpcUrl(chainRpcUrl);
 const managedGroups = parseGroupAddresses(
   process.env.COMMUNITY_NEW_GROUP_ADDRESSES,
@@ -81,7 +91,6 @@ const reputationSnapshotTtlMs = parsePositiveInt(
   "COMMUNITY_NEW_REPUTATION_SNAPSHOT_TTL_MS",
   Math.max(pollIntervalMs, 5 * 60 * 1000)
 );
-const untrustMode = parseUntrustMode(process.env.COMMUNITY_NEW_UNTRUST_MODE);
 const maxUntrustTotal = parsePositiveInt("COMMUNITY_NEW_MAX_UNTRUST_TOTAL", DEFAULT_MAX_UNTRUST_TOTAL);
 const maxUntrustRatioPerGroup = parseRatio("COMMUNITY_NEW_MAX_UNTRUST_RATIO", DEFAULT_MAX_UNTRUST_RATIO_PER_GROUP);
 const oldRegistryAddress = process.env.COMMUNITY_NEW_OLD_REGISTRY_ADDRESS || DEFAULT_OLD_AFFILIATE_REGISTRY_ADDRESS;
@@ -90,7 +99,27 @@ const oldRegistryStartBlock = parsePositiveInt(
   DEFAULT_OLD_AFFILIATE_REGISTRY_START_BLOCK
 );
 const ackGroupAffiliatesRetired = process.env.COMMUNITY_NEW_ACK_GROUP_AFFILIATES_RETIRED === "1";
-const membershipSource = parseMembershipSource(process.env.COMMUNITY_NEW_MEMBERSHIP_SOURCE);
+// Test-dev allowlist: in `hybrid` these avatars are governed by the NEW multi
+// registry (multi-group), everyone else keeps OLD single-slot prod behavior.
+const testAddresses = parseAddressSet(process.env.COMMUNITY_NEW_TEST_ADDRESSES);
+// Fresh dev addresses have reputation 0 (cold-start), which fails the rep gate.
+// Opt-in bypass so allowlisted test avatars can exercise the new flow in hybrid.
+const testBypassReputation = process.env.COMMUNITY_NEW_TEST_BYPASS_REPUTATION === "1";
+const needsNewMap = membershipSource === "registry" || membershipSource === "hybrid";
+const needsOldMap = membershipSource === "old" || membershipSource === "hybrid";
+// Per-member fees come from the staging-only wishlist RPC; only enforce them in
+// `rpc` mode. old/hybrid/new read the chain directly (prod RPC lacks the method)
+// and, like group-affiliates, apply no fee cap.
+const feeCapEnabled = membershipSource === "rpc";
+// Every chain-authoritative mode (old/hybrid/new) is a membership source of
+// truth, so it must UNTRUST departed/removed members — the `wishlist` policy,
+// matching group-affiliates (old) and honoring AffiliateGroupRemoved (new). Only
+// the staging `rpc` mode keeps the migration-safe add-only default. The untrust
+// circuit breaker still guards a wet run whose eviction set is implausibly large.
+const untrustMode = parseUntrustMode(
+  process.env.COMMUNITY_NEW_UNTRUST_MODE,
+  membershipSource === "rpc" ? DEFAULT_UNTRUST_MODE : "wishlist"
+);
 const registryAddress = process.env.COMMUNITY_NEW_REGISTRY_ADDRESS || DEFAULT_MULTI_AFFILIATE_REGISTRY_ADDRESS;
 const registryDeployBlock = parsePositiveInt(
   "COMMUNITY_NEW_REGISTRY_DEPLOY_BLOCK",
@@ -98,6 +127,8 @@ const registryDeployBlock = parsePositiveInt(
 );
 const wssUrl = process.env.COMMUNITY_NEW_WSS_URL || deriveWsUrl(chainRpcUrl);
 const enableWss = process.env.COMMUNITY_NEW_ENABLE_WSS === "1";
+const oldWssUrl = process.env.COMMUNITY_NEW_OLD_WSS_URL || undefined;
+const enableOldWss = process.env.COMMUNITY_NEW_OLD_ENABLE_WSS === "1";
 const stateDbUrl = process.env.LEADER_DB_URL || "";
 const MULTI_MAP_STATE_KEY = "community-new:multi-affiliate-map";
 const dryRun = process.env.DRY_RUN === "1";
@@ -126,9 +157,10 @@ const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slac
 const errorTracker = new ConsecutiveErrorTracker(errorsBeforeCrash);
 const groupService = createGroupService();
 
-const stateStore = membershipSource === "registry" && stateDbUrl.length > 0 ? new StateStore(stateDbUrl) : null;
+const stateStore = membershipSource !== "rpc" && stateDbUrl.length > 0 ? new StateStore(stateDbUrl) : null;
 let multiMap: AffiliateMultiMap | null = null;
 let multiListener: MultiAffiliateListenerHandle | null = null;
+let oldSource: OldRegistrySource | null = null;
 let shuttingDown = false;
 
 function applyMultiEvents(map: AffiliateMultiMap, events: MultiAffiliateEvent[]): void {
@@ -237,8 +269,21 @@ async function start(): Promise<void> {
     }
   }
 
-  if (membershipSource === "registry") {
+  if (needsNewMap) {
     await initMultiMap();
+  }
+  if (needsOldMap) {
+    oldSource = await OldRegistrySource.create({
+      chainRpcUrl,
+      wssUrl: oldWssUrl,
+      registryAddress: oldRegistryAddress,
+      startBlock: oldRegistryStartBlock,
+      logger: logger.child("old-registry"),
+      stateStore,
+      enableWss: enableOldWss
+    });
+    await oldSource.init();
+    logger.info(`Old-affiliate map ready: lastScannedBlock=${oldSource.lastScannedBlock}`);
   }
 
   logConfiguration();
@@ -261,15 +306,13 @@ async function start(): Promise<void> {
       if (healthy) {
         const minRepScoresByGroup = await profileService.fetchMinRepScores(managedGroups);
 
-        // registry mode: keep the on-chain map current (getLogs catch-up — also a
-        // WSS backstop) and use it as the membership source instead of the RPC.
+        // Non-rpc modes: keep the on-chain map(s) current (getLogs catch-up — a
+        // WSS backstop) and derive the membership override instead of the RPC.
         let wishlistOverrideByGroup: Record<string, ReadonlySet<string>> | undefined;
-        if (membershipSource === "registry" && multiMap) {
-          await refreshMultiMap(multiMap);
-          wishlistOverrideByGroup = {};
-          for (const group of managedGroups) {
-            wishlistOverrideByGroup[group] = multiMap.getMembersOf(group);
-          }
+        if (membershipSource !== "rpc") {
+          if (needsNewMap && multiMap) await refreshMultiMap(multiMap);
+          if (needsOldMap && oldSource) await oldSource.refresh();
+          wishlistOverrideByGroup = buildWishlistOverride();
         }
 
         const protectedTrusteesByGroup = untrustMode === "union"
@@ -287,12 +330,15 @@ async function start(): Promise<void> {
             pageSize,
             batchSize,
             feeFetchConcurrency,
+            feeCapEnabled,
             dryRun,
             untrustMode,
             protectedTrusteesByGroup,
             maxUntrustTotal,
             maxUntrustRatioPerGroup,
-            wishlistOverrideByGroup
+            wishlistOverrideByGroup,
+            reputationBypassAddresses:
+              membershipSource === "hybrid" && testBypassReputation ? testAddresses : undefined
           }
         );
         recordRunSuccess(APP_NAME, Date.now() - startedAt);
@@ -406,14 +452,23 @@ function logConfiguration(): void {
   );
   logger.info(`  - safe=${safeAddress || "(not set)"}`);
   logger.info(`  - membershipSource=${membershipSource}`);
-  if (membershipSource === "registry") {
+  logger.info(`  - feeCapEnabled=${feeCapEnabled}`);
+  if (needsNewMap) {
     logger.info(`  - registry=${registryAddress} (deployBlock=${registryDeployBlock})`);
     logger.info(`  - wss=${enableWss ? wssUrl : "(disabled)"}  statePersistence=${stateStore ? "on" : "off"}`);
+  }
+  if (needsOldMap) {
+    logger.info(`  - oldRegistry=${oldRegistryAddress} (startBlock=${oldRegistryStartBlock})`);
+    logger.info(`  - oldWss=${enableOldWss ? (oldWssUrl ?? "(derived from RPC)") : "(disabled)"}`);
+  }
+  if (membershipSource === "hybrid") {
+    logger.info(`  - testAddresses(${testAddresses.size})=${Array.from(testAddresses).join(", ") || "(none)"}`);
+    logger.info(`  - testBypassReputation=${testBypassReputation}`);
   }
   logger.info(`  - untrustMode=${untrustMode}`);
   logger.info(`  - maxUntrustTotal=${maxUntrustTotal} maxUntrustRatioPerGroup=${maxUntrustRatioPerGroup}`);
   if (untrustMode === "union") {
-    logger.info(`  - oldRegistry=${oldRegistryAddress} (startBlock=${oldRegistryStartBlock})`);
+    logger.info(`  - unionProtectedFrom=oldRegistry ${oldRegistryAddress} (startBlock=${oldRegistryStartBlock})`);
   }
   logger.info(`  - ackGroupAffiliatesRetired=${ackGroupAffiliatesRetired}`);
   logger.info(`  - dryRun=${dryRun}`);
@@ -429,6 +484,10 @@ async function shutdown(signal: string): Promise<void> {
       logger.warn("Failed to stop multi-affiliate listener:", error);
     }
     multiListener = null;
+  }
+  if (oldSource) {
+    oldSource.stop();
+    oldSource = null;
   }
   await notify(`🔄 *community-new shutting down* (${signal})`, SlackSeverity.INFO);
   process.exit(0);
@@ -477,20 +536,54 @@ function parseRatio(name: string, fallback: number): number {
   return value;
 }
 
-function parseUntrustMode(raw: string | undefined): UntrustMode {
+function parseUntrustMode(raw: string | undefined, fallback: UntrustMode): UntrustMode {
   const value = (raw ?? "").trim().toLowerCase();
-  if (value.length === 0) return DEFAULT_UNTRUST_MODE;
+  if (value.length === 0) return fallback;
   if (value === "add-only" || value === "union" || value === "wishlist") {
     return value;
   }
   throw new Error(`COMMUNITY_NEW_UNTRUST_MODE must be one of add-only|union|wishlist, received '${raw}'`);
 }
 
-function parseMembershipSource(raw: string | undefined): "rpc" | "registry" {
+function parseMembershipSource(raw: string | undefined): MembershipSource {
   const value = (raw ?? "").trim().toLowerCase();
   if (value.length === 0 || value === "rpc") return "rpc";
-  if (value === "registry") return "registry";
-  throw new Error(`COMMUNITY_NEW_MEMBERSHIP_SOURCE must be one of rpc|registry, received '${raw}'`);
+  if (value === "registry" || value === "new") return "registry";
+  if (value === "old") return "old";
+  if (value === "hybrid") return "hybrid";
+  throw new Error(
+    `COMMUNITY_NEW_MEMBERSHIP_SOURCE must be one of rpc|old|hybrid|new (new=registry), received '${raw}'`
+  );
+}
+
+function parseAddressSet(raw: string | undefined): Set<string> {
+  const set = new Set<string>();
+  if (!raw) return set;
+  for (const value of raw.split(",").map((entry) => entry.trim()).filter(Boolean)) {
+    set.add(getAddress(value).toLowerCase());
+  }
+  return set;
+}
+
+/** Per-group membership override for the current mode (see {@link MembershipSource}). */
+function buildWishlistOverride(): Record<string, ReadonlySet<string>> {
+  const override: Record<string, ReadonlySet<string>> = {};
+  for (const group of managedGroups) {
+    if (membershipSource === "registry" && multiMap) {
+      override[group] = multiMap.getMembersOf(group);
+    } else if (membershipSource === "old" && oldSource) {
+      override[group] = oldSource.getMembersOf(group);
+    } else if (membershipSource === "hybrid" && oldSource && multiMap) {
+      override[group] = mergeHybridMembers(
+        oldSource.getMembersOf(group),
+        multiMap.getMembersOf(group),
+        testAddresses
+      );
+    } else {
+      override[group] = new Set();
+    }
+  }
+  return override;
 }
 
 function asError(cause: unknown): Error {

--- a/src/apps/community-new/main.ts
+++ b/src/apps/community-new/main.ts
@@ -11,6 +11,7 @@ import {recordRunError, recordRunSuccess, startMetricsServer} from "../../servic
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {SafeGroupService} from "../../services/safeGroupService";
 import {SlackService} from "../../services/slackService";
+import {StateStore} from "../../services/stateStore";
 import {resolveTransactionRpcUrl} from "../../services/transactionRpc";
 import {
   BulkReputationService,
@@ -23,8 +24,27 @@ import {
   DEFAULT_COMMUNITY_GROUP_ADDRESSES,
   DEFAULT_COMMUNITY_PAGE_SIZE,
   DEFAULT_FEE_FETCH_CONCURRENCY,
+  DEFAULT_MAX_UNTRUST_RATIO_PER_GROUP,
+  DEFAULT_MAX_UNTRUST_TOTAL,
+  DEFAULT_UNTRUST_MODE,
+  UntrustMode,
   runCommunityReconciliation
 } from "./logic";
+import {AffiliateMultiMap} from "./affiliateMultiMap";
+import {
+  DEFAULT_MULTI_AFFILIATE_REGISTRY_ADDRESS,
+  DEFAULT_MULTI_AFFILIATE_REGISTRY_DEPLOY_BLOCK,
+  MultiAffiliateEvent,
+  MultiAffiliateListenerHandle,
+  deriveWsUrl,
+  fetchMultiAffiliateEvents,
+  startMultiAffiliateListener
+} from "./multiRegistry";
+import {
+  DEFAULT_OLD_AFFILIATE_REGISTRY_ADDRESS,
+  DEFAULT_OLD_AFFILIATE_REGISTRY_START_BLOCK,
+  fetchOldRegistryMembersByGroup
+} from "./oldRegistryMembers";
 import {resolveCommunityReputationConfig} from "./reputationConfig";
 
 const APP_NAME = "community-new";
@@ -61,6 +81,25 @@ const reputationSnapshotTtlMs = parsePositiveInt(
   "COMMUNITY_NEW_REPUTATION_SNAPSHOT_TTL_MS",
   Math.max(pollIntervalMs, 5 * 60 * 1000)
 );
+const untrustMode = parseUntrustMode(process.env.COMMUNITY_NEW_UNTRUST_MODE);
+const maxUntrustTotal = parsePositiveInt("COMMUNITY_NEW_MAX_UNTRUST_TOTAL", DEFAULT_MAX_UNTRUST_TOTAL);
+const maxUntrustRatioPerGroup = parseRatio("COMMUNITY_NEW_MAX_UNTRUST_RATIO", DEFAULT_MAX_UNTRUST_RATIO_PER_GROUP);
+const oldRegistryAddress = process.env.COMMUNITY_NEW_OLD_REGISTRY_ADDRESS || DEFAULT_OLD_AFFILIATE_REGISTRY_ADDRESS;
+const oldRegistryStartBlock = parsePositiveInt(
+  "COMMUNITY_NEW_OLD_REGISTRY_START_BLOCK",
+  DEFAULT_OLD_AFFILIATE_REGISTRY_START_BLOCK
+);
+const ackGroupAffiliatesRetired = process.env.COMMUNITY_NEW_ACK_GROUP_AFFILIATES_RETIRED === "1";
+const membershipSource = parseMembershipSource(process.env.COMMUNITY_NEW_MEMBERSHIP_SOURCE);
+const registryAddress = process.env.COMMUNITY_NEW_REGISTRY_ADDRESS || DEFAULT_MULTI_AFFILIATE_REGISTRY_ADDRESS;
+const registryDeployBlock = parsePositiveInt(
+  "COMMUNITY_NEW_REGISTRY_DEPLOY_BLOCK",
+  DEFAULT_MULTI_AFFILIATE_REGISTRY_DEPLOY_BLOCK
+);
+const wssUrl = process.env.COMMUNITY_NEW_WSS_URL || deriveWsUrl(chainRpcUrl);
+const enableWss = process.env.COMMUNITY_NEW_ENABLE_WSS === "1";
+const stateDbUrl = process.env.LEADER_DB_URL || "";
+const MULTI_MAP_STATE_KEY = "community-new:multi-affiliate-map";
 const dryRun = process.env.DRY_RUN === "1";
 const safeAddress = process.env.COMMUNITY_NEW_SAFE_ADDRESS || "";
 const safeSignerPrivateKey = process.env.COMMUNITY_NEW_SAFE_SIGNER_PRIVATE_KEY || "";
@@ -87,7 +126,83 @@ const slackService = new SlackService(slackWebhookUrl, slackWebhookUrlInfo, slac
 const errorTracker = new ConsecutiveErrorTracker(errorsBeforeCrash);
 const groupService = createGroupService();
 
+const stateStore = membershipSource === "registry" && stateDbUrl.length > 0 ? new StateStore(stateDbUrl) : null;
+let multiMap: AffiliateMultiMap | null = null;
+let multiListener: MultiAffiliateListenerHandle | null = null;
 let shuttingDown = false;
+
+function applyMultiEvents(map: AffiliateMultiMap, events: MultiAffiliateEvent[]): void {
+  for (const event of events) {
+    if (event.type === "add") map.add(event.avatar, event.group, event.blockNumber);
+    else map.remove(event.avatar, event.group, event.blockNumber);
+  }
+}
+
+async function persistMultiMap(map: AffiliateMultiMap): Promise<void> {
+  if (!stateStore) return;
+  try {
+    await map.save(stateStore, MULTI_MAP_STATE_KEY);
+  } catch (error) {
+    logger.warn("Failed to persist multi-affiliate map:", error);
+  }
+}
+
+async function fetchChainHead(): Promise<number> {
+  const response = await fetch(chainRpcUrl, {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: []})
+  });
+  if (!response.ok) throw new Error(`eth_blockNumber failed with HTTP ${response.status}`);
+  const payload = await response.json() as {result?: string; error?: {message?: string}};
+  if (payload.error) throw new Error(payload.error.message ?? "eth_blockNumber RPC error");
+  const head = Number.parseInt(String(payload.result), 16);
+  if (!Number.isFinite(head)) throw new Error(`eth_blockNumber returned a non-numeric head: ${payload.result}`);
+  return head;
+}
+
+/** Incrementally catch the map up to chain head via getLogs and persist it. */
+async function refreshMultiMap(map: AffiliateMultiMap): Promise<void> {
+  const head = await fetchChainHead();
+  const from = Math.max(registryDeployBlock, map.lastScannedBlock + 1);
+  if (from > head) return;
+  const events = await fetchMultiAffiliateEvents(chainRpcUrl, registryAddress, from, head, runLogger);
+  applyMultiEvents(map, events);
+  map.advanceCursor(head);
+  await persistMultiMap(map);
+}
+
+async function initMultiMap(): Promise<void> {
+  multiMap = stateStore ? await AffiliateMultiMap.load(stateStore, MULTI_MAP_STATE_KEY) : null;
+  if (!multiMap) {
+    multiMap = new AffiliateMultiMap(registryDeployBlock - 1);
+  }
+  logger.info(
+    `Backfilling multi-affiliate map from block ` +
+    `${Math.max(registryDeployBlock, multiMap.lastScannedBlock + 1)} (registry ${registryAddress})...`
+  );
+  await refreshMultiMap(multiMap);
+  logger.info(`Multi-affiliate map ready: lastScannedBlock=${multiMap.lastScannedBlock}`);
+
+  if (enableWss) {
+    const map = multiMap;
+    multiListener = startMultiAffiliateListener({
+      httpRpcUrl: chainRpcUrl,
+      wsUrl: wssUrl,
+      registryAddress,
+      logger: logger.child("wss"),
+      getFromBlock: () => map.lastScannedBlock + 1,
+      onEvents: async (events) => {
+        applyMultiEvents(map, events);
+        if (events.length > 0) {
+          map.advanceCursor(events[events.length - 1].blockNumber);
+        }
+        await persistMultiMap(map);
+      }
+    });
+    logger.info(`Multi-affiliate WSS listener started on ${wssUrl}.`);
+  }
+}
 
 process.on("SIGINT", () => { void shutdown("SIGINT"); });
 process.on("SIGTERM", () => { void shutdown("SIGTERM"); });
@@ -102,6 +217,28 @@ async function start(): Promise<void> {
   }
   if (!dryRun || canSimulate) {
     await validateManagedGroupServices();
+  }
+
+  // The wishlist RPC method is only used when membership comes from the RPC.
+  // In `registry` mode membership is read from the on-chain map (fees still use
+  // the RPC and fail loudly on their own if the fee method is unavailable).
+  if (membershipSource === "rpc") {
+    try {
+      await affiliateRpc.assertAffiliateMethodsAvailable(managedGroups[0]);
+      logger.info("Affiliate wishlist RPC methods available on the configured node.");
+    } catch (cause) {
+      throw new Error(
+        `Affiliate wishlist RPC methods unavailable on ${communityRpcUrl} ` +
+        `(circles_getAffiliateGroupMembersWishlist). Set COMMUNITY_NEW_RPC_URL to a node that serves them ` +
+        `— prod rpc.aboutcircles.com currently returns -32601 Method not found — or use ` +
+        `COMMUNITY_NEW_MEMBERSHIP_SOURCE=registry to read membership from chain instead.`,
+        {cause: asError(cause)}
+      );
+    }
+  }
+
+  if (membershipSource === "registry") {
+    await initMultiMap();
   }
 
   logConfiguration();
@@ -123,6 +260,25 @@ async function start(): Promise<void> {
       });
       if (healthy) {
         const minRepScoresByGroup = await profileService.fetchMinRepScores(managedGroups);
+
+        // registry mode: keep the on-chain map current (getLogs catch-up — also a
+        // WSS backstop) and use it as the membership source instead of the RPC.
+        let wishlistOverrideByGroup: Record<string, ReadonlySet<string>> | undefined;
+        if (membershipSource === "registry" && multiMap) {
+          await refreshMultiMap(multiMap);
+          wishlistOverrideByGroup = {};
+          for (const group of managedGroups) {
+            wishlistOverrideByGroup[group] = multiMap.getMembersOf(group);
+          }
+        }
+
+        const protectedTrusteesByGroup = untrustMode === "union"
+          ? await fetchOldRegistryMembersByGroup(chainRpcUrl, managedGroups, {
+              registryAddress: oldRegistryAddress,
+              fromBlock: oldRegistryStartBlock,
+              logger: runLogger
+            })
+          : undefined;
         const outcome = await runCommunityReconciliation(
           {affiliateRpc, circlesRpc, groupService, reputationService, logger: runLogger},
           {
@@ -131,7 +287,12 @@ async function start(): Promise<void> {
             pageSize,
             batchSize,
             feeFetchConcurrency,
-            dryRun
+            dryRun,
+            untrustMode,
+            protectedTrusteesByGroup,
+            maxUntrustTotal,
+            maxUntrustRatioPerGroup,
+            wishlistOverrideByGroup
           }
         );
         recordRunSuccess(APP_NAME, Date.now() - startedAt);
@@ -184,6 +345,17 @@ function createGroupService(): IGroupService {
 }
 
 function validateConfig(): void {
+  // Cutover gate (H3): community-new and group-affiliates manage the same three
+  // groups through the SAME Safe + signer EOA. Two wet workers on one signer
+  // race the nonce (GS026) and fight an untrust war. Refuse to run wet until the
+  // operator has retired group-affiliates for these groups and acknowledged it.
+  if (!dryRun && !ackGroupAffiliatesRetired) {
+    throw new Error(
+      "Refusing to run wet: community-new shares a Safe/signer with group-affiliates for these groups. " +
+      "Retire group-affiliates for the managed groups first, then set " +
+      "COMMUNITY_NEW_ACK_GROUP_AFFILIATES_RETIRED=1 to acknowledge the cutover."
+    );
+  }
   if (!dryRun && safeAddress.trim().length === 0) {
     throw new Error("COMMUNITY_NEW_SAFE_ADDRESS is required unless DRY_RUN=1");
   }
@@ -233,12 +405,31 @@ function logConfiguration(): void {
     `  - reputationMode=${useBulkReputation ? `bulk (${reputationScoresUrl})` : `per-address (${reputationBaseUrl})`}`
   );
   logger.info(`  - safe=${safeAddress || "(not set)"}`);
+  logger.info(`  - membershipSource=${membershipSource}`);
+  if (membershipSource === "registry") {
+    logger.info(`  - registry=${registryAddress} (deployBlock=${registryDeployBlock})`);
+    logger.info(`  - wss=${enableWss ? wssUrl : "(disabled)"}  statePersistence=${stateStore ? "on" : "off"}`);
+  }
+  logger.info(`  - untrustMode=${untrustMode}`);
+  logger.info(`  - maxUntrustTotal=${maxUntrustTotal} maxUntrustRatioPerGroup=${maxUntrustRatioPerGroup}`);
+  if (untrustMode === "union") {
+    logger.info(`  - oldRegistry=${oldRegistryAddress} (startBlock=${oldRegistryStartBlock})`);
+  }
+  logger.info(`  - ackGroupAffiliatesRetired=${ackGroupAffiliatesRetired}`);
   logger.info(`  - dryRun=${dryRun}`);
 }
 
 async function shutdown(signal: string): Promise<void> {
   if (shuttingDown) return;
   shuttingDown = true;
+  if (multiListener) {
+    try {
+      multiListener.stop();
+    } catch (error) {
+      logger.warn("Failed to stop multi-affiliate listener:", error);
+    }
+    multiListener = null;
+  }
   await notify(`🔄 *community-new shutting down* (${signal})`, SlackSeverity.INFO);
   process.exit(0);
 }
@@ -275,6 +466,31 @@ function parsePositiveInt(name: string, fallback: number, max: number = Number.M
     throw new Error(`${name} must be an integer in [1, ${max}], received ${raw ?? value}`);
   }
   return value;
+}
+
+function parseRatio(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const value = raw && raw.trim().length > 0 ? Number(raw) : fallback;
+  if (!Number.isFinite(value) || value <= 0 || value > 1) {
+    throw new Error(`${name} must be a number in (0, 1], received ${raw ?? value}`);
+  }
+  return value;
+}
+
+function parseUntrustMode(raw: string | undefined): UntrustMode {
+  const value = (raw ?? "").trim().toLowerCase();
+  if (value.length === 0) return DEFAULT_UNTRUST_MODE;
+  if (value === "add-only" || value === "union" || value === "wishlist") {
+    return value;
+  }
+  throw new Error(`COMMUNITY_NEW_UNTRUST_MODE must be one of add-only|union|wishlist, received '${raw}'`);
+}
+
+function parseMembershipSource(raw: string | undefined): "rpc" | "registry" {
+  const value = (raw ?? "").trim().toLowerCase();
+  if (value.length === 0 || value === "rpc") return "rpc";
+  if (value === "registry") return "registry";
+  throw new Error(`COMMUNITY_NEW_MEMBERSHIP_SOURCE must be one of rpc|registry, received '${raw}'`);
 }
 
 function asError(cause: unknown): Error {

--- a/src/apps/community-new/multiRegistry.ts
+++ b/src/apps/community-new/multiRegistry.ts
@@ -1,0 +1,338 @@
+import {FallbackProvider, Interface, JsonRpcProvider, Log} from "ethers";
+
+import {ILoggerService} from "../../interfaces/ILoggerService";
+import {createProvider} from "../../services/rpcProvider";
+import {retryWithBackoff} from "../../services/retryWithBackoff";
+
+/** NEW multi-affiliate registry (MultiAffiliateGroupRegistry). */
+export const DEFAULT_MULTI_AFFILIATE_REGISTRY_ADDRESS =
+  "0x4a25a7cf216351963f1637ad965d77b3ae277ef3";
+/** Registry deploy block — start of the event history. */
+export const DEFAULT_MULTI_AFFILIATE_REGISTRY_DEPLOY_BLOCK = 46891940;
+
+const ABI = [
+  "event AffiliateGroupAdded(address affiliateGroup, address avatar)",
+  "event AffiliateGroupRemoved(address affiliateGroup, address avatar)"
+] as const;
+const IFACE = new Interface(ABI);
+export const AFFILIATE_GROUP_ADDED_TOPIC0 =
+  IFACE.getEvent("AffiliateGroupAdded")!.topicHash.toLowerCase();
+export const AFFILIATE_GROUP_REMOVED_TOPIC0 =
+  IFACE.getEvent("AffiliateGroupRemoved")!.topicHash.toLowerCase();
+
+const DEFAULT_LOG_CHUNK_SIZE = 100_000;
+const DEFAULT_RECONNECT_BASE_MS = 2_000;
+const DEFAULT_RECONNECT_MAX_MS = 60_000;
+const DEFAULT_DEBOUNCE_MS = 1_000;
+const WebSocketImpl = (globalThis as unknown as {WebSocket: {new(url: string): WebSocketLike}}).WebSocket;
+
+export type MultiAffiliateEvent = {
+  blockNumber: number;
+  transactionIndex: number;
+  logIndex: number;
+  txHash: string;
+  type: "add" | "remove";
+  avatar: string;
+  group: string;
+};
+
+/**
+ * Chunked `eth_getLogs` history/incremental fetch for both registry events,
+ * returned in on-chain order (block, txIndex, logIndex). Used for the boot
+ * backfill and per-cycle incremental catch-up.
+ */
+export async function fetchMultiAffiliateEvents(
+  rpcUrl: string,
+  registryAddress: string,
+  fromBlock: number,
+  toBlock: number,
+  logger?: ILoggerService,
+  chunkSize = DEFAULT_LOG_CHUNK_SIZE
+): Promise<MultiAffiliateEvent[]> {
+  if (fromBlock > toBlock) return [];
+
+  const provider = createProvider(rpcUrl) as JsonRpcProvider | FallbackProvider;
+  const events: MultiAffiliateEvent[] = [];
+  let chunkStart = Math.max(0, fromBlock);
+  try {
+    while (chunkStart <= toBlock) {
+      const chunkEnd = Math.min(toBlock, chunkStart + chunkSize - 1);
+      const logs = await retryWithBackoff(() =>
+        provider.getLogs({
+          address: registryAddress,
+          fromBlock: chunkStart,
+          toBlock: chunkEnd,
+          topics: [[AFFILIATE_GROUP_ADDED_TOPIC0, AFFILIATE_GROUP_REMOVED_TOPIC0]]
+        })
+      );
+      logger?.info(`[multi-registry-fetch] range=${chunkStart}-${chunkEnd} logs=${logs.length}`);
+      for (const log of logs) {
+        const parsed = parseLog(fromEthersLog(log), registryAddress);
+        if (parsed) events.push(parsed);
+      }
+      chunkStart = chunkEnd + 1;
+    }
+  } finally {
+    provider.destroy();
+  }
+  return sortEvents(events);
+}
+
+type EthLogLike = {
+  address?: string;
+  topics?: unknown[];
+  data?: string;
+  blockNumber?: string | number;
+  transactionHash?: string;
+  transactionIndex?: string | number;
+  logIndex?: string | number;
+};
+
+type WebSocketLike = {
+  addEventListener: (type: string, listener: (event: any) => void) => void;
+  send: (data: string) => void;
+  close: () => void;
+};
+
+export type MultiAffiliateListenerHandle = {stop: () => void};
+
+/**
+ * WSS `eth_subscribe(logs)` listener for both registry events, keeping an
+ * in-memory map current between poll cycles. On (re)connect it runs a getLogs
+ * catch-up from `getFromBlock()` so no event is missed across disconnects.
+ * Faithful to group-affiliates' realtime listener (backoff reconnect, debounce),
+ * adapted for two non-indexed events.
+ */
+export function startMultiAffiliateListener(options: {
+  httpRpcUrl: string;
+  wsUrl: string;
+  registryAddress: string;
+  logger: ILoggerService;
+  getFromBlock: () => number;
+  onEvents: (events: MultiAffiliateEvent[]) => Promise<void> | void;
+  debounceMs?: number;
+  reconnectBaseMs?: number;
+  reconnectMaxMs?: number;
+}): MultiAffiliateListenerHandle {
+  const {
+    httpRpcUrl, wsUrl, registryAddress, logger, getFromBlock, onEvents,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    reconnectBaseMs = DEFAULT_RECONNECT_BASE_MS,
+    reconnectMaxMs = DEFAULT_RECONNECT_MAX_MS
+  } = options;
+
+  let stopped = false;
+  let ws: WebSocketLike | null = null;
+  let reconnectTimer: NodeJS.Timeout | null = null;
+  let flushTimer: NodeJS.Timeout | null = null;
+  let reconnectAttempt = 0;
+  let catchUpInFlight = false;
+  const pending: MultiAffiliateEvent[] = [];
+
+  const clearReconnect = (): void => {
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+  };
+  const closeSocket = (): void => {
+    if (!ws) return;
+    try { ws.close(); } catch { /* ignore */ }
+    ws = null;
+  };
+  const scheduleReconnect = (reason: string): void => {
+    if (stopped || reconnectTimer) return;
+    const delay = Math.min(reconnectBaseMs * (2 ** reconnectAttempt), reconnectMaxMs);
+    reconnectAttempt += 1;
+    logger.warn(`Multi-affiliate listener disconnected (${reason}); reconnecting in ${delay}ms.`);
+    reconnectTimer = setTimeout(() => { reconnectTimer = null; connect(); }, delay);
+  };
+
+  const deliver = async (events: MultiAffiliateEvent[]): Promise<void> => {
+    if (events.length === 0) return;
+    try {
+      await onEvents(sortEvents(events));
+    } catch (error) {
+      logger.error("Multi-affiliate listener callback failed:", error);
+    }
+  };
+  const flush = async (): Promise<void> => {
+    if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+    if (pending.length === 0) return;
+    await deliver(pending.splice(0, pending.length));
+  };
+  const scheduleFlush = (): void => {
+    if (flushTimer) return;
+    flushTimer = setTimeout(() => { void flush(); }, debounceMs);
+  };
+
+  const catchUp = async (): Promise<void> => {
+    if (catchUpInFlight) return;
+    catchUpInFlight = true;
+    try {
+      const head = await fetchHeadBlock(httpRpcUrl);
+      const from = getFromBlock();
+      if (head === null || head < from) return;
+      const events = await fetchMultiAffiliateEvents(httpRpcUrl, registryAddress, from, head, logger);
+      await deliver(events);
+    } catch (error) {
+      logger.warn("Multi-affiliate listener catch-up failed:", error);
+    } finally {
+      catchUpInFlight = false;
+    }
+  };
+
+  const connect = (): void => {
+    if (stopped) return;
+    clearReconnect();
+    closeSocket();
+    logger.info(`Connecting multi-affiliate listener to ${wsUrl}...`);
+    ws = new WebSocketImpl(wsUrl);
+
+    ws.addEventListener("open", () => {
+      reconnectAttempt = 0;
+      ws?.send(JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "eth_subscribe",
+        params: ["logs", {address: registryAddress, topics: [[AFFILIATE_GROUP_ADDED_TOPIC0, AFFILIATE_GROUP_REMOVED_TOPIC0]]}]
+      }));
+    });
+
+    ws.addEventListener("message", (event: {data: unknown}) => {
+      let message: {id?: number; method?: string; error?: {message?: string}; params?: {result?: unknown}};
+      try {
+        message = JSON.parse(String(event.data));
+      } catch {
+        return;
+      }
+      if (message.id === 1) {
+        if (message.error) {
+          logger.error(`Multi-affiliate subscription failed: ${message.error.message ?? "unknown"}`);
+          closeSocket();
+          scheduleReconnect("subscription failed");
+          return;
+        }
+        void catchUp();
+        return;
+      }
+      if (message.method === "eth_subscription") {
+        const raw = message.params?.result;
+        const logs = Array.isArray(raw) ? raw : raw ? [raw] : [];
+        for (const log of logs as EthLogLike[]) {
+          const parsed = parseLog(log, registryAddress);
+          if (parsed) pending.push(parsed);
+        }
+        if (pending.length > 0) scheduleFlush();
+      }
+    });
+
+    ws.addEventListener("error", (e: unknown) => logger.warn("Multi-affiliate listener websocket error:", e));
+    ws.addEventListener("close", (e: {code: number}) => {
+      ws = null;
+      if (!stopped) scheduleReconnect(`close code ${e.code}`);
+    });
+  };
+
+  connect();
+  return {
+    stop: () => {
+      stopped = true;
+      clearReconnect();
+      if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+      closeSocket();
+    }
+  };
+}
+
+export function deriveWsUrl(rpcUrl: string): string {
+  const trimmed = rpcUrl.trim();
+  if (trimmed.startsWith("ws://") || trimmed.startsWith("wss://")) return trimmed;
+  const url = new URL(trimmed);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  if (!url.pathname || url.pathname === "/") url.pathname = "/ws/chain";
+  return url.toString();
+}
+
+async function fetchHeadBlock(httpRpcUrl: string): Promise<number | null> {
+  const response = await fetch(httpRpcUrl, {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify({jsonrpc: "2.0", id: 1, method: "eth_blockNumber", params: []})
+  });
+  if (!response.ok) throw new Error(`eth_blockNumber failed with HTTP ${response.status}`);
+  const payload = await response.json() as {result?: string | number; error?: {message?: string}};
+  if (payload.error) throw new Error(payload.error.message ?? "eth_blockNumber RPC error");
+  return toNumber(payload.result);
+}
+
+function parseLog(log: EthLogLike, registryAddress?: string): MultiAffiliateEvent | null {
+  if (registryAddress && typeof log.address === "string" &&
+      log.address.toLowerCase() !== registryAddress.toLowerCase()) {
+    return null;
+  }
+  const topics = Array.isArray(log.topics)
+    ? log.topics.filter((t): t is string => typeof t === "string")
+    : [];
+  if (topics.length === 0 || typeof log.data !== "string") return null;
+  const topic0 = topics[0].toLowerCase();
+  const type: "add" | "remove" | null =
+    topic0 === AFFILIATE_GROUP_ADDED_TOPIC0 ? "add"
+      : topic0 === AFFILIATE_GROUP_REMOVED_TOPIC0 ? "remove"
+        : null;
+  if (!type) return null;
+
+  let parsed;
+  try {
+    parsed = IFACE.parseLog({topics, data: log.data});
+  } catch {
+    return null;
+  }
+  const blockNumber = toNumber(log.blockNumber);
+  const transactionIndex = toNumber(log.transactionIndex);
+  const logIndex = toNumber(log.logIndex);
+  if (!parsed || blockNumber === null || transactionIndex === null || logIndex === null || !log.transactionHash) {
+    return null;
+  }
+  return {
+    blockNumber,
+    transactionIndex,
+    logIndex,
+    txHash: log.transactionHash,
+    type,
+    avatar: String(parsed.args.avatar),
+    group: String(parsed.args.affiliateGroup)
+  };
+}
+
+function fromEthersLog(log: Log): EthLogLike {
+  return {
+    address: log.address,
+    topics: [...log.topics],
+    data: log.data,
+    blockNumber: log.blockNumber,
+    transactionHash: log.transactionHash,
+    transactionIndex: log.transactionIndex,
+    logIndex: log.index
+  };
+}
+
+function sortEvents(events: MultiAffiliateEvent[]): MultiAffiliateEvent[] {
+  const seen = new Set<string>();
+  const deduped: MultiAffiliateEvent[] = [];
+  for (const event of events) {
+    const key = `${event.txHash}:${event.blockNumber}:${event.transactionIndex}:${event.logIndex}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(event);
+  }
+  return deduped.sort((a, b) =>
+    a.blockNumber - b.blockNumber ||
+    a.transactionIndex - b.transactionIndex ||
+    a.logIndex - b.logIndex
+  );
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = value.startsWith("0x") ? Number.parseInt(value, 16) : Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}

--- a/src/apps/community-new/oldRegistryMembers.ts
+++ b/src/apps/community-new/oldRegistryMembers.ts
@@ -1,0 +1,66 @@
+import {getAddress} from "ethers";
+
+import {ILoggerService} from "../../interfaces/ILoggerService";
+import {AffiliateGroupEventsService} from "../../services/affiliateGroupEventsService";
+
+/** OLD single-slot affiliate registry (AffiliateGroupChanged). */
+export const DEFAULT_OLD_AFFILIATE_REGISTRY_ADDRESS =
+  "0xca8222e780d046707083f51377b5fd85e2866014";
+/** First block the old registry is scanned from (matches group-affiliates' start block). */
+export const DEFAULT_OLD_AFFILIATE_REGISTRY_START_BLOCK = 46282003;
+
+function normalizeAddress(address: string): string {
+  return getAddress(address).toLowerCase();
+}
+
+export type OldRegistryMembersOptions = {
+  registryAddress?: string;
+  fromBlock?: number;
+  toBlock?: number;
+  logger?: ILoggerService;
+};
+
+/**
+ * Reads the OLD single-slot affiliate registry and returns, per managed group,
+ * the set of avatars whose CURRENT old-registry affiliate group is that group.
+ *
+ * Single-slot reduction: within the event stream filtered to a group, a human
+ * is added on `newGroup == group` and removed on `oldGroup == group`, applied in
+ * block order. Any transition that moves a human OUT of the group carries
+ * `oldGroup == group` (so it is in the filtered stream), and any transition that
+ * moves them elsewhere from a non-group state does not touch the group — so the
+ * filtered stream fully captures the group's membership. This mirrors the
+ * reduction in `oic/logic.ts` and `group-affiliates/affiliateMap.ts`.
+ *
+ * Used by `union` untrust mode (migration bridge — do not evict members who
+ * joined via the old path) and the pre-cutover eviction-diff tool. Read-only.
+ */
+export async function fetchOldRegistryMembersByGroup(
+  rpcUrl: string,
+  groupAddresses: readonly string[],
+  options: OldRegistryMembersOptions = {}
+): Promise<Record<string, Set<string>>> {
+  const registry = normalizeAddress(options.registryAddress ?? DEFAULT_OLD_AFFILIATE_REGISTRY_ADDRESS);
+  const fromBlock = options.fromBlock ?? DEFAULT_OLD_AFFILIATE_REGISTRY_START_BLOCK;
+  const service = new AffiliateGroupEventsService(rpcUrl, options.logger);
+
+  try {
+    const membersByGroup: Record<string, Set<string>> = {};
+    for (const rawGroup of groupAddresses) {
+      const group = normalizeAddress(rawGroup);
+      const events = await service.fetchAffiliateGroupChanged(registry, group, fromBlock, options.toBlock);
+      events.sort((left, right) => left.blockNumber - right.blockNumber);
+
+      const members = new Set<string>();
+      for (const event of events) {
+        const human = normalizeAddress(event.human);
+        if (normalizeAddress(event.newGroup) === group) members.add(human);
+        if (normalizeAddress(event.oldGroup) === group) members.delete(human);
+      }
+      membersByGroup[group] = members;
+    }
+    return membersByGroup;
+  } finally {
+    service.destroy();
+  }
+}

--- a/src/apps/community-new/oldRegistrySource.ts
+++ b/src/apps/community-new/oldRegistrySource.ts
@@ -1,0 +1,174 @@
+import {ILoggerService} from "../../interfaces/ILoggerService";
+import {StateStore} from "../../services/stateStore";
+import {AffiliateMap} from "../group-affiliates/affiliateMap";
+import {
+  AffiliateGroupChangedListenerHandle,
+  deriveGroupAffiliatesWsUrl,
+  fetchAffiliateGroupChangedEventsBetween,
+  fetchCurrentBlockNumber,
+  makeHeadCursor,
+  startAffiliateGroupChangedListener
+} from "../group-affiliates/realtime";
+
+/**
+ * Old single-slot affiliate-registry membership source for community-new.
+ *
+ * This is the exact engine group-affiliates uses — the shared {@link AffiliateMap}
+ * (human → current affiliate group, last-writer-wins) hydrated by replaying
+ * `AffiliateGroupChanged` events, plus the same getLogs backfill / WSS realtime
+ * listener from group-affiliates/realtime. Reusing that code (rather than
+ * re-implementing it) guarantees byte-identical old-registry behavior, so
+ * community-new in `old`/`hybrid` mode is a faithful replacement.
+ *
+ * `getMembersOf(group)` returns the current single-slot membership of a group —
+ * this is what feeds `wishlistOverrideByGroup` for non-test avatars.
+ */
+export const OLD_AFFILIATE_MAP_STATE_KEY = "community-new:old-affiliate-map";
+
+export type OldRegistrySourceOptions = {
+  chainRpcUrl: string;
+  wssUrl?: string;
+  registryAddress: string;
+  startBlock: number;
+  logger: ILoggerService;
+  stateStore: StateStore | null;
+  enableWss: boolean;
+};
+
+export class OldRegistrySource {
+  private listener: AffiliateGroupChangedListenerHandle | null = null;
+  // Serializes ALL map mutations (poll refresh + WSS onEvents) so they never
+  // interleave — AffiliateMap.set is last-writer-wins by CALL order, not block
+  // order, so concurrent writers could regress a human to a stale group. Mirrors
+  // group-affiliates' enqueueExclusive.
+  private tail: Promise<unknown> = Promise.resolve();
+
+  private constructor(
+    private readonly map: AffiliateMap,
+    private readonly opts: OldRegistrySourceOptions
+  ) {}
+
+  private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.tail.then(() => fn());
+    this.tail = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  /** Load the persisted map (if any) or start fresh at the registry deploy block. */
+  static async create(opts: OldRegistrySourceOptions): Promise<OldRegistrySource> {
+    const loaded = opts.stateStore
+      ? await AffiliateMap.load(opts.stateStore, OLD_AFFILIATE_MAP_STATE_KEY)
+      : null;
+    const map = loaded ?? new AffiliateMap(Math.max(0, opts.startBlock - 1));
+    return new OldRegistrySource(map, opts);
+  }
+
+  /**
+   * Full backfill from the persisted cursor to chain head BEFORE the first
+   * reconcile (mirrors group-affiliates' ensureAffiliateMapBackfill), so the
+   * membership set is complete — a partial map would look like mass departures
+   * and, under wishlist untrust, evict real members. Then optionally start the
+   * WSS listener for realtime updates.
+   */
+  async init(): Promise<void> {
+    await this.refresh();
+    if (this.opts.enableWss) {
+      this.startListener();
+    }
+  }
+
+  /** Incremental getLogs catch-up to chain head + persist. Also the poll backstop. */
+  refresh(): Promise<void> {
+    return this.runExclusive(() => this.refreshInner());
+  }
+
+  private async refreshInner(): Promise<void> {
+    const head = await fetchCurrentBlockNumber(this.opts.chainRpcUrl);
+    if (head === null) return;
+    const from = Math.max(this.opts.startBlock, this.map.lastScannedBlock + 1);
+    if (from > head) return;
+    const events = await fetchAffiliateGroupChangedEventsBetween(
+      this.opts.chainRpcUrl,
+      this.opts.registryAddress,
+      from,
+      head,
+      null,
+      this.opts.logger
+    );
+    for (const event of events) {
+      this.map.set(event.human, event.newGroup, event.blockNumber);
+    }
+    this.map.advanceCursor(head);
+    await this.persist();
+  }
+
+  /** Current single-slot members of a group (lowercased). */
+  getMembersOf(group: string): Set<string> {
+    return new Set(this.map.getAffiliatesOf(group));
+  }
+
+  get lastScannedBlock(): number {
+    return this.map.lastScannedBlock;
+  }
+
+  stop(): void {
+    if (this.listener) {
+      try {
+        this.listener.stop();
+      } catch (error) {
+        this.opts.logger.warn("Failed to stop old-affiliate listener:", error);
+      }
+      this.listener = null;
+    }
+  }
+
+  private startListener(): void {
+    const wsUrl = this.opts.wssUrl ?? deriveGroupAffiliatesWsUrl(this.opts.chainRpcUrl);
+    this.listener = startAffiliateGroupChangedListener({
+      httpRpcUrl: this.opts.chainRpcUrl,
+      wsUrl,
+      registryAddress: this.opts.registryAddress,
+      logger: this.opts.logger.child("wss-old"),
+      startCursor: makeHeadCursor(this.map.lastScannedBlock),
+      onEvents: (events) => this.runExclusive(async () => {
+        for (const event of events) {
+          this.map.set(event.human, event.newGroup, event.blockNumber);
+        }
+        await this.persist();
+        return true;
+      })
+    });
+    this.opts.logger.info(`Old-affiliate WSS listener started on ${wsUrl}.`);
+  }
+
+  private async persist(): Promise<void> {
+    if (!this.opts.stateStore) return;
+    try {
+      await this.map.save(this.opts.stateStore, OLD_AFFILIATE_MAP_STATE_KEY);
+    } catch (error) {
+      this.opts.logger.warn("Failed to persist old-affiliate map:", error);
+    }
+  }
+}
+
+/**
+ * Hybrid membership merge, per group. Non-test avatars are governed by the OLD
+ * single-slot registry (prod behavior, unchanged); test-dev avatars in the
+ * allowlist are governed entirely by the NEW multi-registry (so they can exercise
+ * add/remove-multiple-groups). Per-address the source switches — not a union.
+ * All inputs are lowercased.
+ */
+export function mergeHybridMembers(
+  oldMembers: ReadonlySet<string>,
+  newMembers: ReadonlySet<string>,
+  testAddresses: ReadonlySet<string>
+): Set<string> {
+  const merged = new Set<string>();
+  for (const avatar of oldMembers) {
+    if (!testAddresses.has(avatar)) merged.add(avatar);
+  }
+  for (const avatar of newMembers) {
+    if (testAddresses.has(avatar)) merged.add(avatar);
+  }
+  return merged;
+}

--- a/src/apps/community-new/reputationConfig.ts
+++ b/src/apps/community-new/reputationConfig.ts
@@ -1,5 +1,8 @@
+// The analytics rep_score service exposes the default ScoreGroup under the slug
+// `score_group_v2` (or its address form 0x93ed5a96…); the older `score_group`
+// slug 404s ("Unknown group: score_group") and silently yields no scores.
 export const DEFAULT_COMMUNITY_REPUTATION_SCORES_URL =
-  "https://rpc.aboutcircles.com/analytics/rep_score/groups/score_group/scores";
+  "https://rpc.aboutcircles.com/analytics/rep_score/groups/score_group_v2/scores";
 
 export type CommunityReputationConfig = {
   baseUrl: string;

--- a/src/apps/community-new/tools/evictionDiff.ts
+++ b/src/apps/community-new/tools/evictionDiff.ts
@@ -1,16 +1,18 @@
 /**
  * READ-ONLY pre-cutover verification tool for community-new.
  *
- * Runs the real reconciler in dry-run for each untrust mode and reports, per
- * managed group, exactly which current on-chain members each mode would evict.
- * This is the "0 regressions" proof: before flipping community-new wet, the
- * chosen mode's eviction set must be empty (or intentional).
+ * Runs the real reconciler in dry-run and reports, per managed group, exactly
+ * which current on-chain members each untrust mode would evict. This is the
+ * "0 regressions" proof: before flipping community-new wet, the chosen mode's
+ * eviction set must be empty (or intentional).
  *
- *   add-only  → always 0 evictions (migration-safe default).
- *   union     → evicts only current members absent from BOTH the new wishlist
- *               and the old registry (truly orphaned / manual trusts).
- *   wishlist  → evicts every current member not eligible on the new wishlist
- *               (the full migration-eviction blast radius).
+ * Two report shapes, selected by COMMUNITY_NEW_MEMBERSHIP_SOURCE:
+ *   rpc (default) — membership from the staging wishlist RPC; reports add-only /
+ *                   union / wishlist evictions (the migration blast radius).
+ *   old|hybrid|new — membership rebuilt from chain events (the modes that run on
+ *                   prod1). Reports the wishlist-authoritative eviction set —
+ *                   i.e. exactly what the worker would untrust once wet. Fees are
+ *                   off (feeCapEnabled=false), matching the worker on prod.
  *
  * Makes no on-chain writes. Reads config from the same COMMUNITY_NEW_* env vars
  * as the worker. Run: `npm run diff:community-new` (after `npm run build`).
@@ -21,11 +23,13 @@ import {IGroupService} from "../../../interfaces/IGroupService";
 import {AffiliateGroupsRpcService} from "../../../services/affiliateGroupsRpcService";
 import {CirclesRpcService} from "../../../services/circlesRpcService";
 import {LoggerService} from "../../../services/loggerService";
+import {fetchCurrentBlockNumber} from "../../group-affiliates/realtime";
 import {
   BulkReputationService,
   IReputationService,
   ReputationService
 } from "../../group-affiliates/reputationService";
+import {AffiliateMultiMap} from "../affiliateMultiMap";
 import {CommunityGroupProfileService} from "../groupProfileService";
 import {
   DEFAULT_COMMUNITY_GROUP_ADDRESSES,
@@ -34,7 +38,17 @@ import {
   UntrustMode,
   runCommunityReconciliation
 } from "../logic";
-import {fetchOldRegistryMembersByGroup} from "../oldRegistryMembers";
+import {
+  DEFAULT_MULTI_AFFILIATE_REGISTRY_ADDRESS,
+  DEFAULT_MULTI_AFFILIATE_REGISTRY_DEPLOY_BLOCK,
+  fetchMultiAffiliateEvents
+} from "../multiRegistry";
+import {
+  DEFAULT_OLD_AFFILIATE_REGISTRY_ADDRESS,
+  DEFAULT_OLD_AFFILIATE_REGISTRY_START_BLOCK,
+  fetchOldRegistryMembersByGroup
+} from "../oldRegistryMembers";
+import {OldRegistrySource, mergeHybridMembers} from "../oldRegistrySource";
 import {resolveCommunityReputationConfig} from "../reputationConfig";
 
 const READONLY_GROUP_SERVICE: IGroupService = {
@@ -57,10 +71,94 @@ function resolveGroups(): string[] {
   return Array.from(new Set(values.map((value) => getAddress(value).toLowerCase())));
 }
 
+function parseAddressSet(raw: string | undefined): Set<string> {
+  const set = new Set<string>();
+  if (!raw) return set;
+  for (const value of raw.split(",").map((entry) => entry.trim()).filter(Boolean)) {
+    set.add(getAddress(value).toLowerCase());
+  }
+  return set;
+}
+
+function parseSource(raw: string | undefined): "rpc" | "registry" | "old" | "hybrid" {
+  const value = (raw ?? "").trim().toLowerCase();
+  if (value === "registry" || value === "new") return "registry";
+  if (value === "old") return "old";
+  if (value === "hybrid") return "hybrid";
+  return "rpc";
+}
+
+/** Rebuild the per-group membership override from chain events (old/hybrid/new). */
+async function buildChainOverride(
+  source: "registry" | "old" | "hybrid",
+  groups: string[],
+  chainRpcUrl: string,
+  logger: LoggerService
+): Promise<Record<string, ReadonlySet<string>>> {
+  const needOld = source === "old" || source === "hybrid";
+  const needNew = source === "registry" || source === "hybrid";
+  const testAddresses = parseAddressSet(process.env.COMMUNITY_NEW_TEST_ADDRESSES);
+
+  let oldSource: OldRegistrySource | null = null;
+  if (needOld) {
+    oldSource = await OldRegistrySource.create({
+      chainRpcUrl,
+      registryAddress: process.env.COMMUNITY_NEW_OLD_REGISTRY_ADDRESS || DEFAULT_OLD_AFFILIATE_REGISTRY_ADDRESS,
+      startBlock: parseIntEnv("COMMUNITY_NEW_OLD_REGISTRY_START_BLOCK", DEFAULT_OLD_AFFILIATE_REGISTRY_START_BLOCK),
+      logger,
+      stateStore: null,
+      enableWss: false
+    });
+    await oldSource.init();
+  }
+
+  let multiMap: AffiliateMultiMap | null = null;
+  if (needNew) {
+    const registryAddress = process.env.COMMUNITY_NEW_REGISTRY_ADDRESS || DEFAULT_MULTI_AFFILIATE_REGISTRY_ADDRESS;
+    const deployBlock = parseIntEnv("COMMUNITY_NEW_REGISTRY_DEPLOY_BLOCK", DEFAULT_MULTI_AFFILIATE_REGISTRY_DEPLOY_BLOCK);
+    const head = await fetchCurrentBlockNumber(chainRpcUrl);
+    multiMap = new AffiliateMultiMap(deployBlock - 1);
+    if (head !== null) {
+      const events = await fetchMultiAffiliateEvents(chainRpcUrl, registryAddress, deployBlock, head, logger);
+      for (const event of events) {
+        if (event.type === "add") multiMap.add(event.avatar, event.group, event.blockNumber);
+        else multiMap.remove(event.avatar, event.group, event.blockNumber);
+      }
+    }
+  }
+
+  const override: Record<string, ReadonlySet<string>> = {};
+  for (const group of groups) {
+    if (source === "old" && oldSource) {
+      override[group] = oldSource.getMembersOf(group);
+    } else if (source === "registry" && multiMap) {
+      override[group] = multiMap.getMembersOf(group);
+    } else if (source === "hybrid" && oldSource && multiMap) {
+      override[group] = mergeHybridMembers(oldSource.getMembersOf(group), multiMap.getMembersOf(group), testAddresses);
+    } else {
+      override[group] = new Set();
+    }
+  }
+  return override;
+}
+
+function parseIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw || raw.trim().length === 0) return fallback;
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
 async function run(): Promise<void> {
   const logger = new LoggerService(false, "community-new-diff");
-  const communityRpcUrl = process.env.COMMUNITY_NEW_RPC_URL || "https://rpc.staging.aboutcircles.com";
-  const chainRpcUrl = process.env.RPC_URL || communityRpcUrl;
+  const source = parseSource(process.env.COMMUNITY_NEW_MEMBERSHIP_SOURCE);
+  // Mirror the worker's RPC resolution (main.ts): in non-rpc modes trustees +
+  // profiles must read the SAME prod chain as membership, never the staging
+  // default — else the diff compares prod membership against staging trustees,
+  // producing a bogus "0-regression" proof.
+  const chainRpcUrl = process.env.RPC_URL || "https://rpc.staging.aboutcircles.com";
+  const communityRpcUrl = process.env.COMMUNITY_NEW_RPC_URL
+    || (source === "rpc" ? "https://rpc.staging.aboutcircles.com" : chainRpcUrl);
   const groups = resolveGroups();
 
   const affiliateRpc = new AffiliateGroupsRpcService(communityRpcUrl);
@@ -72,8 +170,7 @@ async function run(): Promise<void> {
     : new ReputationService(baseUrl);
 
   const minRepScoresByGroup = await profileService.fetchMinRepScores(groups);
-  const oldRegistryMembers = await fetchOldRegistryMembersByGroup(chainRpcUrl, groups, {logger});
-
+  const deps = {affiliateRpc, circlesRpc, groupService: READONLY_GROUP_SERVICE, reputationService, logger};
   const baseCfg = {
     managedGroupAddresses: groups,
     minRepScoresByGroup,
@@ -86,41 +183,81 @@ async function run(): Promise<void> {
     maxUntrustTotal: Number.MAX_SAFE_INTEGER,
     maxUntrustRatioPerGroup: 1
   };
-  const deps = {affiliateRpc, circlesRpc, groupService: READONLY_GROUP_SERVICE, reputationService, logger};
 
-  const wishlist = await runCommunityReconciliation(deps, {...baseCfg, untrustMode: "wishlist" as UntrustMode});
-  const union = await runCommunityReconciliation(deps, {
-    ...baseCfg,
-    untrustMode: "union" as UntrustMode,
-    protectedTrusteesByGroup: oldRegistryMembers
-  });
+  const lines: string[] = ["", `=== community-new pre-cutover eviction diff (READ-ONLY, source=${source}) ===`];
 
-  let totalWishlist = 0;
-  let totalUnion = 0;
-  const lines: string[] = ["", "=== community-new pre-cutover eviction diff (READ-ONLY) ==="];
-  for (const group of groups) {
-    const trustees = wishlist.currentTrusteesByGroup[group] ?? 0;
-    const wl = wishlist.wishlistMembersByGroup[group] ?? 0;
-    const oldMembers = oldRegistryMembers[group]?.size ?? 0;
-    const wEvict = wishlist.untrustedByGroup[group] ?? [];
-    const uEvict = union.untrustedByGroup[group] ?? [];
-    totalWishlist += wEvict.length;
-    totalUnion += uEvict.length;
+  if (source === "rpc") {
+    // Legacy staging path: compare add-only / union / wishlist against the RPC wishlist.
+    const oldRegistryMembers = await fetchOldRegistryMembersByGroup(chainRpcUrl, groups, {logger});
+    const wishlist = await runCommunityReconciliation(deps, {...baseCfg, untrustMode: "wishlist" as UntrustMode});
+    const union = await runCommunityReconciliation(deps, {
+      ...baseCfg,
+      untrustMode: "union" as UntrustMode,
+      protectedTrusteesByGroup: oldRegistryMembers
+    });
+    let totalWishlist = 0;
+    let totalUnion = 0;
+    for (const group of groups) {
+      const trustees = wishlist.currentTrusteesByGroup[group] ?? 0;
+      const wl = wishlist.wishlistMembersByGroup[group] ?? 0;
+      const oldMembers = oldRegistryMembers[group]?.size ?? 0;
+      const wEvict = wishlist.untrustedByGroup[group] ?? [];
+      const uEvict = union.untrustedByGroup[group] ?? [];
+      totalWishlist += wEvict.length;
+      totalUnion += uEvict.length;
+      lines.push(
+        "",
+        `Group ${group}`,
+        `  on-chain trustees=${trustees}  wishlist=${wl}  old-registry members=${oldMembers}`,
+        `  add-only mode → evictions: 0`,
+        `  union mode    → evictions: ${uEvict.length}${uEvict.length ? "  [" + uEvict.join(", ") + "]" : ""}`,
+        `  wishlist mode → evictions: ${wEvict.length}${wEvict.length ? "  [" + wEvict.join(", ") + "]" : ""}`
+      );
+    }
     lines.push(
       "",
-      `Group ${group}`,
-      `  on-chain trustees=${trustees}  wishlist=${wl}  old-registry members=${oldMembers}`,
-      `  add-only mode → evictions: 0`,
-      `  union mode    → evictions: ${uEvict.length}${uEvict.length ? "  [" + uEvict.join(", ") + "]" : ""}`,
-      `  wishlist mode → evictions: ${wEvict.length}${wEvict.length ? "  [" + wEvict.join(", ") + "]" : ""}`
+      `TOTAL evictions — add-only: 0   union: ${totalUnion}   wishlist: ${totalWishlist}`,
+      "Zero-regression cutover requires the chosen mode's eviction set to be empty or intentional.",
+      ""
+    );
+  } else {
+    // Prod path: membership rebuilt from chain; report the authoritative eviction set.
+    const wishlistOverrideByGroup = await buildChainOverride(source, groups, chainRpcUrl, logger);
+    const reputationBypassAddresses = source === "hybrid" && process.env.COMMUNITY_NEW_TEST_BYPASS_REPUTATION === "1"
+      ? parseAddressSet(process.env.COMMUNITY_NEW_TEST_ADDRESSES)
+      : undefined;
+    const result = await runCommunityReconciliation(deps, {
+      ...baseCfg,
+      untrustMode: "wishlist" as UntrustMode,
+      feeCapEnabled: false,
+      wishlistOverrideByGroup,
+      reputationBypassAddresses
+    });
+    let totalEvict = 0;
+    let totalTrust = 0;
+    for (const group of groups) {
+      const trustees = result.currentTrusteesByGroup[group] ?? 0;
+      const members = result.wishlistMembersByGroup[group] ?? 0;
+      const evict = result.untrustedByGroup[group] ?? [];
+      const add = result.trustedByGroup[group] ?? [];
+      totalEvict += evict.length;
+      totalTrust += add.length;
+      lines.push(
+        "",
+        `Group ${group}`,
+        `  on-chain trustees=${trustees}  ${source}-members=${members}`,
+        `  would UNTRUST: ${evict.length}${evict.length ? "  [" + evict.join(", ") + "]" : ""}`,
+        `  would TRUST:   ${add.length}${add.length ? "  [" + add.join(", ") + "]" : ""}`
+      );
+    }
+    lines.push(
+      "",
+      `TOTAL — untrust: ${totalEvict}   trust: ${totalTrust}  (mode=wishlist, feeCap=off)`,
+      "Zero-regression cutover requires the untrust set to be empty or intentional.",
+      ""
     );
   }
-  lines.push(
-    "",
-    `TOTAL evictions — add-only: 0   union: ${totalUnion}   wishlist: ${totalWishlist}`,
-    "Zero-regression cutover requires the chosen mode's eviction set to be empty or intentional.",
-    ""
-  );
+
   // Intentional stdout report (this is a CLI tool, not the worker loop).
   process.stdout.write(lines.join("\n") + "\n");
 }

--- a/src/apps/community-new/tools/evictionDiff.ts
+++ b/src/apps/community-new/tools/evictionDiff.ts
@@ -1,0 +1,131 @@
+/**
+ * READ-ONLY pre-cutover verification tool for community-new.
+ *
+ * Runs the real reconciler in dry-run for each untrust mode and reports, per
+ * managed group, exactly which current on-chain members each mode would evict.
+ * This is the "0 regressions" proof: before flipping community-new wet, the
+ * chosen mode's eviction set must be empty (or intentional).
+ *
+ *   add-only  → always 0 evictions (migration-safe default).
+ *   union     → evicts only current members absent from BOTH the new wishlist
+ *               and the old registry (truly orphaned / manual trusts).
+ *   wishlist  → evicts every current member not eligible on the new wishlist
+ *               (the full migration-eviction blast radius).
+ *
+ * Makes no on-chain writes. Reads config from the same COMMUNITY_NEW_* env vars
+ * as the worker. Run: `npm run diff:community-new` (after `npm run build`).
+ */
+import {getAddress} from "ethers";
+
+import {IGroupService} from "../../../interfaces/IGroupService";
+import {AffiliateGroupsRpcService} from "../../../services/affiliateGroupsRpcService";
+import {CirclesRpcService} from "../../../services/circlesRpcService";
+import {LoggerService} from "../../../services/loggerService";
+import {
+  BulkReputationService,
+  IReputationService,
+  ReputationService
+} from "../../group-affiliates/reputationService";
+import {CommunityGroupProfileService} from "../groupProfileService";
+import {
+  DEFAULT_COMMUNITY_GROUP_ADDRESSES,
+  DEFAULT_COMMUNITY_PAGE_SIZE,
+  DEFAULT_FEE_FETCH_CONCURRENCY,
+  UntrustMode,
+  runCommunityReconciliation
+} from "../logic";
+import {fetchOldRegistryMembersByGroup} from "../oldRegistryMembers";
+import {resolveCommunityReputationConfig} from "../reputationConfig";
+
+const READONLY_GROUP_SERVICE: IGroupService = {
+  trustBatchWithConditions: async () => {
+    throw new Error("eviction-diff is read-only: no trust writes");
+  },
+  untrustBatch: async () => {
+    throw new Error("eviction-diff is read-only: no untrust writes");
+  },
+  fetchGroupOwnerAndService: async () => {
+    throw new Error("eviction-diff is read-only: group service lookups not needed");
+  }
+};
+
+function resolveGroups(): string[] {
+  const raw = process.env.COMMUNITY_NEW_GROUP_ADDRESSES;
+  const values = raw
+    ? raw.split(",").map((value) => value.trim()).filter(Boolean)
+    : [...DEFAULT_COMMUNITY_GROUP_ADDRESSES];
+  return Array.from(new Set(values.map((value) => getAddress(value).toLowerCase())));
+}
+
+async function run(): Promise<void> {
+  const logger = new LoggerService(false, "community-new-diff");
+  const communityRpcUrl = process.env.COMMUNITY_NEW_RPC_URL || "https://rpc.staging.aboutcircles.com";
+  const chainRpcUrl = process.env.RPC_URL || communityRpcUrl;
+  const groups = resolveGroups();
+
+  const affiliateRpc = new AffiliateGroupsRpcService(communityRpcUrl);
+  const circlesRpc = new CirclesRpcService(communityRpcUrl);
+  const profileService = new CommunityGroupProfileService(communityRpcUrl);
+  const {baseUrl, scoresUrl, useBulk} = resolveCommunityReputationConfig(process.env);
+  const reputationService: IReputationService = useBulk
+    ? new BulkReputationService(scoresUrl)
+    : new ReputationService(baseUrl);
+
+  const minRepScoresByGroup = await profileService.fetchMinRepScores(groups);
+  const oldRegistryMembers = await fetchOldRegistryMembersByGroup(chainRpcUrl, groups, {logger});
+
+  const baseCfg = {
+    managedGroupAddresses: groups,
+    minRepScoresByGroup,
+    pageSize: DEFAULT_COMMUNITY_PAGE_SIZE,
+    batchSize: 20,
+    feeFetchConcurrency: DEFAULT_FEE_FETCH_CONCURRENCY,
+    dryRun: true,
+    // In dry-run the circuit breaker only warns; keep caps wide so the full
+    // would-be-eviction set is computed and reported rather than truncated.
+    maxUntrustTotal: Number.MAX_SAFE_INTEGER,
+    maxUntrustRatioPerGroup: 1
+  };
+  const deps = {affiliateRpc, circlesRpc, groupService: READONLY_GROUP_SERVICE, reputationService, logger};
+
+  const wishlist = await runCommunityReconciliation(deps, {...baseCfg, untrustMode: "wishlist" as UntrustMode});
+  const union = await runCommunityReconciliation(deps, {
+    ...baseCfg,
+    untrustMode: "union" as UntrustMode,
+    protectedTrusteesByGroup: oldRegistryMembers
+  });
+
+  let totalWishlist = 0;
+  let totalUnion = 0;
+  const lines: string[] = ["", "=== community-new pre-cutover eviction diff (READ-ONLY) ==="];
+  for (const group of groups) {
+    const trustees = wishlist.currentTrusteesByGroup[group] ?? 0;
+    const wl = wishlist.wishlistMembersByGroup[group] ?? 0;
+    const oldMembers = oldRegistryMembers[group]?.size ?? 0;
+    const wEvict = wishlist.untrustedByGroup[group] ?? [];
+    const uEvict = union.untrustedByGroup[group] ?? [];
+    totalWishlist += wEvict.length;
+    totalUnion += uEvict.length;
+    lines.push(
+      "",
+      `Group ${group}`,
+      `  on-chain trustees=${trustees}  wishlist=${wl}  old-registry members=${oldMembers}`,
+      `  add-only mode → evictions: 0`,
+      `  union mode    → evictions: ${uEvict.length}${uEvict.length ? "  [" + uEvict.join(", ") + "]" : ""}`,
+      `  wishlist mode → evictions: ${wEvict.length}${wEvict.length ? "  [" + wEvict.join(", ") + "]" : ""}`
+    );
+  }
+  lines.push(
+    "",
+    `TOTAL evictions — add-only: 0   union: ${totalUnion}   wishlist: ${totalWishlist}`,
+    "Zero-regression cutover requires the chosen mode's eviction set to be empty or intentional.",
+    ""
+  );
+  // Intentional stdout report (this is a CLI tool, not the worker loop).
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+run().then(() => process.exit(0)).catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/src/services/affiliateGroupsRpcService.ts
+++ b/src/services/affiliateGroupsRpcService.ts
@@ -14,6 +14,19 @@ const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_RETRY_BASE_DELAY_MS = 1_000;
 const DEFAULT_RETRY_MAX_DELAY_MS = 30_000;
 
+/**
+ * The Circles RPC affiliate methods are being renamed (…AffiliateGroup…→…Community…)
+ * on the Nethermind plugin. We try the NEW name first and fall back to the OLD on
+ * `-32601 Method not found`, caching the winner, so the worker keeps working on
+ * nodes before AND after the rename ships. Only used in `rpc` membership mode.
+ */
+type MethodPair = {primary: string; fallback: string};
+const RENAMED_METHODS: Record<"membersWishlist" | "members" | "fees", MethodPair> = {
+  membersWishlist: {primary: "circles_getCommunityMembersWishlist", fallback: "circles_getAffiliateGroupMembersWishlist"},
+  members: {primary: "circles_getCommunityMembers", fallback: "circles_getAffiliateGroupMembers"},
+  fees: {primary: "circles_getAvatarCommunityFeesPercentage", fallback: "circles_getAffiliateGroupFeesPercentage"}
+};
+
 type JsonRpcError = {
   code?: unknown;
   message?: unknown;
@@ -48,6 +61,8 @@ class AffiliateRpcHttpError extends Error {
  */
 export class AffiliateGroupsRpcService implements IAffiliateGroupsRpc {
   private requestId = 0;
+  /** Resolved method name per pair.primary (new-vs-old rename), decided once. */
+  private readonly resolvedNames = new Map<string, string>();
 
   constructor(
     rpcUrl: string,
@@ -69,44 +84,44 @@ export class AffiliateGroupsRpcService implements IAffiliateGroupsRpc {
     groupAddress: string,
     pageSize: number = DEFAULT_PAGE_SIZE
   ): Promise<AffiliateGroupMember[]> {
-    return this.fetchAllMembers("circles_getAffiliateGroupMembersWishlist", groupAddress, pageSize);
+    return this.fetchAllMembers(RENAMED_METHODS.membersWishlist, groupAddress, pageSize);
   }
 
   /**
-   * Startup probe: verifies the affiliate wishlist RPC method exists on the
-   * configured node. The `circles_getAffiliateGroup*` methods are not served by
-   * every Circles RPC (prod `rpc.aboutcircles.com` returns `-32601 Method not
-   * found`). A single-page call surfaces a wrong-endpoint misconfiguration at
-   * boot instead of after a poll cycle. Throws on any RPC/transport error.
+   * Startup probe: verifies the community/affiliate wishlist RPC method exists on
+   * the configured node. These methods are not served by every Circles RPC (prod
+   * `rpc.aboutcircles.com` returns `-32601 Method not found`). A single-page call
+   * surfaces a wrong-endpoint misconfiguration at boot instead of after a poll
+   * cycle. Tolerates the …Affiliate…→…Community… rename via fallback.
    */
   async assertAffiliateMethodsAvailable(groupAddress: string): Promise<void> {
     const group = normalizeAddress(groupAddress, "group");
-    await this.call("circles_getAffiliateGroupMembersWishlist", [group, 1]);
+    await this.callWithFallback(RENAMED_METHODS.membersWishlist, [group, 1]);
   }
 
   fetchAllGroupMembers(
     groupAddress: string,
     pageSize: number = DEFAULT_PAGE_SIZE
   ): Promise<AffiliateGroupMember[]> {
-    return this.fetchAllMembers("circles_getAffiliateGroupMembers", groupAddress, pageSize);
+    return this.fetchAllMembers(RENAMED_METHODS.members, groupAddress, pageSize);
   }
 
   async fetchAffiliateGroupFeesPercentage(avatarAddress: string): Promise<number> {
     const avatar = normalizeAddress(avatarAddress, "avatar");
-    const result = await this.call("circles_getAffiliateGroupFeesPercentage", [avatar]);
+    const result = await this.callWithFallback(RENAMED_METHODS.fees, [avatar]);
     if (!isRecord(result)) {
-      throw new Error("circles_getAffiliateGroupFeesPercentage returned a non-object result");
+      throw new Error("community fees RPC returned a non-object result");
     }
 
     const total = result.totalFeePercentage;
     if (typeof total !== "number" || !Number.isFinite(total) || total < 0) {
-      throw new Error("circles_getAffiliateGroupFeesPercentage returned an invalid totalFeePercentage");
+      throw new Error("community fees RPC returned an invalid totalFeePercentage");
     }
     return total;
   }
 
   private async fetchAllMembers(
-    method: "circles_getAffiliateGroupMembersWishlist" | "circles_getAffiliateGroupMembers",
+    methodPair: MethodPair,
     groupAddress: string,
     pageSize: number
   ): Promise<AffiliateGroupMember[]> {
@@ -114,11 +129,12 @@ export class AffiliateGroupsRpcService implements IAffiliateGroupsRpc {
     const limit = normalizePageSize(pageSize);
     const members = new Map<string, AffiliateGroupMember>();
     const seenCursors = new Set<string>();
+    const label = methodPair.primary;
     let cursor: string | null = null;
 
     for (let pageNumber = 1; pageNumber <= this.maxPages; pageNumber++) {
       const params: unknown[] = cursor ? [group, limit, cursor] : [group, limit];
-      const page = parseMembersPage(await this.call(method, params), method);
+      const page = parseMembersPage(await this.callWithFallback(methodPair, params), label);
       for (const member of page.results) {
         members.set(member.avatarAddress, member);
       }
@@ -127,16 +143,38 @@ export class AffiliateGroupsRpcService implements IAffiliateGroupsRpc {
         return Array.from(members.values());
       }
       if (!page.nextCursor) {
-        throw new Error(`${method} returned hasMore=true without nextCursor`);
+        throw new Error(`${label} returned hasMore=true without nextCursor`);
       }
       if (seenCursors.has(page.nextCursor)) {
-        throw new Error(`${method} returned a repeated pagination cursor`);
+        throw new Error(`${label} returned a repeated pagination cursor`);
       }
       seenCursors.add(page.nextCursor);
       cursor = page.nextCursor;
     }
 
-    throw new Error(`${method} exceeded the ${this.maxPages}-page safety limit`);
+    throw new Error(`${label} exceeded the ${this.maxPages}-page safety limit`);
+  }
+
+  /**
+   * Call `pair.primary`, falling back to `pair.fallback` on `-32601 Method not
+   * found` (the …Affiliate…→…Community… rename). The resolved name is cached, so
+   * the fallback probe happens at most once per method per process.
+   */
+  private async callWithFallback(pair: MethodPair, params: unknown[]): Promise<unknown> {
+    const cached = this.resolvedNames.get(pair.primary);
+    if (cached) {
+      return this.call(cached, params);
+    }
+    try {
+      const result = await this.call(pair.primary, params);
+      this.resolvedNames.set(pair.primary, pair.primary);
+      return result;
+    } catch (error) {
+      if (!isMethodNotFound(error)) throw error;
+      const result = await this.call(pair.fallback, params);
+      this.resolvedNames.set(pair.primary, pair.fallback);
+      return result;
+    }
   }
 
   private async call(method: string, params: unknown[]): Promise<unknown> {
@@ -266,4 +304,10 @@ function normalizePageSize(value: number): number {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** JSON-RPC "method not found" (-32601) — used to trigger the rename fallback. */
+function isMethodNotFound(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  return message.includes("-32601") || message.includes("method not found");
 }

--- a/src/services/affiliateGroupsRpcService.ts
+++ b/src/services/affiliateGroupsRpcService.ts
@@ -72,6 +72,18 @@ export class AffiliateGroupsRpcService implements IAffiliateGroupsRpc {
     return this.fetchAllMembers("circles_getAffiliateGroupMembersWishlist", groupAddress, pageSize);
   }
 
+  /**
+   * Startup probe: verifies the affiliate wishlist RPC method exists on the
+   * configured node. The `circles_getAffiliateGroup*` methods are not served by
+   * every Circles RPC (prod `rpc.aboutcircles.com` returns `-32601 Method not
+   * found`). A single-page call surfaces a wrong-endpoint misconfiguration at
+   * boot instead of after a poll cycle. Throws on any RPC/transport error.
+   */
+  async assertAffiliateMethodsAvailable(groupAddress: string): Promise<void> {
+    const group = normalizeAddress(groupAddress, "group");
+    await this.call("circles_getAffiliateGroupMembersWishlist", [group, 1]);
+  }
+
   fetchAllGroupMembers(
     groupAddress: string,
     pageSize: number = DEFAULT_PAGE_SIZE

--- a/tests/apps/community-new/affiliateMultiMap.spec.ts
+++ b/tests/apps/community-new/affiliateMultiMap.spec.ts
@@ -1,0 +1,79 @@
+import {AffiliateMultiMap} from "../../../src/apps/community-new/affiliateMultiMap";
+
+const AVATAR = "0x1000000000000000000000000000000000000001";
+const AVATAR_2 = "0x2000000000000000000000000000000000000002";
+const GROUP_A = "0x4e2564e5df6c1fb10c1a018538de36e4d5844de5";
+const GROUP_B = "0x2709757a543cf1bf4d92586b73d3891438b2589d";
+const GROUP_C = "0xeecae593589a6ee4a12ae64f19420b47f3112fa9";
+
+describe("AffiliateMultiMap", () => {
+  it("holds several groups per avatar simultaneously (multi-membership)", () => {
+    const map = new AffiliateMultiMap();
+    map.add(AVATAR, GROUP_A);
+    map.add(AVATAR, GROUP_B);
+    map.add(AVATAR, GROUP_C);
+
+    expect(map.getGroups(AVATAR)).toEqual([GROUP_B, GROUP_C, GROUP_A].sort());
+    expect(map.getMembersOf(GROUP_A)).toEqual(new Set([AVATAR]));
+    expect(map.getMembersOf(GROUP_B)).toEqual(new Set([AVATAR]));
+  });
+
+  it("indexes members per group across avatars", () => {
+    const map = new AffiliateMultiMap();
+    map.add(AVATAR, GROUP_A);
+    map.add(AVATAR_2, GROUP_A);
+    expect(map.getMembersOf(GROUP_A)).toEqual(new Set([AVATAR, AVATAR_2]));
+  });
+
+  it("removes a single membership without touching the others", () => {
+    const map = new AffiliateMultiMap();
+    map.add(AVATAR, GROUP_A);
+    map.add(AVATAR, GROUP_B);
+    map.remove(AVATAR, GROUP_A);
+
+    expect(map.getGroups(AVATAR)).toEqual([GROUP_B]);
+    expect(map.getMembersOf(GROUP_A).size).toBe(0);
+    expect(map.getMembersOf(GROUP_B)).toEqual(new Set([AVATAR]));
+  });
+
+  it("is idempotent on duplicate add and no-op remove", () => {
+    const map = new AffiliateMultiMap();
+    map.add(AVATAR, GROUP_A);
+    map.add(AVATAR, GROUP_A);
+    expect(map.getMembersOf(GROUP_A)).toEqual(new Set([AVATAR]));
+    map.remove(AVATAR_2, GROUP_A); // never a member
+    expect(map.getMembersOf(GROUP_A)).toEqual(new Set([AVATAR]));
+  });
+
+  it("normalizes address casing", () => {
+    const map = new AffiliateMultiMap();
+    map.add(AVATAR.toUpperCase().replace("0X", "0x"), GROUP_A.toUpperCase().replace("0X", "0x"));
+    expect(map.getMembersOf(GROUP_A)).toEqual(new Set([AVATAR]));
+  });
+
+  it("round-trips through a snapshot and advances the scan cursor", () => {
+    const map = new AffiliateMultiMap(100);
+    map.add(AVATAR, GROUP_A, 150);
+    map.add(AVATAR, GROUP_B, 160);
+    map.add(AVATAR_2, GROUP_A, 170);
+
+    const snapshot = map.snapshot();
+    expect(snapshot.lastScannedBlock).toBe(170);
+
+    const restored = AffiliateMultiMap.fromSnapshot(snapshot);
+    expect(restored.getGroups(AVATAR)).toEqual([GROUP_B, GROUP_A].sort());
+    expect(restored.getMembersOf(GROUP_A)).toEqual(new Set([AVATAR, AVATAR_2]));
+    expect(restored.lastScannedBlock).toBe(170);
+    expect(restored.dirty).toBe(false);
+  });
+
+  it("tracks dirty state and cursor advancement", () => {
+    const map = new AffiliateMultiMap(100);
+    expect(map.dirty).toBe(false);
+    map.add(AVATAR, GROUP_A, 120);
+    expect(map.dirty).toBe(true);
+    expect(map.lastScannedBlock).toBe(120);
+    map.advanceCursor(130);
+    expect(map.lastScannedBlock).toBe(130);
+  });
+});

--- a/tests/apps/community-new/logic.spec.ts
+++ b/tests/apps/community-new/logic.spec.ts
@@ -290,4 +290,66 @@ describe("runCommunityReconciliation", () => {
       .toThrow(`No minRepScore was loaded for managed group ${GROUP_A}`);
     expect(deps.groupService.calls).toEqual([]);
   });
+
+  it("feeCapEnabled=false skips the fee RPC and treats fees as unbounded (old/hybrid/new parity)", async () => {
+    const deps = setup();
+    // Membership from override (no wishlist RPC); no fees registered → the fake
+    // fee RPC would throw if called, proving fetchFeePercentages is skipped.
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [];
+    deps.reputationService.scores.set(ELIGIBLE, 90);
+
+    const outcome = await runCommunityReconciliation(deps, config({
+      feeCapEnabled: false,
+      wishlistOverrideByGroup: {[GROUP_A]: new Set([ELIGIBLE])}
+    }));
+
+    expect(outcome.trustedByGroup[GROUP_A]).toEqual([ELIGIBLE]);
+    expect(deps.affiliateRpc.feeRequests).toEqual([]);
+  });
+
+  it("reputationBypassAddresses trusts a cold-start (score 0) test address in hybrid", async () => {
+    const deps = setup();
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [];
+    deps.reputationService.scores.set(ELIGIBLE, 0); // below threshold 40
+
+    const outcome = await runCommunityReconciliation(deps, config({
+      feeCapEnabled: false,
+      wishlistOverrideByGroup: {[GROUP_A]: new Set([ELIGIBLE])},
+      reputationBypassAddresses: new Set([ELIGIBLE])
+    }));
+
+    expect(outcome.trustedByGroup[GROUP_A]).toEqual([ELIGIBLE]);
+    expect(outcome.ineligible).toEqual([]);
+  });
+
+  it("without the bypass, a score-0 address stays ineligible (control)", async () => {
+    const deps = setup();
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [];
+    deps.reputationService.scores.set(ELIGIBLE, 0);
+
+    const outcome = await runCommunityReconciliation(deps, config({
+      feeCapEnabled: false,
+      wishlistOverrideByGroup: {[GROUP_A]: new Set([ELIGIBLE])}
+    }));
+
+    expect(outcome.trustedByGroup[GROUP_A]).toEqual([]);
+    expect(outcome.ineligible).toEqual([
+      expect.objectContaining({avatarAddress: ELIGIBLE, reasons: ["reputation"]})
+    ]);
+  });
+
+  it("old-mode override untrusts a trustee absent from the old-registry membership (affiliates parity)", async () => {
+    const deps = setup();
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [ELIGIBLE, STALE_CONFIRMED];
+    deps.reputationService.scores.set(ELIGIBLE, 90);
+
+    const outcome = await runCommunityReconciliation(deps, config({
+      feeCapEnabled: false,
+      untrustMode: "wishlist",
+      wishlistOverrideByGroup: {[GROUP_A]: new Set([ELIGIBLE])}
+    }));
+
+    expect(outcome.untrustedByGroup[GROUP_A]).toEqual([STALE_CONFIRMED]);
+    expect(outcome.trustedByGroup[GROUP_A]).toEqual([]);
+  });
 });

--- a/tests/apps/community-new/logic.spec.ts
+++ b/tests/apps/community-new/logic.spec.ts
@@ -2,6 +2,7 @@ import {AffiliateGroupMember, IAffiliateGroupsRpc} from "../../../src/interfaces
 import {
   CommunityRunConfig,
   DEFAULT_FEE_FETCH_CONCURRENCY,
+  DEFAULT_UNTRUST_MODE,
   runCommunityReconciliation
 } from "../../../src/apps/community-new/logic";
 import {IReputationService, ReputationVerdict} from "../../../src/apps/group-affiliates/reputationService";
@@ -15,6 +16,8 @@ const EXISTING = "0x2000000000000000000000000000000000000002";
 const LOW_SCORE = "0x3000000000000000000000000000000000000003";
 const OVER_FEE_CAP = "0x4000000000000000000000000000000000000004";
 const STALE_CONFIRMED = "0x5000000000000000000000000000000000000005";
+const PROTECTED = "0x6000000000000000000000000000000000000006";
+const ORPHAN = "0x7000000000000000000000000000000000000007";
 
 class FakeAffiliateRpc implements IAffiliateGroupsRpc {
   wishlistByGroup: Record<string, string[]> = {};
@@ -25,7 +28,7 @@ class FakeAffiliateRpc implements IAffiliateGroupsRpc {
     return (this.wishlistByGroup[groupAddress] ?? []).map(member);
   }
 
-  async fetchAllGroupMembers(groupAddress: string): Promise<AffiliateGroupMember[]> {
+  async fetchAllGroupMembers(_groupAddress: string): Promise<AffiliateGroupMember[]> {
     return [];
   }
 
@@ -82,6 +85,10 @@ describe("runCommunityReconciliation", () => {
     expect(DEFAULT_FEE_FETCH_CONCURRENCY).toBe(2);
   });
 
+  it("defaults to add-only untrust mode (migration-safe)", () => {
+    expect(DEFAULT_UNTRUST_MODE).toBe("add-only");
+  });
+
   it("trusts only wishlist members that pass the group threshold and aggregate fee cap", async () => {
     const deps = setup();
     deps.affiliateRpc.wishlistByGroup[GROUP_A] = [ELIGIBLE, EXISTING, LOW_SCORE, OVER_FEE_CAP];
@@ -99,7 +106,13 @@ describe("runCommunityReconciliation", () => {
       [OVER_FEE_CAP, 90]
     ]);
 
-    const outcome = await runCommunityReconciliation(deps, config());
+    // `wishlist` mode = the snapshot-authoritative behavior these assertions target.
+    // Widen the ratio cap so the circuit breaker (a separate concern) does not
+    // fire on this deliberately small fixture (2 of 3 trustees untrusted).
+    const outcome = await runCommunityReconciliation(
+      deps,
+      config({untrustMode: "wishlist", maxUntrustRatioPerGroup: 1})
+    );
 
     expect(outcome.trustedByGroup[GROUP_A]).toEqual([ELIGIBLE]);
     expect(outcome.untrustedByGroup[GROUP_A]).toEqual([LOW_SCORE, OVER_FEE_CAP]);
@@ -135,18 +148,116 @@ describe("runCommunityReconciliation", () => {
     expect(deps.affiliateRpc.feeRequests).toEqual([ELIGIBLE]);
   });
 
-  it("untrusts a current trustee removed from the wishlist regardless of criteria", async () => {
+  it("supports multi-membership: an eligible avatar is trusted by every group it wishlists", async () => {
     const deps = setup();
-    deps.circlesRpc.trusteesByTruster[GROUP_A] = [STALE_CONFIRMED];
+    deps.affiliateRpc.wishlistByGroup = {
+      [GROUP_A]: [ELIGIBLE],
+      [GROUP_B]: [ELIGIBLE]
+    };
+    deps.affiliateRpc.feesByAvatar[ELIGIBLE] = 0;
+    deps.reputationService.scores.set(ELIGIBLE, 90);
 
-    const outcome = await runCommunityReconciliation(deps, config());
+    const outcome = await runCommunityReconciliation(deps, config({
+      managedGroupAddresses: [GROUP_A, GROUP_B],
+      minRepScoresByGroup: {[GROUP_A]: 40, [GROUP_B]: 40}
+    }));
+
+    expect(outcome.trustedByGroup[GROUP_A]).toEqual([ELIGIBLE]);
+    expect(outcome.trustedByGroup[GROUP_B]).toEqual([ELIGIBLE]);
+  });
+
+  it("wishlist mode untrusts a current trustee absent from a non-empty wishlist", async () => {
+    const deps = setup();
+    // ELIGIBLE keeps the wishlist non-empty (so the empty-wishlist guard does not fire).
+    deps.affiliateRpc.wishlistByGroup[GROUP_A] = [ELIGIBLE];
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [ELIGIBLE, STALE_CONFIRMED];
+    deps.affiliateRpc.feesByAvatar[ELIGIBLE] = 0;
+    deps.reputationService.scores.set(ELIGIBLE, 90);
+
+    const outcome = await runCommunityReconciliation(deps, config({untrustMode: "wishlist"}));
 
     expect(outcome.leftByGroup[GROUP_A]).toEqual([STALE_CONFIRMED]);
+    expect(outcome.trustedByGroup[GROUP_A]).toEqual([]);
     expect(outcome.untrustedByGroup[GROUP_A]).toEqual([STALE_CONFIRMED]);
-    expect(outcome.ineligible).toEqual([]);
     expect(deps.groupService.calls).toEqual([
       {type: "untrust", groupAddress: GROUP_A, trusteeAddresses: [STALE_CONFIRMED]}
     ]);
+  });
+
+  it("add-only mode (default) never untrusts, even wishlist-absent trustees", async () => {
+    const deps = setup();
+    deps.affiliateRpc.wishlistByGroup[GROUP_A] = [ELIGIBLE];
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [STALE_CONFIRMED];
+    deps.affiliateRpc.feesByAvatar[ELIGIBLE] = 0;
+    deps.reputationService.scores.set(ELIGIBLE, 90);
+
+    const outcome = await runCommunityReconciliation(deps, config());
+
+    expect(outcome.untrustedByGroup[GROUP_A]).toEqual([]);
+    expect(outcome.trustedByGroup[GROUP_A]).toEqual([ELIGIBLE]);
+    expect(deps.groupService.calls).toEqual([
+      {type: "trust", groupAddress: GROUP_A, trusteeAddresses: [ELIGIBLE]}
+    ]);
+  });
+
+  it("union mode protects old-registry members and untrusts only orphans", async () => {
+    const deps = setup();
+    deps.affiliateRpc.wishlistByGroup[GROUP_A] = [ELIGIBLE];
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [ELIGIBLE, PROTECTED, ORPHAN];
+    deps.affiliateRpc.feesByAvatar[ELIGIBLE] = 0;
+    deps.reputationService.scores.set(ELIGIBLE, 90);
+
+    const outcome = await runCommunityReconciliation(deps, config({
+      untrustMode: "union",
+      protectedTrusteesByGroup: {[GROUP_A]: new Set([PROTECTED])}
+    }));
+
+    // PROTECTED is an old-registry member → kept; ORPHAN is on neither source → untrusted.
+    expect(outcome.untrustedByGroup[GROUP_A]).toEqual([ORPHAN]);
+    expect(outcome.trustedByGroup[GROUP_A]).toEqual([]);
+  });
+
+  it("empty-wishlist guard: never mass-untrusts when the wishlist comes back empty", async () => {
+    const deps = setup();
+    // No wishlist entries for GROUP_A while it still has trustees.
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [STALE_CONFIRMED, PROTECTED];
+
+    const outcome = await runCommunityReconciliation(deps, config({untrustMode: "wishlist"}));
+
+    expect(outcome.untrustedByGroup[GROUP_A]).toEqual([]);
+    expect(deps.groupService.calls).toEqual([]);
+  });
+
+  it("untrust circuit breaker throws before writing when the cap is exceeded (wet)", async () => {
+    const deps = setup();
+    deps.affiliateRpc.wishlistByGroup[GROUP_A] = [ELIGIBLE];
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [ELIGIBLE, STALE_CONFIRMED, ORPHAN];
+    deps.affiliateRpc.feesByAvatar[ELIGIBLE] = 0;
+    deps.reputationService.scores.set(ELIGIBLE, 90);
+
+    await expect(runCommunityReconciliation(deps, config({
+      untrustMode: "wishlist",
+      maxUntrustTotal: 1
+    }))).rejects.toThrow(/circuit breaker/i);
+    expect(deps.groupService.calls).toEqual([]);
+  });
+
+  it("untrust circuit breaker only warns in dry-run so the plan stays observable", async () => {
+    const deps = setup();
+    deps.affiliateRpc.wishlistByGroup[GROUP_A] = [ELIGIBLE];
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [ELIGIBLE, STALE_CONFIRMED, ORPHAN];
+    deps.affiliateRpc.feesByAvatar[ELIGIBLE] = 0;
+    deps.reputationService.scores.set(ELIGIBLE, 90);
+
+    const outcome = await runCommunityReconciliation(deps, config({
+      untrustMode: "wishlist",
+      maxUntrustTotal: 1,
+      dryRun: true
+    }));
+
+    // Untrust arrays are returned lexicographically sorted.
+    expect(outcome.untrustedByGroup[GROUP_A]).toEqual([STALE_CONFIRMED, ORPHAN]);
+    expect(deps.groupService.calls).toEqual([]);
   });
 
   it("simulates dry-run batches without submitting writes", async () => {
@@ -156,7 +267,11 @@ describe("runCommunityReconciliation", () => {
     deps.affiliateRpc.feesByAvatar = {[ELIGIBLE]: 0, [EXISTING]: 0};
     deps.reputationService.scores = new Map([[ELIGIBLE, 90], [EXISTING, 90]]);
 
-    const outcome = await runCommunityReconciliation(deps, config({batchSize: 1, dryRun: true}));
+    const outcome = await runCommunityReconciliation(deps, config({
+      batchSize: 1,
+      dryRun: true,
+      untrustMode: "wishlist"
+    }));
 
     expect(outcome.trustedByGroup[GROUP_A]).toEqual([ELIGIBLE, EXISTING]);
     expect(deps.groupService.calls).toEqual([]);

--- a/tests/apps/community-new/oldRegistrySource.spec.ts
+++ b/tests/apps/community-new/oldRegistrySource.spec.ts
@@ -1,0 +1,45 @@
+import {mergeHybridMembers} from "../../../src/apps/community-new/oldRegistrySource";
+
+// Lowercased avatar addresses (mergeHybridMembers compares by set membership).
+const TEST_A = "0xaaaa000000000000000000000000000000000001";
+const TEST_B = "0xaaaa000000000000000000000000000000000002";
+const OLD_MEMBER = "0xbbbb000000000000000000000000000000000001";
+const NEW_ONLY = "0xcccc000000000000000000000000000000000001";
+
+describe("mergeHybridMembers", () => {
+  it("governs non-test avatars by OLD registry and test avatars by NEW registry", () => {
+    const testAddresses = new Set([TEST_A]);
+    // OLD has a normal member + a test address; NEW has that test address + a non-test address.
+    const oldMembers = new Set([OLD_MEMBER, TEST_A]);
+    const newMembers = new Set([TEST_A, NEW_ONLY]);
+
+    const merged = mergeHybridMembers(oldMembers, newMembers, testAddresses);
+
+    // OLD_MEMBER kept (non-test, from OLD); TEST_A from NEW (test); NEW_ONLY dropped (non-test, NEW-only).
+    expect(merged).toEqual(new Set([OLD_MEMBER, TEST_A]));
+  });
+
+  it("drops a test address that is in OLD but absent from NEW (switched to NEW governance)", () => {
+    const merged = mergeHybridMembers(new Set([TEST_A]), new Set(), new Set([TEST_A]));
+    expect(merged).toEqual(new Set());
+  });
+
+  it("adds a test address present only in NEW (its multi-group membership)", () => {
+    const merged = mergeHybridMembers(new Set(), new Set([TEST_A, TEST_B]), new Set([TEST_A, TEST_B]));
+    expect(merged).toEqual(new Set([TEST_A, TEST_B]));
+  });
+
+  it("with an empty test allowlist is identical to pure OLD membership", () => {
+    const oldMembers = new Set([OLD_MEMBER, TEST_A]);
+    const newMembers = new Set([NEW_ONLY]);
+    const merged = mergeHybridMembers(oldMembers, newMembers, new Set());
+    expect(merged).toEqual(oldMembers);
+  });
+
+  it("ignores NEW-registry membership for non-test avatars", () => {
+    // NEW_ONLY joined a group via the new registry but is NOT a test address →
+    // must be ignored (prod behavior unchanged for everyone but test devs).
+    const merged = mergeHybridMembers(new Set([OLD_MEMBER]), new Set([NEW_ONLY]), new Set([TEST_A]));
+    expect(merged).toEqual(new Set([OLD_MEMBER]));
+  });
+});

--- a/tests/apps/community-new/reputationConfig.spec.ts
+++ b/tests/apps/community-new/reputationConfig.spec.ts
@@ -4,14 +4,15 @@ import {
 } from "../../../src/apps/community-new/reputationConfig";
 
 describe("resolveCommunityReputationConfig", () => {
-  it("defaults bulk reputation to the backend's score_group scores endpoint", () => {
+  it("defaults bulk reputation to the backend's score_group_v2 scores endpoint", () => {
     expect(resolveCommunityReputationConfig({})).toEqual({
       baseUrl: "",
       scoresUrl: DEFAULT_COMMUNITY_REPUTATION_SCORES_URL,
       useBulk: true
     });
+    // The `score_group` slug 404s ("Unknown group"); `score_group_v2` is the live one.
     expect(DEFAULT_COMMUNITY_REPUTATION_SCORES_URL).toBe(
-      "https://rpc.aboutcircles.com/analytics/rep_score/groups/score_group/scores"
+      "https://rpc.aboutcircles.com/analytics/rep_score/groups/score_group_v2/scores"
     );
   });
 

--- a/tests/services/affiliateGroupsRpcService.spec.ts
+++ b/tests/services/affiliateGroupsRpcService.spec.ts
@@ -37,10 +37,34 @@ describe("AffiliateGroupsRpcService", () => {
     const firstBody = JSON.parse(fetchMock.mock.calls[0][1].body);
     const secondBody = JSON.parse(fetchMock.mock.calls[1][1].body);
     expect(firstBody).toMatchObject({
-      method: "circles_getAffiliateGroupMembersWishlist",
+      method: "circles_getCommunityMembersWishlist",
       params: [GROUP, 50]
     });
     expect(secondBody.params).toEqual([GROUP, 50, "opaque-page-2"]);
+  });
+
+  it("falls back to the legacy affiliate method name on -32601 (rename transition)", async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({jsonrpc: "2.0", id: 1, error: {code: -32601, message: "Method not found"}})
+      })
+      .mockResolvedValueOnce(rpcResponse({
+        results: [{avatarName: null, avatarAddress: AVATAR_A, timestamp: 1}],
+        hasMore: false,
+        nextCursor: null
+      }));
+    const service = new AffiliateGroupsRpcService(RPC_URL);
+
+    await expect(service.fetchAllGroupMembersWishlist(GROUP, 10)).resolves.toEqual([
+      {avatarName: null, avatarAddress: AVATAR_A, timestamp: 1}
+    ]);
+    // Tries the NEW name first, then falls back to the OLD name on method-not-found.
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).method).toBe("circles_getCommunityMembersWishlist");
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).method).toBe("circles_getAffiliateGroupMembersWishlist");
   });
 
   it("reads and validates an avatar's aggregate wishlist fee", async () => {
@@ -50,7 +74,7 @@ describe("AffiliateGroupsRpcService", () => {
     await expect(service.fetchAffiliateGroupFeesPercentage(AVATAR_A)).resolves.toBe(100);
     const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
     expect(body).toMatchObject({
-      method: "circles_getAffiliateGroupFeesPercentage",
+      method: "circles_getAvatarCommunityFeesPercentage",
       params: [AVATAR_A]
     });
   });


### PR DESCRIPTION
Adds a membership-source mode switch so community-new can replace group-affiliates.

## What changed
- `COMMUNITY_NEW_MEMBERSHIP_SOURCE=old|hybrid|new|rpc`
  - `old`: OLD single-slot registry via the reused AffiliateMap + realtime engine (byte-identical to group-affiliates)
  - `hybrid`: OLD registry for everyone except a `COMMUNITY_NEW_TEST_ADDRESSES` allowlist, who are governed by the NEW multi-affiliate registry
  - `new`: NEW multi-affiliate registry for everyone
- chain-authoritative modes default `untrustMode=wishlist`; `rpc` keeps `add-only`
- bypass the staging-only fee RPC in non-rpc modes (`feeCapEnabled`)
- `COMMUNITY_NEW_TEST_BYPASS_REPUTATION` for cold-start test avatars
- default the community RPC to the chain RPC in non-rpc modes (no staging trust reads on prod)
- RPC method-rename tolerance: try `circles_get{Community*,AvatarCommunity*}`, fall back to the legacy affiliate names on -32601 (supersedes the hard rename in #96)
- serialize old-registry map writes (poll refresh + WSS)
- extend the eviction-diff tool to old/hybrid/new membership sources

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (503 passing)
- [ ] staging dry-run in `old` mode: eviction-diff shows no unexpected untrust