### PR TITLE
chore: sync staging→master (community-new grandfather cutover)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,16 @@ COMMUNITY_NEW_UNTRUST_MODE=                       # add-only|union|wishlist (per
 COMMUNITY_NEW_MAX_UNTRUST_TOTAL=20
 COMMUNITY_NEW_MAX_UNTRUST_RATIO=0.5               # (0,1]
 
+# Cutover grandfather list (union mode ONLY). JSON mapping each managed group to
+# avatars that are trusted on-chain but absent from the registry feeding the
+# wishlist (orphans). They are added to the union protected set so an
+# authoritative sweep spares exactly these addresses, while every OTHER member
+# still gets full join/leave/reputation enforcement. Frozen by config on purpose
+# (a recomputed set would re-protect post-cutover leavers). Errors if set while
+# UNTRUST_MODE is not union, or if it names an unmanaged group.
+#   {"0x<group>":["0x<avatar>", ...]}
+COMMUNITY_NEW_GRANDFATHER_ADDRESSES=
+
 # Cutover gate: community-new shares the Safe/signer with group-affiliates. Must
 # retire group-affiliates for these groups first, then set this to run wet.
 COMMUNITY_NEW_ACK_GROUP_AFFILIATES_RETIRED=0
@@ -421,8 +431,8 @@ VERBOSE_LOGGING=1
 ```
 
 **prod1 cutover (replaces group-affiliates — same Safe, so only one runs wet):**
-1. Deploy `MEMBERSHIP_SOURCE=old`, `DRY_RUN=1`; run `npm run diff:community-new` and confirm the untrust set is empty/expected.
-2. Stop group-affiliates → set `COMMUNITY_NEW_ACK_GROUP_AFFILIATES_RETIRED=1`, `DRY_RUN=0` (still `old`). Verify trust/untrust matches the prior worker.
+1. Deploy `MEMBERSHIP_SOURCE=hybrid`, `UNTRUST_MODE=union`, `DRY_RUN=1`; run `npm run diff:community-new`. The report prints both the strict `wishlist` blast radius and the `union+grandfather` set the worker applies — confirm the latter is 0 (or intentional). Populate `COMMUNITY_NEW_GRANDFATHER_ADDRESSES` with the orphans the `wishlist` column lists so day-one removals are zero while leave/rep enforcement stays live for everyone else.
+2. Stop group-affiliates → set `COMMUNITY_NEW_ACK_GROUP_AFFILIATES_RETIRED=1`, `DRY_RUN=0`. Verify trust/untrust matches the prior worker (grandfathered orphans retained; genuine leavers still untrusted).
 3. Switch to `hybrid` with `COMMUNITY_NEW_TEST_ADDRESSES=…` (+ `COMMUNITY_NEW_TEST_BYPASS_REPUTATION=1` for cold-start dev addresses) to exercise multi-group.
 4. GA: switch to `new` for full multi-membership.
 

--- a/src/apps/community-new/grandfather.ts
+++ b/src/apps/community-new/grandfather.ts
@@ -1,0 +1,100 @@
+import {getAddress} from "ethers";
+
+/**
+ * Cutover grandfather list.
+ *
+ * At the old→new cutover a handful of avatars are trusted on-chain but absent
+ * from the registry that feeds the wishlist (orphans — e.g. members whose old
+ * single-slot points elsewhere yet were left trusted by the event-driven
+ * predecessor). A strictly authoritative `wishlist` sweep would evict them.
+ * Listing them here adds them to the `union` protected set, so an authoritative
+ * run spares exactly those addresses while EVERY other member still gets full
+ * join / leave / reputation enforcement.
+ *
+ * The list is frozen by config on purpose. A recomputed "current trustees minus
+ * current members" set would re-protect anyone who leaves AFTER cutover (the
+ * moment they leave they become an orphan), silently defeating leave handling.
+ * A static, reviewable list keeps leave/rep enforcement intact for everyone
+ * except the explicitly enumerated carve-outs.
+ *
+ * Format: a JSON object mapping a managed group address to the avatar addresses
+ * grandfathered in that group, e.g.
+ *   COMMUNITY_NEW_GRANDFATHER_ADDRESSES={"0x4e25…":["0x154d…","0x1e34…"]}
+ * Keys and values are checksum-validated and lowercased. Only consulted in
+ * `union` untrust mode.
+ */
+export const GRANDFATHER_ENV = "COMMUNITY_NEW_GRANDFATHER_ADDRESSES";
+
+function normalizeAddress(value: string): string {
+  return getAddress(value).toLowerCase();
+}
+
+/** Parses {@link GRANDFATHER_ENV}. Empty/unset → no grandfathering. Throws on malformed input. */
+export function parseGrandfatherAddresses(raw: string | undefined): Record<string, Set<string>> {
+  const result: Record<string, Set<string>> = {};
+  const trimmed = (raw ?? "").trim();
+  if (trimmed.length === 0) return result;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (cause) {
+    throw new Error(
+      `${GRANDFATHER_ENV} must be a JSON object mapping group address → avatar address[]; got invalid JSON`,
+      {cause: cause instanceof Error ? cause : new Error(String(cause))}
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${GRANDFATHER_ENV} must be a JSON object mapping group address → avatar address[]`);
+  }
+
+  for (const [rawGroup, rawAddresses] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!Array.isArray(rawAddresses)) {
+      throw new Error(`${GRANDFATHER_ENV}["${rawGroup}"] must be an array of avatar addresses`);
+    }
+    let group: string;
+    try {
+      group = normalizeAddress(rawGroup);
+    } catch {
+      throw new Error(`${GRANDFATHER_ENV} has an invalid group address "${rawGroup}"`);
+    }
+    const set = result[group] ?? new Set<string>();
+    for (const rawAddress of rawAddresses) {
+      if (typeof rawAddress !== "string") {
+        throw new Error(`${GRANDFATHER_ENV}["${rawGroup}"] must contain only address strings`);
+      }
+      try {
+        set.add(normalizeAddress(rawAddress));
+      } catch {
+        throw new Error(`${GRANDFATHER_ENV}["${rawGroup}"] has an invalid avatar address "${rawAddress}"`);
+      }
+    }
+    result[group] = set;
+  }
+  return result;
+}
+
+/** Total grandfathered addresses across all groups (logging / validation). */
+export function countGrandfather(byGroup: Record<string, ReadonlySet<string>>): number {
+  return Object.values(byGroup).reduce((sum, set) => sum + set.size, 0);
+}
+
+/**
+ * Folds the frozen grandfather list into a per-group protected set (e.g. the
+ * old-registry members `union` already protects), so an authoritative run spares
+ * both current members and the grandfathered orphans. Inputs are not mutated.
+ */
+export function mergeProtectedTrustees(
+  base: Record<string, ReadonlySet<string>>,
+  grandfather: Record<string, ReadonlySet<string>>
+): Record<string, Set<string>> {
+  const merged: Record<string, Set<string>> = {};
+  const groups = new Set<string>([...Object.keys(base), ...Object.keys(grandfather)]);
+  for (const group of groups) {
+    const set = new Set<string>();
+    for (const address of base[group] ?? []) set.add(address);
+    for (const address of grandfather[group] ?? []) set.add(address);
+    merged[group] = set;
+  }
+  return merged;
+}

--- a/src/apps/community-new/main.ts
+++ b/src/apps/community-new/main.ts
@@ -45,6 +45,12 @@ import {
   DEFAULT_OLD_AFFILIATE_REGISTRY_START_BLOCK,
   fetchOldRegistryMembersByGroup
 } from "./oldRegistryMembers";
+import {
+  GRANDFATHER_ENV,
+  countGrandfather,
+  mergeProtectedTrustees,
+  parseGrandfatherAddresses
+} from "./grandfather";
 import {OldRegistrySource, mergeHybridMembers} from "./oldRegistrySource";
 import {resolveCommunityReputationConfig} from "./reputationConfig";
 
@@ -120,6 +126,11 @@ const untrustMode = parseUntrustMode(
   process.env.COMMUNITY_NEW_UNTRUST_MODE,
   membershipSource === "rpc" ? DEFAULT_UNTRUST_MODE : "wishlist"
 );
+// Cutover carve-outs (union mode only): orphans trusted on-chain but absent
+// from the registry that feeds the wishlist. They are added to the union
+// protected set so an authoritative sweep spares them, while every other member
+// keeps full join/leave/rep enforcement. See grandfather.ts.
+const grandfatherByGroup = parseGrandfatherAddresses(process.env.COMMUNITY_NEW_GRANDFATHER_ADDRESSES);
 const registryAddress = process.env.COMMUNITY_NEW_REGISTRY_ADDRESS || DEFAULT_MULTI_AFFILIATE_REGISTRY_ADDRESS;
 const registryDeployBlock = parsePositiveInt(
   "COMMUNITY_NEW_REGISTRY_DEPLOY_BLOCK",
@@ -316,11 +327,14 @@ async function start(): Promise<void> {
         }
 
         const protectedTrusteesByGroup = untrustMode === "union"
-          ? await fetchOldRegistryMembersByGroup(chainRpcUrl, managedGroups, {
-              registryAddress: oldRegistryAddress,
-              fromBlock: oldRegistryStartBlock,
-              logger: runLogger
-            })
+          ? mergeProtectedTrustees(
+              await fetchOldRegistryMembersByGroup(chainRpcUrl, managedGroups, {
+                registryAddress: oldRegistryAddress,
+                fromBlock: oldRegistryStartBlock,
+                logger: runLogger
+              }),
+              grandfatherByGroup
+            )
           : undefined;
         const outcome = await runCommunityReconciliation(
           {affiliateRpc, circlesRpc, groupService, reputationService, logger: runLogger},
@@ -421,6 +435,28 @@ function validateConfig(): void {
       throw new Error(`Configured community signer ${expected} does not match private-key signer ${actual}`);
     }
   }
+
+  // Grandfather carve-outs are only consulted by union mode; fail loud rather
+  // than let an operator believe addresses are protected when the active mode
+  // would still evict (wishlist) or already spares everyone (add-only).
+  const grandfatherGroups = Object.keys(grandfatherByGroup);
+  if (grandfatherGroups.length > 0) {
+    if (untrustMode !== "union") {
+      throw new Error(
+        `${GRANDFATHER_ENV} is only honored in union untrust mode, but ` +
+        `COMMUNITY_NEW_UNTRUST_MODE resolves to '${untrustMode}'. Set it to union, or clear the grandfather list.`
+      );
+    }
+    const managed = new Set(managedGroups);
+    for (const group of grandfatherGroups) {
+      if (!managed.has(group)) {
+        throw new Error(
+          `${GRANDFATHER_ENV} references group ${group}, which is not in COMMUNITY_NEW_GROUP_ADDRESSES — ` +
+          `grandfathering an unmanaged group has no effect (likely a typo).`
+        );
+      }
+    }
+  }
 }
 
 async function validateManagedGroupServices(): Promise<void> {
@@ -469,6 +505,10 @@ function logConfiguration(): void {
   logger.info(`  - maxUntrustTotal=${maxUntrustTotal} maxUntrustRatioPerGroup=${maxUntrustRatioPerGroup}`);
   if (untrustMode === "union") {
     logger.info(`  - unionProtectedFrom=oldRegistry ${oldRegistryAddress} (startBlock=${oldRegistryStartBlock})`);
+    logger.info(`  - grandfatherAddresses=${countGrandfather(grandfatherByGroup)} (frozen carve-outs, union-protected)`);
+    for (const [group, set] of Object.entries(grandfatherByGroup)) {
+      logger.info(`    · ${group}: ${set.size} [${Array.from(set).join(", ")}]`);
+    }
   }
   logger.info(`  - ackGroupAffiliatesRetired=${ackGroupAffiliatesRetired}`);
   logger.info(`  - dryRun=${dryRun}`);

--- a/src/apps/community-new/tools/evictionDiff.ts
+++ b/src/apps/community-new/tools/evictionDiff.ts
@@ -48,6 +48,7 @@ import {
   DEFAULT_OLD_AFFILIATE_REGISTRY_START_BLOCK,
   fetchOldRegistryMembersByGroup
 } from "../oldRegistryMembers";
+import {mergeProtectedTrustees, parseGrandfatherAddresses} from "../grandfather";
 import {OldRegistrySource, mergeHybridMembers} from "../oldRegistrySource";
 import {resolveCommunityReputationConfig} from "../reputationConfig";
 
@@ -221,39 +222,54 @@ async function run(): Promise<void> {
       ""
     );
   } else {
-    // Prod path: membership rebuilt from chain; report the authoritative eviction set.
+    // Prod path: membership rebuilt from chain. Report BOTH the strict wishlist
+    // blast radius AND the union+grandfather set the worker actually applies, so
+    // the operator sees exactly which orphans the grandfather list spares.
     const wishlistOverrideByGroup = await buildChainOverride(source, groups, chainRpcUrl, logger);
     const reputationBypassAddresses = source === "hybrid" && process.env.COMMUNITY_NEW_TEST_BYPASS_REPUTATION === "1"
       ? parseAddressSet(process.env.COMMUNITY_NEW_TEST_ADDRESSES)
       : undefined;
-    const result = await runCommunityReconciliation(deps, {
-      ...baseCfg,
-      untrustMode: "wishlist" as UntrustMode,
-      feeCapEnabled: false,
-      wishlistOverrideByGroup,
-      reputationBypassAddresses
+    const oldRegistryMembers = await fetchOldRegistryMembersByGroup(chainRpcUrl, groups, {
+      registryAddress: process.env.COMMUNITY_NEW_OLD_REGISTRY_ADDRESS || DEFAULT_OLD_AFFILIATE_REGISTRY_ADDRESS,
+      fromBlock: parseIntEnv("COMMUNITY_NEW_OLD_REGISTRY_START_BLOCK", DEFAULT_OLD_AFFILIATE_REGISTRY_START_BLOCK),
+      logger
     });
-    let totalEvict = 0;
+    const grandfatherByGroup = parseGrandfatherAddresses(process.env.COMMUNITY_NEW_GRANDFATHER_ADDRESSES);
+    const protectedByGroup = mergeProtectedTrustees(oldRegistryMembers, grandfatherByGroup);
+
+    const commonCfg = {...baseCfg, feeCapEnabled: false, wishlistOverrideByGroup, reputationBypassAddresses};
+    const wishlist = await runCommunityReconciliation(deps, {...commonCfg, untrustMode: "wishlist" as UntrustMode});
+    const union = await runCommunityReconciliation(deps, {
+      ...commonCfg,
+      untrustMode: "union" as UntrustMode,
+      protectedTrusteesByGroup: protectedByGroup
+    });
+    let totalWishlist = 0;
+    let totalUnion = 0;
     let totalTrust = 0;
     for (const group of groups) {
-      const trustees = result.currentTrusteesByGroup[group] ?? 0;
-      const members = result.wishlistMembersByGroup[group] ?? 0;
-      const evict = result.untrustedByGroup[group] ?? [];
-      const add = result.trustedByGroup[group] ?? [];
-      totalEvict += evict.length;
+      const trustees = wishlist.currentTrusteesByGroup[group] ?? 0;
+      const members = wishlist.wishlistMembersByGroup[group] ?? 0;
+      const gf = grandfatherByGroup[group]?.size ?? 0;
+      const wEvict = wishlist.untrustedByGroup[group] ?? [];
+      const uEvict = union.untrustedByGroup[group] ?? [];
+      const add = wishlist.trustedByGroup[group] ?? [];
+      totalWishlist += wEvict.length;
+      totalUnion += uEvict.length;
       totalTrust += add.length;
       lines.push(
         "",
         `Group ${group}`,
-        `  on-chain trustees=${trustees}  ${source}-members=${members}`,
-        `  would UNTRUST: ${evict.length}${evict.length ? "  [" + evict.join(", ") + "]" : ""}`,
-        `  would TRUST:   ${add.length}${add.length ? "  [" + add.join(", ") + "]" : ""}`
+        `  on-chain trustees=${trustees}  ${source}-members=${members}  grandfathered=${gf}`,
+        `  wishlist mode     → UNTRUST ${wEvict.length}${wEvict.length ? "  [" + wEvict.join(", ") + "]" : ""}`,
+        `  union+grandfather → UNTRUST ${uEvict.length}${uEvict.length ? "  [" + uEvict.join(", ") + "]" : ""}`,
+        `  would TRUST       → ${add.length}${add.length ? "  [" + add.join(", ") + "]" : ""}`
       );
     }
     lines.push(
       "",
-      `TOTAL — untrust: ${totalEvict}   trust: ${totalTrust}  (mode=wishlist, feeCap=off)`,
-      "Zero-regression cutover requires the untrust set to be empty or intentional.",
+      `TOTAL — wishlist untrust: ${totalWishlist}   union+grandfather untrust: ${totalUnion}   trust: ${totalTrust}  (feeCap=off)`,
+      "Zero-change cutover requires the configured mode's untrust set to be empty or intentional.",
       ""
     );
   }

--- a/tests/apps/community-new/grandfather.spec.ts
+++ b/tests/apps/community-new/grandfather.spec.ts
@@ -1,0 +1,102 @@
+import {
+  GRANDFATHER_ENV,
+  countGrandfather,
+  mergeProtectedTrustees,
+  parseGrandfatherAddresses
+} from "../../../src/apps/community-new/grandfather";
+
+const GROUP_A = "0x4e2564e5df6c1fb10c1a018538de36e4d5844de5";
+const GROUP_B = "0xeecae593589a6ee4a12ae64f19420b47f3112fa9";
+const ADDR_1 = "0x154dff8fdd67102bc7f77d4f5c363e5c191833f3";
+const ADDR_2 = "0x1e3438ea622c927a30f2977fdf1b36577bf9f6ef";
+
+describe("parseGrandfatherAddresses", () => {
+  it("returns an empty map for unset or blank input", () => {
+    expect(parseGrandfatherAddresses(undefined)).toEqual({});
+    expect(parseGrandfatherAddresses("")).toEqual({});
+    expect(parseGrandfatherAddresses("   ")).toEqual({});
+  });
+
+  it("parses a per-group JSON object and lowercases group + avatar addresses", () => {
+    const parsed = parseGrandfatherAddresses(
+      JSON.stringify({[GROUP_A.toUpperCase().replace("0X", "0x")]: [ADDR_1, ADDR_2]})
+    );
+    expect(Object.keys(parsed)).toEqual([GROUP_A]);
+    expect(parsed[GROUP_A]).toEqual(new Set([ADDR_1, ADDR_2]));
+  });
+
+  it("normalizes checksummed addresses to lowercase", () => {
+    const checksummed = "0x154DFf8fdD67102Bc7F77d4F5C363E5c191833F3"; // EIP-55 form of ADDR_1
+    const parsed = parseGrandfatherAddresses(JSON.stringify({[GROUP_A]: [checksummed]}));
+    expect(parsed[GROUP_A]).toEqual(new Set([ADDR_1]));
+  });
+
+  it("dedupes repeated avatars within a group", () => {
+    const parsed = parseGrandfatherAddresses(JSON.stringify({[GROUP_A]: [ADDR_1, ADDR_1]}));
+    expect(parsed[GROUP_A].size).toBe(1);
+  });
+
+  it("throws on invalid JSON", () => {
+    expect(() => parseGrandfatherAddresses("{not json")).toThrow(GRANDFATHER_ENV);
+  });
+
+  it("throws when the top level is not an object", () => {
+    expect(() => parseGrandfatherAddresses(JSON.stringify([ADDR_1]))).toThrow(GRANDFATHER_ENV);
+    expect(() => parseGrandfatherAddresses(JSON.stringify("x"))).toThrow(GRANDFATHER_ENV);
+  });
+
+  it("throws when a group value is not an array", () => {
+    expect(() => parseGrandfatherAddresses(JSON.stringify({[GROUP_A]: ADDR_1}))).toThrow(/must be an array/);
+  });
+
+  it("throws on an invalid group address", () => {
+    expect(() => parseGrandfatherAddresses(JSON.stringify({"0xnotanaddress": [ADDR_1]})))
+      .toThrow(/invalid group address/);
+  });
+
+  it("throws on an invalid avatar address", () => {
+    expect(() => parseGrandfatherAddresses(JSON.stringify({[GROUP_A]: ["0xzzzz"]})))
+      .toThrow(/invalid avatar address/);
+  });
+
+  it("throws on a non-string avatar entry", () => {
+    expect(() => parseGrandfatherAddresses(JSON.stringify({[GROUP_A]: [42]})))
+      .toThrow(/only address strings/);
+  });
+});
+
+describe("countGrandfather", () => {
+  it("sums addresses across groups", () => {
+    expect(countGrandfather({})).toBe(0);
+    expect(countGrandfather({[GROUP_A]: new Set([ADDR_1, ADDR_2]), [GROUP_B]: new Set([ADDR_1])})).toBe(3);
+  });
+});
+
+describe("mergeProtectedTrustees", () => {
+  it("unions the grandfather list into the base per group without mutating inputs", () => {
+    const base = {[GROUP_A]: new Set([ADDR_1])};
+    const grandfather = {[GROUP_A]: new Set([ADDR_2])};
+
+    const merged = mergeProtectedTrustees(base, grandfather);
+
+    expect(merged[GROUP_A]).toEqual(new Set([ADDR_1, ADDR_2]));
+    // inputs untouched
+    expect(base[GROUP_A]).toEqual(new Set([ADDR_1]));
+    expect(grandfather[GROUP_A]).toEqual(new Set([ADDR_2]));
+  });
+
+  it("keeps groups isolated — a carve-out in one group does not leak into another", () => {
+    const merged = mergeProtectedTrustees(
+      {[GROUP_A]: new Set([ADDR_1]), [GROUP_B]: new Set<string>()},
+      {[GROUP_A]: new Set([ADDR_2])}
+    );
+    expect(merged[GROUP_A]).toEqual(new Set([ADDR_1, ADDR_2]));
+    expect(merged[GROUP_B]).toEqual(new Set<string>());
+    expect(merged[GROUP_B].has(ADDR_2)).toBe(false);
+  });
+
+  it("includes groups that appear only in the grandfather list", () => {
+    const merged = mergeProtectedTrustees({}, {[GROUP_A]: new Set([ADDR_1])});
+    expect(merged[GROUP_A]).toEqual(new Set([ADDR_1]));
+  });
+});

--- a/tests/apps/community-new/logic.spec.ts
+++ b/tests/apps/community-new/logic.spec.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_UNTRUST_MODE,
   runCommunityReconciliation
 } from "../../../src/apps/community-new/logic";
+import {mergeProtectedTrustees} from "../../../src/apps/community-new/grandfather";
 import {IReputationService, ReputationVerdict} from "../../../src/apps/group-affiliates/reputationService";
 import {FakeGroupService, FakeLogger} from "../../../fakes/fakes";
 import {FakeCirclesRpc} from "../../../fakes/fakes";
@@ -215,6 +216,31 @@ describe("runCommunityReconciliation", () => {
     // PROTECTED is an old-registry member → kept; ORPHAN is on neither source → untrusted.
     expect(outcome.untrustedByGroup[GROUP_A]).toEqual([ORPHAN]);
     expect(outcome.trustedByGroup[GROUP_A]).toEqual([]);
+  });
+
+  it("union + grandfather list spares a cutover orphan while still untrusting a real leaver", async () => {
+    const deps = setup();
+    // PROTECTED is trusted but in neither the wishlist nor the old registry — a
+    // cutover orphan we grandfather. ORPHAN is likewise off both sources but NOT
+    // grandfathered → it must still be untrusted (leave enforcement intact).
+    deps.affiliateRpc.wishlistByGroup[GROUP_A] = [ELIGIBLE];
+    deps.circlesRpc.trusteesByTruster[GROUP_A] = [ELIGIBLE, PROTECTED, ORPHAN];
+    deps.affiliateRpc.feesByAvatar[ELIGIBLE] = 0;
+    deps.reputationService.scores.set(ELIGIBLE, 90);
+
+    // Old registry has no members for this group (base is empty); PROTECTED is
+    // carried solely by the frozen grandfather list.
+    const protectedTrusteesByGroup = mergeProtectedTrustees(
+      {[GROUP_A]: new Set<string>()},
+      {[GROUP_A]: new Set([PROTECTED])}
+    );
+    const outcome = await runCommunityReconciliation(deps, config({
+      untrustMode: "union",
+      protectedTrusteesByGroup
+    }));
+
+    expect(outcome.untrustedByGroup[GROUP_A]).toEqual([ORPHAN]);
+    expect(outcome.untrustedByGroup[GROUP_A]).not.toContain(PROTECTED);
   });
 
   it("empty-wishlist guard: never mass-untrusts when the wishlist comes back empty", async () => {


### PR DESCRIPTION
Bring master up to staging. Only diff is the community-new grandfather carve-out feature (PR #98), already merged to staging and deployed. No other commits between master and staging.