### PR TITLE
fix(new-gnosis): pace batched RPC reads and detect rate limits behind a cause

### DIFF
--- a/src/apps/new-gnosis/main.ts
+++ b/src/apps/new-gnosis/main.ts
@@ -16,6 +16,7 @@ import {startMetricsServer, recordRunSuccess, recordRunError} from "../../servic
 import {ensureRpcHealthyOrNotify} from "../../services/rpcHealthService";
 import {resolveTransactionRpcUrl} from "../../services/transactionRpc";
 import {createProvider, primaryRpcUrl} from "../../services/rpcProvider";
+import {mapPacedChunks, PacedChunkOptions} from "../../services/pacedChunks";
 import {formatErrorWithCauses} from "../../formatError";
 import {
   runBackfill,
@@ -42,9 +43,20 @@ const TRUST_BATCH_ABI = [
   "function optOuts(address) view returns (bool)"
 ];
 const TX_CONFIRMATION_TIMEOUT_MS = 5 * 60 * 1_000;
-const READ_CONCURRENCY = 25;
 const REGISTERED_HUMAN_LOOKUP_BATCH = 500;
 const AVATAR_INFO_LOOKUP_BATCH = 500;
+
+// The Circles RPC host rate-limits per client IP with a token bucket that counts
+// JSON-RPC *batch items* individually (100 tokens/s sustained, 200 burst). ethers
+// packs the concurrent eth_calls of one chunk into a single batch, so a chunk of
+// N reads costs ~N tokens at once. Chunks used to run back to back with no gap,
+// which drained the whole burst in milliseconds and made the next call fail with
+// HTTP 429, often a call as cheap as a one-token circles_getAvatarInfoBatch.
+//
+// DEFAULT_READ_CHUNK_DELAY_MS keeps the sustained rate under the server budget:
+// 25 items per 300ms is ~83/s. Retry stays as the safety net for the rest.
+const DEFAULT_READ_CONCURRENCY = 25;
+const DEFAULT_READ_CHUNK_DELAY_MS = 300;
 
 const verboseLogging = !!process.env.VERBOSE_LOGGING;
 const rootLogger = new LoggerService(verboseLogging, APP_NAME);
@@ -70,6 +82,8 @@ const scoreThreshold = parseEnvFloat("NEW_GNOSIS_SCORE_THRESHOLD", DEFAULT_SCORE
 const scoreBatchSize = Math.max(1, parseEnvInt("NEW_GNOSIS_SCORE_BATCH_SIZE", DEFAULT_TRUST_SCORE_BATCH_SIZE));
 const scoreFetchTimeoutMs = Math.max(1_000, parseEnvInt("NEW_GNOSIS_SCORE_FETCH_TIMEOUT_MS", DEFAULT_TRUST_SCORE_TIMEOUT_MS));
 const cutoffBlock = parseEnvInt("NEW_GNOSIS_CUTOFF_BLOCK", DEFAULT_CUTOFF_BLOCK);
+const readConcurrency = Math.max(1, parseEnvInt("NEW_GNOSIS_READ_CONCURRENCY", DEFAULT_READ_CONCURRENCY));
+const readChunkDelayMs = Math.max(0, parseEnvInt("NEW_GNOSIS_READ_DELAY_MS", DEFAULT_READ_CHUNK_DELAY_MS));
 const errorsBeforeCrash = 3;
 
 if (!dryRun && signerPrivateKey.trim().length === 0) {
@@ -455,15 +469,18 @@ async function fetchOutgoingTrustees(rpc: CirclesRpc, truster: string): Promise<
  */
 async function filterHumanAvatars(rpc: CirclesRpc, addresses: string[]): Promise<Set<string>> {
   const result = new Set<string>();
-  for (let i = 0; i < addresses.length; i += AVATAR_INFO_LOOKUP_BATCH) {
-    const chunk = addresses.slice(i, i + AVATAR_INFO_LOOKUP_BATCH);
-    const infos = await rpc.avatar.getAvatarInfoBatch(chunk as `0x${string}`[]);
-    for (const info of infos) {
-      if (info.type === "CrcV2_RegisterHuman") {
-        result.add(info.avatar.toLowerCase());
+  await mapPacedChunks(
+    addresses,
+    {...readPacing(), chunkSize: AVATAR_INFO_LOOKUP_BATCH},
+    async (chunk) => {
+      const infos = await rpc.avatar.getAvatarInfoBatch(chunk as `0x${string}`[]);
+      for (const info of infos) {
+        if (info.type === "CrcV2_RegisterHuman") {
+          result.add(info.avatar.toLowerCase());
+        }
       }
     }
-  }
+  );
   return result;
 }
 
@@ -483,8 +500,7 @@ async function filterTrustSimulated(
 ): Promise<Set<string>> {
   const overrides = from ? {from} : {};
   const result = new Set<string>();
-  for (let i = 0; i < addresses.length; i += READ_CONCURRENCY) {
-    const chunk = addresses.slice(i, i + READ_CONCURRENCY);
+  await mapPacedChunks(addresses, readPacing(), async (chunk) => {
     const outcomes = await Promise.all(chunk.map(async (a) => {
       try {
         await contract.trust.staticCall(a, overrides);
@@ -497,17 +513,16 @@ async function filterTrustSimulated(
     chunk.forEach((a, idx) => {
       if (outcomes[idx]) result.add(a.toLowerCase());
     });
-  }
+  });
   return result;
 }
 
 async function fetchIsOptedOutBatch(contract: Contract, addresses: string[]): Promise<Map<string, boolean>> {
   const result = new Map<string, boolean>();
-  for (let i = 0; i < addresses.length; i += READ_CONCURRENCY) {
-    const chunk = addresses.slice(i, i + READ_CONCURRENCY);
+  await mapPacedChunks(addresses, readPacing(), async (chunk) => {
     const flags = await Promise.all(chunk.map((a) => contract.optOuts(a) as Promise<boolean>));
     chunk.forEach((a, idx) => result.set(a.toLowerCase(), flags[idx] === true));
-  }
+  });
   return result;
 }
 
@@ -531,6 +546,11 @@ async function fetchRegisteredHumans(
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Pacing applied to every batched on-chain read, so no single phase can drain the RPC rate-limit bucket. */
+function readPacing(): PacedChunkOptions {
+  return {chunkSize: readConcurrency, delayMs: readChunkDelayMs};
 }
 
 function parseEnvInt(name: string, fallback: number): number {

--- a/src/services/pacedChunks.ts
+++ b/src/services/pacedChunks.ts
@@ -1,0 +1,52 @@
+import {retryWithBackoff} from "./retryWithBackoff";
+
+/**
+ * Sequential chunked iteration with a gap between chunks.
+ *
+ * Chunking alone does not bound the request rate: an `await`ed loop over chunks
+ * that each resolve in a millisecond still issues every chunk inside the same
+ * second. Servers that rate-limit per client see that as one burst. The gap is
+ * what keeps the sustained rate inside their budget; the retry wrapper is the
+ * safety net for whatever still slips through.
+ */
+export interface PacedChunkOptions {
+  /** Items per chunk. Values below 1 are treated as 1. */
+  chunkSize: number;
+  /** Gap after each chunk except the last. Values below 0 are treated as 0. */
+  delayMs: number;
+  /** Injectable for tests; defaults to setTimeout. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable for tests; defaults to retryWithBackoff. */
+  run?: <T>(fn: () => Promise<T>) => Promise<T>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Splits `items` into chunks, runs `fn` on each one in order, and returns the
+ * results in chunk order. No gap is taken after the final chunk, so a single
+ * chunk costs nothing extra.
+ */
+export async function mapPacedChunks<TItem, TResult>(
+  items: readonly TItem[],
+  opts: PacedChunkOptions,
+  fn: (chunk: TItem[]) => Promise<TResult>
+): Promise<TResult[]> {
+  const chunkSize = Math.max(1, Math.floor(opts.chunkSize));
+  const delayMs = Math.max(0, opts.delayMs);
+  const sleep = opts.sleep ?? defaultSleep;
+  const run = opts.run ?? ((task) => retryWithBackoff(task));
+
+  const results: TResult[] = [];
+  for (let i = 0; i < items.length; i += chunkSize) {
+    const chunk = items.slice(i, i + chunkSize) as TItem[];
+    results.push(await run(() => fn(chunk)));
+
+    const isLastChunk = i + chunkSize >= items.length;
+    if (!isLastChunk && delayMs > 0) {
+      await sleep(delayMs);
+    }
+  }
+  return results;
+}

--- a/src/services/retryWithBackoff.ts
+++ b/src/services/retryWithBackoff.ts
@@ -23,7 +23,16 @@ const TRANSIENT_CODES = new Set<number>([
 /** Match "429" only as a standalone token, not inside larger numbers like "42900001". */
 const RATE_LIMIT_PATTERN = /\b429\b/;
 
-export function isTransientRpcError(err: unknown): boolean {
+/** How deep to follow .cause / .error before giving up. */
+const MAX_CAUSE_DEPTH = 8;
+
+/**
+ * Classifies a single error object, ignoring any wrapped cause.
+ * `allowCallExceptionHeuristic` is only set for the outermost error: a nested
+ * CALL_EXCEPTION says nothing about whether the operation we invoked is worth
+ * retrying, and treating it as transient would retry genuine reverts.
+ */
+function isTransientRpcErrorShallow(err: unknown, allowCallExceptionHeuristic: boolean): boolean {
   if (err == null) return false;
   const msg = String((err as any)?.message ?? err);
   const code = ((err as any)?.code ?? (err as any)?.error?.code) as number | undefined;
@@ -36,13 +45,43 @@ export function isTransientRpcError(err: unknown): boolean {
   // ethers CALL_EXCEPTION with data strictly null/undefined = RPC failed to simulate
   // (returned no revert payload at all). data="0x" means a real bare revert() — not transient.
   // Caveat: some RPCs omit revert data even for genuine reverts. This is a best-effort heuristic.
-  const ethersCode = (err as any)?.code as string | undefined;
-  if (ethersCode === "CALL_EXCEPTION") {
-    const d = (err as any)?.data;
-    if (d === null || d === undefined) return true;
+  if (allowCallExceptionHeuristic) {
+    const ethersCode = (err as any)?.code as string | undefined;
+    if (ethersCode === "CALL_EXCEPTION") {
+      const d = (err as any)?.data;
+      if (d === null || d === undefined) return true;
+    }
   }
 
   return TRANSIENT_MESSAGES.some((t) => msg.includes(t));
+}
+
+/**
+ * True when the error, or anything in its `.cause` / `.error` chain, is a
+ * transient RPC failure.
+ *
+ * Walking the chain is required, not cosmetic: `@aboutcircles/sdk-rpc` reports a
+ * rate limit as `RpcError: Failed to connect to RPC endpoint` and puts the
+ * `HTTP 429: Too Many Requests` on `.cause`, so a top-level-only check reads it
+ * as permanent and never retries. The chain can be circular, so track visited
+ * nodes and cap the depth.
+ */
+export function isTransientRpcError(err: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH && current != null; depth++) {
+    if (seen.has(current)) return false;
+    seen.add(current);
+
+    if (isTransientRpcErrorShallow(current, depth === 0)) return true;
+
+    const next = (current as any)?.cause ?? (current as any)?.error;
+    if (next === current) return false;
+    current = next;
+  }
+
+  return false;
 }
 
 export interface RetryOptions {

--- a/tests/services/pacedChunks.spec.ts
+++ b/tests/services/pacedChunks.spec.ts
@@ -1,0 +1,121 @@
+import {mapPacedChunks} from "../../src/services/pacedChunks";
+
+const noRetry = <T>(fn: () => Promise<T>): Promise<T> => fn();
+
+describe("mapPacedChunks", () => {
+  it("splits into chunks of the requested size and preserves order", async () => {
+    const seen: number[][] = [];
+    const results = await mapPacedChunks(
+      [1, 2, 3, 4, 5],
+      {chunkSize: 2, delayMs: 0, run: noRetry},
+      async (chunk) => {
+        seen.push(chunk);
+        return chunk.length;
+      }
+    );
+
+    expect(seen).toEqual([[1, 2], [3, 4], [5]]);
+    expect(results).toEqual([2, 2, 1]);
+  });
+
+  it("sleeps between chunks but not after the last one", async () => {
+    const sleeps: number[] = [];
+    await mapPacedChunks(
+      [1, 2, 3, 4, 5],
+      {chunkSize: 2, delayMs: 300, run: noRetry, sleep: async (ms) => { sleeps.push(ms); }},
+      async () => undefined
+    );
+
+    // 3 chunks -> 2 gaps. A trailing sleep would be pure latency for no benefit.
+    expect(sleeps).toEqual([300, 300]);
+  });
+
+  it("takes no gap at all for a single chunk", async () => {
+    const sleeps: number[] = [];
+    await mapPacedChunks(
+      [1, 2],
+      {chunkSize: 25, delayMs: 300, run: noRetry, sleep: async (ms) => { sleeps.push(ms); }},
+      async () => undefined
+    );
+
+    expect(sleeps).toEqual([]);
+  });
+
+  it("runs chunks strictly sequentially", async () => {
+    const events: string[] = [];
+    await mapPacedChunks(
+      [1, 2, 3, 4],
+      {chunkSize: 2, delayMs: 0, run: noRetry},
+      async (chunk) => {
+        events.push(`start:${chunk[0]}`);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        events.push(`end:${chunk[0]}`);
+      }
+    );
+
+    expect(events).toEqual(["start:1", "end:1", "start:3", "end:3"]);
+  });
+
+  it("routes every chunk through the retry wrapper", async () => {
+    let runCalls = 0;
+    const run = <T>(fn: () => Promise<T>): Promise<T> => {
+      runCalls += 1;
+      return fn();
+    };
+    await mapPacedChunks([1, 2, 3], {chunkSize: 1, delayMs: 0, run}, async () => undefined);
+
+    expect(runCalls).toBe(3);
+  });
+
+  it("retries a chunk that fails with a wrapped 429, using the real retry wrapper", async () => {
+    let attempts = 0;
+    const results = await mapPacedChunks([1, 2], {chunkSize: 2, delayMs: 0}, async (chunk) => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("Failed to connect to RPC endpoint", {
+          cause: new Error("HTTP 429: Too Many Requests")
+        });
+      }
+      return chunk.length;
+    });
+
+    expect(attempts).toBe(2);
+    expect(results).toEqual([2]);
+  });
+
+  it("propagates a chunk failure and stops processing", async () => {
+    const seen: number[][] = [];
+    await expect(
+      mapPacedChunks([1, 2, 3, 4], {chunkSize: 2, delayMs: 0, run: noRetry}, async (chunk) => {
+        seen.push(chunk);
+        if (chunk[0] === 1) throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+
+    expect(seen).toEqual([[1, 2]]);
+  });
+
+  it("does nothing for an empty input", async () => {
+    const fn = jest.fn(async () => undefined);
+    const results = await mapPacedChunks([], {chunkSize: 25, delayMs: 300, run: noRetry}, fn);
+
+    expect(results).toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("clamps a non-positive chunk size to 1 instead of looping forever", async () => {
+    const seen: number[][] = [];
+    await mapPacedChunks([1, 2], {chunkSize: 0, delayMs: 0, run: noRetry}, async (chunk) => {
+      seen.push(chunk);
+    });
+
+    expect(seen).toEqual([[1], [2]]);
+  });
+
+  it("clamps a negative delay to no sleep", async () => {
+    const sleep = jest.fn(async () => undefined);
+    await mapPacedChunks([1, 2, 3], {chunkSize: 1, delayMs: -5, run: noRetry, sleep}, async () => undefined);
+
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/tests/services/retryWithBackoff.spec.ts
+++ b/tests/services/retryWithBackoff.spec.ts
@@ -46,6 +46,58 @@ describe("isTransientRpcError", () => {
     expect(isTransientRpcError(null)).toBe(false);
     expect(isTransientRpcError(undefined)).toBe(false);
   });
+
+  // sdk-rpc reports a rate limit as a generic connection failure and puts the
+  // 429 on .cause. Classifying only the outer error reads that as permanent.
+  it("returns true for a 429 wrapped as .cause behind an opaque message", () => {
+    const wrapped = new Error("Failed to connect to RPC endpoint", {
+      cause: new Error("HTTP 429: Too Many Requests")
+    });
+    expect(isTransientRpcError(wrapped)).toBe(true);
+  });
+
+  it("returns true for a 429 nested two causes deep", () => {
+    const inner = new Error("HTTP 429: Too Many Requests");
+    const middle = new Error("request failed", {cause: inner});
+    const outer = new Error("Failed to connect to RPC endpoint", {cause: middle});
+    expect(isTransientRpcError(outer)).toBe(true);
+  });
+
+  it("returns false when nothing in the cause chain is transient", () => {
+    const wrapped = new Error("Failed to connect to RPC endpoint", {
+      cause: new Error("execution reverted")
+    });
+    expect(isTransientRpcError(wrapped)).toBe(false);
+  });
+
+  it("terminates on a circular cause chain", () => {
+    const a: any = new Error("outer boom");
+    const b: any = new Error("inner boom");
+    a.cause = b;
+    b.cause = a;
+    expect(isTransientRpcError(a)).toBe(false);
+  });
+
+  it("terminates when an error is its own cause", () => {
+    const self: any = new Error("self boom");
+    self.cause = self;
+    expect(isTransientRpcError(self)).toBe(false);
+  });
+
+  // The data-less CALL_EXCEPTION heuristic guesses that the node failed to
+  // simulate. A nested one says nothing about the call we made, and honouring it
+  // would retry genuine reverts.
+  it("ignores a data-less CALL_EXCEPTION found in the cause chain", () => {
+    const wrapped: any = new Error("trust simulation failed", {
+      cause: Object.assign(new Error("call exception"), {code: "CALL_EXCEPTION", data: null})
+    });
+    expect(isTransientRpcError(wrapped)).toBe(false);
+  });
+
+  it("still honours a data-less CALL_EXCEPTION on the outermost error", () => {
+    const err: any = Object.assign(new Error("call exception"), {code: "CALL_EXCEPTION", data: null});
+    expect(isTransientRpcError(err)).toBe(true);
+  });
 });
 
 describe("retryWithBackoff", () => {


### PR DESCRIPTION
## What

The Circles RPC host rate-limits per client IP with a token bucket that counts JSON-RPC batch items individually. new-gnosis walked its candidate set in chunks of 25 concurrent `eth_call`s, which ethers packs into one batch per chunk, and the chunk loop had no gap between iterations. Each chunk resolved in about a millisecond, so a whole run's reads landed inside the same second and drained the burst allowance. The next call then failed with `HTTP 429`, frequently a call far cheaper than the ones that caused the pressure, and three such runs in a row tripped the consecutive-error threshold and restarted the worker. A restart resets `group_tms_last_successful_run_timestamp` to 0, which arms the no-run-since-start alert.

The retry helper could not absorb it either: the RPC SDK reports a rate limit as `Failed to connect to RPC endpoint` and puts the 429 on `.cause`, while `isTransientRpcError` only inspected the outermost error, so the wrapped 429 read as permanent.

## Changes

- add `mapPacedChunks`: sequential chunks, a configurable gap between them but never after the last, each chunk wrapped in `retryWithBackoff`
- route the trust simulation, opt-out and avatar-info reads through it
- default to 25 items per 300ms, about 83/s, under the server budget; override with `NEW_GNOSIS_READ_CONCURRENCY` and `NEW_GNOSIS_READ_DELAY_MS`
- walk the `.cause` / `.error` chain in `isTransientRpcError`, cycle-safe and depth-capped, so a wrapped 429 is retried
- keep the data-less `CALL_EXCEPTION` heuristic at the outermost error only, so a nested one cannot turn a genuine revert into a retry

Steady-state cost is a few seconds per run against a 30 minute interval. No behavioural change to which avatars are selected.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx jest` (535 tests, 40 suites, all pass)
- [x] mutation: stop walking the cause chain, the two wrapped-429 cases and the end-to-end retry case fail
- [x] mutation: sleep after the last chunk too, the gap cases fail
- [x] mutation: run chunks concurrently, the sequencing case fails
- [x] mutation: honour nested `CALL_EXCEPTION`, the nested-revert case fails
- [ ] after deploy: no `Rate limited batch` entries attributable to the worker, and the run-success gauge advances every interval