### PR TITLE
docs(community-new): correct stale staging-only claims for community RPC methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Specialized services for Circles protocol trust management:
 * Supports dry-run mode with optional Safe transaction simulation
 
 ## Community New App
-* Reads multi-affiliate community intent from `circles_getAffiliateGroupMembersWishlist`
+* Reads multi-affiliate community intent from `circles_getCommunityMembersWishlist`
 * Loads each managed group's `minRepScore` and checks every intended member's reputation
 * Enforces the aggregate community membership-fee cap (`totalFeePercentage <= 100`)
 * Trusts eligible intended members and untrusts members that become ineligible
@@ -334,7 +334,7 @@ VERBOSE_LOGGING=1
 # Chain reads (getLogs, eth_blockNumber) and Safe writes.
 RPC_URL=https://rpc.aboutcircles.com/
 TX_RPC_URL=https://your-write-rpc.example/       # optional
-# Only used by MEMBERSHIP_SOURCE=rpc (staging-only wishlist methods).
+# Only used by MEMBERSHIP_SOURCE=rpc (the wishlist methods; served on staging and prod).
 COMMUNITY_NEW_RPC_URL=https://rpc.staging.aboutcircles.com
 
 # Comma-separated groups managed by this worker (BaseGroups). Defaults to the
@@ -343,7 +343,8 @@ COMMUNITY_NEW_RPC_URL=https://rpc.staging.aboutcircles.com
 COMMUNITY_NEW_GROUP_ADDRESSES=0x4E2564e5df6C1Fb10C1A018538de36E4D5844DE5,0x2709757a543CF1BF4d92586b73d3891438b2589d,0xEEcAe593589a6eE4a12AE64F19420B47F3112Fa9
 
 # --- Membership source: where the worker reads group intent from ---
-#   rpc     — staging-only wishlist RPC (dev/staging only).
+#   rpc     — indexer wishlist RPC (dev/staging only, by policy — the methods
+#             themselves are served on prod too).
 #   old     — OLD single-slot registry (0xca8222) via AffiliateGroupChanged;
 #             byte-identical to group-affiliates (prod parity baseline).
 #   hybrid  — OLD registry for everyone EXCEPT COMMUNITY_NEW_TEST_ADDRESSES,
@@ -410,11 +411,12 @@ COMMUNITY_NEW_RPC_TIMEOUT_MS=30000
 COMMUNITY_NEW_RPC_MAX_PAGES=500
 COMMUNITY_NEW_ERRORS_BEFORE_CRASH=5
 
-# Group criteria and reputation lookups. The fee cap uses a staging-only RPC and
-# is only enforced in `rpc` mode; old/hybrid/new run with no fee cap (parity with
-# group-affiliates). In prod the reputation base URL is set to the in-network,
-# address-indexed endpoint (…/groups/0x93ed5a96…/avatars) so a slug rename cannot
-# 404 it; the public `score_group_v2` slug below is the code default fallback.
+# Group criteria and reputation lookups. The fee cap is only enforced in `rpc`
+# mode; old/hybrid/new run with no fee cap (parity with group-affiliates — a
+# deliberate choice, not an RPC limitation). In prod the reputation base URL is
+# set to the in-network, address-indexed endpoint (…/groups/0x93ed5a96…/avatars)
+# so a slug rename cannot 404 it; the public `score_group_v2` slug below is the
+# code default fallback.
 COMMUNITY_NEW_PROFILE_TIMEOUT_MS=30000
 COMMUNITY_NEW_REPUTATION_BASE_URL=                 # required only when bulk mode is disabled
 COMMUNITY_NEW_REPUTATION_SCORES_URL=https://rpc.aboutcircles.com/analytics/rep_score/groups/score_group_v2/scores

--- a/src/apps/community-new/affiliateMultiMap.ts
+++ b/src/apps/community-new/affiliateMultiMap.ts
@@ -10,7 +10,8 @@ import {StateStore} from "../../services/stateStore";
  * an avatar here belongs to MANY groups at once — mirroring the on-chain
  * per-avatar linked list. Maintained by history backfill on boot and kept current
  * by the realtime WSS listener; consumed by the reconciler as the membership
- * source so community-new no longer depends on the staging-only wishlist RPC.
+ * source so community-new no longer depends on the wishlist RPC (or on how far
+ * the indexer behind it has caught up).
  *
  * Not a security boundary: a stale/incomplete map can only under-report members
  * (fail to trust), never over-untrust — untrust decisions remain gated by the

--- a/src/apps/community-new/logic.ts
+++ b/src/apps/community-new/logic.ts
@@ -50,11 +50,12 @@ export type CommunityRunConfig = {
   maxTotalFeePercentage?: number;
   /**
    * Whether to fetch + enforce the per-member affiliate fee cap. Default true.
-   * The fee data comes from `circles_getAffiliateGroupFeesPercentage`, which is
-   * only served on the staging RPC. On prod (old/hybrid/new membership sources)
-   * this must be false — group-affiliates has no fee cap, and calling the missing
-   * method would throw. When false, fees are treated as unbounded (never a reason
-   * for ineligibility) and the fee RPC is never called.
+   * The fee data comes from `circles_getAvatarCommunityFeesPercentage` (served on
+   * staging and prod since the circles-nethermind-plugin community rename; the
+   * pre-rename `circles_getAffiliateGroupFeesPercentage` is gone). In old/hybrid/new
+   * membership modes this must be false for parity — group-affiliates has no fee
+   * cap. When false, fees are treated as unbounded (never a reason for
+   * ineligibility) and the fee RPC is never called.
    */
   feeCapEnabled?: boolean;
   dryRun?: boolean;
@@ -69,8 +70,8 @@ export type CommunityRunConfig = {
   /**
    * Membership source override. When provided for a group, this set (e.g. the
    * on-chain-derived {@link AffiliateMultiMap} members) is used as the wishlist
-   * instead of calling the wishlist RPC — removing the dependency on the
-   * staging-only `circles_getAffiliateGroupMembersWishlist` method.
+   * instead of calling the wishlist RPC — removing the dependency on
+   * `circles_getCommunityMembersWishlist` and on indexer freshness.
    */
   wishlistOverrideByGroup?: Record<string, ReadonlySet<string>>;
   /**

--- a/src/apps/community-new/main.ts
+++ b/src/apps/community-new/main.ts
@@ -65,10 +65,13 @@ const runLogger = logger.child("run");
 const membershipSource = parseMembershipSource(process.env.COMMUNITY_NEW_MEMBERSHIP_SOURCE);
 const chainRpcUrl = process.env.RPC_URL || DEFAULT_COMMUNITY_RPC_URL;
 // The community RPC serves trustees + profile (minRepScore) reads and, in `rpc`
-// mode, the staging-only wishlist methods. In old/hybrid/new there is NO
-// staging-only dependency, so it must be the same prod chain as RPC_URL — fall
-// back to it (never the staging default) so the worker can't read staging trust
-// state on prod and untrust against it.
+// mode, the wishlist methods. Those are now served on prod as well as staging
+// (renamed …AffiliateGroup…→…Community… on the Nethermind plugin), so `rpc` mode
+// is no longer pinned to staging by capability — but the default below points at
+// staging deliberately. In old/hybrid/new there is no wishlist dependency at all,
+// so the URL must be the same prod chain as RPC_URL — fall back to it (never the
+// staging default) so the worker can't read staging trust state on prod and
+// untrust against it.
 const communityRpcUrl = process.env.COMMUNITY_NEW_RPC_URL
   || (membershipSource === "rpc" ? DEFAULT_COMMUNITY_RPC_URL : chainRpcUrl);
 const txRpcUrl = resolveTransactionRpcUrl(chainRpcUrl);
@@ -113,9 +116,10 @@ const testAddresses = parseAddressSet(process.env.COMMUNITY_NEW_TEST_ADDRESSES);
 const testBypassReputation = process.env.COMMUNITY_NEW_TEST_BYPASS_REPUTATION === "1";
 const needsNewMap = membershipSource === "registry" || membershipSource === "hybrid";
 const needsOldMap = membershipSource === "old" || membershipSource === "hybrid";
-// Per-member fees come from the staging-only wishlist RPC; only enforce them in
-// `rpc` mode. old/hybrid/new read the chain directly (prod RPC lacks the method)
-// and, like group-affiliates, apply no fee cap.
+// Per-member fees come from the wishlist RPC; only enforce them in `rpc` mode.
+// old/hybrid/new read the chain directly and, like group-affiliates, apply no fee
+// cap — a deliberate parity choice, not an RPC limitation (the fee method is
+// served on prod too since the community rename).
 const feeCapEnabled = membershipSource === "rpc";
 // Every chain-authoritative mode (old/hybrid/new) is a membership source of
 // truth, so it must UNTRUST departed/removed members — the `wishlist` policy,
@@ -271,10 +275,11 @@ async function start(): Promise<void> {
       logger.info("Affiliate wishlist RPC methods available on the configured node.");
     } catch (cause) {
       throw new Error(
-        `Affiliate wishlist RPC methods unavailable on ${communityRpcUrl} ` +
-        `(circles_getAffiliateGroupMembersWishlist). Set COMMUNITY_NEW_RPC_URL to a node that serves them ` +
-        `— prod rpc.aboutcircles.com currently returns -32601 Method not found — or use ` +
-        `COMMUNITY_NEW_MEMBERSHIP_SOURCE=registry to read membership from chain instead.`,
+        `Community wishlist RPC methods unavailable on ${communityRpcUrl} ` +
+        `(circles_getCommunityMembersWishlist, or the pre-rename circles_getAffiliateGroupMembersWishlist). ` +
+        `Both staging and prod serve these — check COMMUNITY_NEW_RPC_URL points at a Circles RPC host ` +
+        `(not a plain chain RPC), or use COMMUNITY_NEW_MEMBERSHIP_SOURCE=registry to read membership ` +
+        `from chain instead.`,
         {cause: asError(cause)}
       );
     }

--- a/src/services/affiliateGroupsRpcService.ts
+++ b/src/services/affiliateGroupsRpcService.ts
@@ -15,10 +15,12 @@ const DEFAULT_RETRY_BASE_DELAY_MS = 1_000;
 const DEFAULT_RETRY_MAX_DELAY_MS = 30_000;
 
 /**
- * The Circles RPC affiliate methods are being renamed (…AffiliateGroup…→…Community…)
- * on the Nethermind plugin. We try the NEW name first and fall back to the OLD on
- * `-32601 Method not found`, caching the winner, so the worker keeps working on
- * nodes before AND after the rename ships. Only used in `rpc` membership mode.
+ * The Circles RPC affiliate methods were renamed (…AffiliateGroup…→…Community…)
+ * on the Nethermind plugin and the new names are live on staging and prod.
+ * We try the NEW name first and fall back to the OLD on `-32601 Method not found`,
+ * caching the winner, so the worker also keeps working against a node still on a
+ * pre-rename image. The fallback is legacy — drop it once no such node remains.
+ * Only used in `rpc` membership mode.
  */
 type MethodPair = {primary: string; fallback: string};
 const RENAMED_METHODS: Record<"membersWishlist" | "members" | "fees", MethodPair> = {
@@ -88,11 +90,11 @@ export class AffiliateGroupsRpcService implements IAffiliateGroupsRpc {
   }
 
   /**
-   * Startup probe: verifies the community/affiliate wishlist RPC method exists on
-   * the configured node. These methods are not served by every Circles RPC (prod
-   * `rpc.aboutcircles.com` returns `-32601 Method not found`). A single-page call
-   * surfaces a wrong-endpoint misconfiguration at boot instead of after a poll
-   * cycle. Tolerates the …Affiliate…→…Community… rename via fallback.
+   * Startup probe: verifies the community wishlist RPC method exists on the
+   * configured node. Staging and prod both serve it, but a plain chain RPC does
+   * not — a single-page call surfaces a wrong-endpoint misconfiguration at boot
+   * instead of after a poll cycle. Tolerates the …Affiliate…→…Community… rename
+   * via fallback.
    */
   async assertAffiliateMethodsAvailable(groupAddress: string): Promise<void> {
     const group = normalizeAddress(groupAddress, "group");


### PR DESCRIPTION
## Summary

The community wishlist/fee JSON-RPC methods are served on both staging and production, but this repo's comments, README and startup error message still described them as staging-only and claimed production returns `-32601 Method not found`.

The worst offender is the `community-new` boot preflight: on failure it told operators to repoint `COMMUNITY_NEW_RPC_URL` at "a node that serves them" and named production as the culprit — advice that now sends them down a dead end, since the real cause is pointing at a plain chain RPC instead of a Circles RPC host.

## Changes

- **README** — use the current `circles_getCommunityMembersWishlist` name in the Community New feature list; drop "staging-only" from the `MEMBERSHIP_SOURCE` and fee-cap notes, framing `rpc` mode as a policy choice rather than a capability limit
- **`community-new/main.ts`** — rewrite the preflight error to name both the current and pre-rename methods and point at the real misconfiguration; correct the `communityRpcUrl` and `feeCapEnabled` comments
- **`community-new/logic.ts`**, **`affiliateMultiMap.ts`** — describe the fee and wishlist RPC dependencies in terms of the current method names and indexer freshness
- **`services/affiliateGroupsRpcService.ts`** — mark the old-name fallback as legacy, kept only for nodes still on a pre-rename image

Comments, docs and one error string only. No behaviour change: the `rpc`-mode default URL and the rename fallback are deliberately left as-is.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 39 suites, 518 tests, all pass
- [x] All five current method names verified live against both staging and production